### PR TITLE
Update ansible-python-jobs to use fedora-latest-1vcpu

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -5,7 +5,9 @@
       A common set of python jobs to run.
     check:
       jobs:
-        - tox-linters
+        - tox-linters:
+            nodeset: fedora-latest-1vcpu
     gate:
       jobs:
-        - tox-linters
+        - tox-linters:
+            nodeset: fedora-latest-1vcpu


### PR DESCRIPTION
We want python3 to be the default for testing, as a results we should be
using fedora-latest-1vcpu here. Another option is to default to
ubuntu-bionic, but that needs to be discussed.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>