### PR TITLE
Don't assume where ara-report is run from

### DIFF
--- a/playbooks/ansible-network-appliance-base/post.yaml
+++ b/playbooks/ansible-network-appliance-base/post.yaml
@@ -9,7 +9,7 @@
     - name: Generate ARA HTML output
       command: ".tox/venv/bin/ara generate html {{ ansible_user_dir }}/zuul-output/logs/logs/ara-report"
       args:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
+        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"
 
     # TODO: Migrate to fetch-zuul-logs when
     # https://review.openstack.org/#/c/583346/ is merged.


### PR DESCRIPTION
This is true when doing periodic jobs on ansible/ansible.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>