### PR TITLE
Refactor ansible-test-network-integration-eos jobs

### DIFF
--- a/playbooks/ansible-network-eos-appliance/pre.yaml
+++ b/playbooks/ansible-network-eos-appliance/pre.yaml
@@ -6,4 +6,5 @@
         name: tox
       vars:
         tox_extra_args: -- ansible-playbook -v -c network_cli playbooks/ansible-network-eos-appliance/files/bootstrap.yaml
+        tox_install_siblings: false
         zuul_work_dir: "{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"

--- a/playbooks/ansible-network-vyos-appliance/pre.yaml
+++ b/playbooks/ansible-network-vyos-appliance/pre.yaml
@@ -5,6 +5,6 @@
       include_role:
         name: tox
       vars:
-        tox_install_siblings: false
         tox_extra_args: -vv -- ansible-playbook -v -c network_cli playbooks/ansible-network-vyos-appliance/files/bootstrap.yaml
+        tox_install_siblings: false
         zuul_work_dir: "{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"

--- a/playbooks/ansible-test-network-integration-eos/pre.yaml
+++ b/playbooks/ansible-test-network-integration-eos/pre.yaml
@@ -6,4 +6,5 @@
         name: tox
       vars:
         tox_extra_args: -- ansible-playbook -vvvv playbooks/ansible-test-network-integration-eos/files/bootstrap.yaml
+        tox_install_siblings: false
         zuul_work_dir: "{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"

--- a/playbooks/ansible-test-network-integration-eos/run.yaml
+++ b/playbooks/ansible-test-network-integration-eos/run.yaml
@@ -10,4 +10,4 @@
     - name: Run the integration test suite
       args:
         chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
-      shell: ./test/runner/ansible-test network-integration --continue-on-error --diff --tox --tox-sitepackages --python 3.7 --inventory /home/zuul/inventory eos_.* -vv
+      shell: "./test/runner/ansible-test network-integration --continue-on-error --diff --tox --tox-sitepackages --python {{ ansible_test_python }} --inventory /home/zuul/inventory eos_.* -vv"

--- a/playbooks/ansible-test-network-integration-vyos/pre.yaml
+++ b/playbooks/ansible-test-network-integration-vyos/pre.yaml
@@ -5,6 +5,6 @@
       include_role:
         name: tox
       vars:
-        tox_install_siblings: false
         tox_extra_args: -vv -- ansible-playbook -v -c network_cli playbooks/ansible-test-network-integration-vyos/files/bootstrap.yaml
+        tox_install_siblings: false
         zuul_work_dir: "{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -55,7 +55,7 @@
         ansible_python_interpreter: python
     required-projects:
       - name: github.com/ansible/ansible-zuul-jobs
-    nodeset: eos-4.20.10-python3
+    nodeset: eos-4.20.10-python37
 
 - job:
     name: ansible-network-vyos-appliance
@@ -79,6 +79,20 @@
     required-projects:
       - name: github.com/ansible/ansible
     timeout: 7200
+
+- job:
+    name: ansible-test-network-integration-eos-python36
+    parent: ansible-test-network-integration-eos
+    nodeset: eos-4.20.10-python36
+    vars:
+      ansible_test_python: 3.6
+
+- job:
+    name: ansible-test-network-integration-eos-python37
+    parent: ansible-test-network-integration-eos
+    nodeset: eos-4.20.10-python37
+    vars:
+      ansible_test_python: 3.7
 
 - job:
     name: ansible-test-network-integration-vyos

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -25,7 +25,22 @@
 
 # Ansible network appliance nodesets
 - nodeset:
-    name: eos-4.20.10-python3
+    name: eos-4.20.10-python36
+    nodes:
+      - name: ubuntu-bionic
+        label: ubuntu-bionic-1vcpu
+      - name: eos-4.20.10
+        label: eos-4.20.10
+    groups:
+      - name: appliance
+        nodes:
+          - eos-4.20.10
+      - name: controller
+        nodes:
+          - ubuntu-bionic
+
+- nodeset:
+    name: eos-4.20.10-python37
     nodes:
       - name: fedora-29
         label: fedora-29-1vcpu

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -28,7 +28,11 @@
     name: ansible-test-network-integration
     periodic-3hr:
       jobs:
-        - ansible-test-network-integration-eos:
+        - ansible-test-network-integration-eos-python36:
+            branches:
+              - devel
+              - stable-2.8
+        - ansible-test-network-integration-eos-python37:
             branches:
               - devel
               - stable-2.8
@@ -42,7 +46,12 @@
               - stable-2.8
     periodic:
       jobs:
-        - ansible-test-network-integration-eos:
+        - ansible-test-network-integration-eos-python36:
+            branches:
+              - stable-2.7
+              - stable-2.6
+              - stable-2.5
+        - ansible-test-network-integration-eos-python37:
             branches:
               - stable-2.7
               - stable-2.6


### PR DESCRIPTION
This now supports both python36 / python37 for controller node.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>