### PR TITLE
Use google dns for backup

### DIFF
--- a/roles/configure-unbound/defaults/main.yaml
+++ b/roles/configure-unbound/defaults/main.yaml
@@ -1,10 +1,11 @@
 ---
-# 1.1.1.1
+# OpenDNS
 unbound_primary_nameserver_v6: "2606:4700:4700::1111"
 unbound_primary_nameserver_v4: "1.1.1.1"
 
-unbound_secondary_nameserver_v6: "2606:4700:4700::1001"
-unbound_secondary_nameserver_v4: "1.0.0.1"
+# Google
+unbound_secondary_nameserver_v6: "2001:4860:4860::8888"
+unbound_secondary_nameserver_v4: "8.8.8.8"
 
 # Time to live maximum for  RRsets  and  messages  in  the  cache.
 # Default  is  86400  seconds  (1  day).  If the maximum kicks in,


### PR DESCRIPTION
When we copied this role from rdocloud, we didn't properly setup google
as our backup dns.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>