### PR TITLE
Fix inventory for ansible-test-network-integration-eos

### DIFF
--- a/playbooks/ansible-test-network-integration-eos/templates/inventory.j2
+++ b/playbooks/ansible-test-network-integration-eos/templates/inventory.j2
@@ -6,5 +6,6 @@ eos-4.20.10 ansible_port=22 ansible_python_interpreter=python ansible_host={{ ho
 
 [eos:vars]
 debug=False
-cli={'transport': 'cli', 'authorize': 'yes'}
-eapi={'transport': 'eapi', 'use_ssl': 'no', 'port': '80', 'authorize': 'yes'}
+cli={'transport': 'cli', 'authorize': true}
+# NOTE(pabelanger): ansible_httpapi_pass doesn't work for ansible_connection local.
+eapi={'transport': 'eapi', 'use_ssl': false, 'port': '80', 'authorize': true, 'password': 'superSecretPass'}

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -78,7 +78,7 @@
     run: playbooks/ansible-test-network-integration-eos/run.yaml
     required-projects:
       - name: github.com/ansible/ansible
-    timeout: 5400
+    timeout: 7200
 
 - job:
     name: ansible-test-network-integration-vyos


### PR DESCRIPTION
Switch from strings to boolean in our inventory file, this is apparently
breaking one of our eos tests.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>