### PR TITLE
Add python35 network-integration coverage

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -90,6 +90,13 @@
       ansible_test_python: 2.7
 
 - job:
+    name: ansible-test-network-integration-eos-python35
+    parent: ansible-test-network-integration-eos
+    nodeset: eos-4.20.10-python35
+    vars:
+      ansible_test_python: 3.5
+
+- job:
     name: ansible-test-network-integration-eos-python36
     parent: ansible-test-network-integration-eos
     nodeset: eos-4.20.10-python36
@@ -121,6 +128,13 @@
     nodeset: vyos-1.1.8-python36
     vars:
       ansible_test_python: 2.7
+
+- job:
+    name: ansible-test-network-integration-vyos-python35
+    parent: ansible-test-network-integration-vyos
+    nodeset: vyos-1.1.8-python35
+    vars:
+      ansible_test_python: 3.5
 
 - job:
     name: ansible-test-network-integration-vyos-python36

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -40,6 +40,21 @@
           - ubuntu-bionic
 
 - nodeset:
+    name: eos-4.20.10-python35
+    nodes:
+      - name: ubuntu-xenial
+        label: ubuntu-xenial-1vcpu
+      - name: eos-4.20.10
+        label: eos-4.20.10
+    groups:
+      - name: appliance
+        nodes:
+          - eos-4.20.10
+      - name: controller
+        nodes:
+          - ubuntu-xenial
+
+- nodeset:
     name: eos-4.20.10-python36
     nodes:
       - name: ubuntu-bionic
@@ -83,6 +98,21 @@
       - name: controller
         nodes:
           - ubuntu-bionic
+
+- nodeset:
+    name: vyos-1.1.8-python35
+    nodes:
+      - name: ubuntu-xenial
+        label: ubuntu-xenial-1vcpu
+      - name: vyos-1.1.8
+        label: vyos-1.1.8-1vcpu
+    groups:
+      - name: appliance
+        nodes:
+          - vyos-1.1.8
+      - name: controller
+        nodes:
+          - ubuntu-xenial
 
 - nodeset:
     name: vyos-1.1.8-python36

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -35,6 +35,13 @@
               - stable-2.7
               - stable-2.6
               - stable-2.5
+        - ansible-test-network-integration-eos-python35:
+            branches:
+              - devel
+              - stable-2.8
+              - stable-2.7
+              - stable-2.6
+              - stable-2.5
         - ansible-test-network-integration-eos-python36:
             branches:
               - devel
@@ -50,6 +57,13 @@
               - stable-2.6
               - stable-2.5
         - ansible-test-network-integration-vyos-python27:
+            branches:
+              - devel
+              - stable-2.8
+              - stable-2.7
+              - stable-2.6
+              - stable-2.5
+        - ansible-test-network-integration-vyos-python35:
             branches:
               - devel
               - stable-2.8


### PR DESCRIPTION
Bring online more testing coverage against ansible/ansible.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>