### PR TITLE
Add ansible-test-network-integration-eos job

### DIFF
--- a/playbooks/ansible-network-appliance-base/pre.yaml
+++ b/playbooks/ansible-network-appliance-base/pre.yaml
@@ -5,7 +5,7 @@
       include_role:
         name: bindep
       vars:
-        zuul_work_dir: "{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"
+        bindep_dir: "{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"
 
     - name: Run test-setup role
       include_role:


### PR DESCRIPTION
This now adds support to run eos tests against ansible/ansible.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>