### PR TITLE
Add ansible-network-vyos-base job

### DIFF
--- a/playbooks/ansible-network-vyos-base/run.yaml
+++ b/playbooks/ansible-network-vyos-base/run.yaml
@@ -1,0 +1,3 @@
+---
+- hosts: all
+  tasks: []

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -41,6 +41,7 @@
 - job:
     name: ansible-network-vyos-base
     pre-run: playbooks/ansible-network-vyos-base/pre.yaml
+    run: playbooks/ansible-network-vyos-base/run.yaml
     host-vars:
       vyos-1.1.8:
         ansible_connection: network_cli

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -2,3 +2,9 @@
 - project:
     templates:
       - ansible-python-jobs
+    check:
+      jobs:
+        - ansible-network-vyos-base
+    gate:
+      jobs:
+        - ansible-network-vyos-base


### PR DESCRIPTION
This helps to ensure we gate the job properly and don't break anything
for ansible-network jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>