### PR TITLE
Add vyos-1.1.8-1vcpu nodeset

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -8,6 +8,11 @@
     pre-run: playbooks/base/pre.yaml
 
 - job:
+    name: ansible-tox-linters
+    parent: tox-linters
+    nodeset: fedora-latest-1vcpu
+
+- job:
     name: ansible-tox-py27
     parent: tox
     vars:


### PR DESCRIPTION
This brings online vyos nodeset which will be used by the
ansible-network team.

Depends-On: https://review.openstack.org/650880
Signed-off-by: Paul Belanger <pabelanger@redhat.com>