### PR TITLE
Add ansible-tox-linters

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -8,6 +8,11 @@
     pre-run: playbooks/base/pre.yaml
 
 - job:
+    name: ansible-tox-linters
+    parent: tox-linters
+    nodeset: fedora-latest-1vcpu
+
+- job:
     name: ansible-tox-py27
     parent: tox
     vars:


### PR DESCRIPTION
This just adds a fedora-latest nodeset to tox-linters.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>