### PR TITLE
Fix syntax error with system-required project-template

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -29,6 +29,7 @@
 
 - project-template:
     name: system-required
+    description: |
       Jobs that *every* project in Ansible should have by default.
 
       This is automatically added to all projects in Ansible zuul tenant, no


### PR DESCRIPTION
We are missing the description header.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>