### PR TITLE
Add validate-host role to base jobs

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -8,3 +8,9 @@
     - name: Run configure-unbound role
       include_role:
         name: configure-unbound
+
+- hosts: all
+  tasks:
+    - name: Run validate-host role
+      include_role:
+        name: validate-host


### PR DESCRIPTION
This logs extra information about our build host, helpful when users
need to debug failures.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>