### PR TITLE
Add fedora-latest-1vcpu nodeset

### DIFF
--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -4,3 +4,9 @@
     nodes:
       - name: centos-7
         label: centos-7-1vcpu
+
+- nodeset:
+    name: fedora-latest-1vcpu
+    nodes:
+      - name: fedora-29
+        label: fedora-29-1vcpu


### PR DESCRIPTION
Now that we have fedora-29 images in nodepool, we can use them for jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>