### PR TITLE
Move junos jobs back to periodic pipeline

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -26,24 +26,6 @@
 
 - project-template:
     name: ansible-test-network-integration
-    periodic-3hr:
-      jobs:
-        - ansible-test-network-integration-junos-python27:
-            branches:
-              - devel
-              - stable-2.8
-        - ansible-test-network-integration-junos-python35:
-            branches:
-              - devel
-              - stable-2.8
-        - ansible-test-network-integration-junos-python36:
-            branches:
-              - devel
-              - stable-2.8
-        - ansible-test-network-integration-junos-python37:
-            branches:
-              - devel
-              - stable-2.8
     periodic:
       jobs:
         - ansible-test-network-integration-eos-python27:
@@ -76,21 +58,29 @@
               - stable-2.5
         - ansible-test-network-integration-junos-python27:
             branches:
+              - devel
+              - stable-2.8
               - stable-2.7
               - stable-2.6
               - stable-2.5
         - ansible-test-network-integration-junos-python35:
             branches:
+              - devel
+              - stable-2.8
               - stable-2.7
               - stable-2.6
               - stable-2.5
         - ansible-test-network-integration-junos-python36:
             branches:
+              - devel
+              - stable-2.8
               - stable-2.7
               - stable-2.6
               - stable-2.5
         - ansible-test-network-integration-junos-python37:
             branches:
+              - devel
+              - stable-2.8
               - stable-2.7
               - stable-2.6
               - stable-2.5


### PR DESCRIPTION
We've confirmed the jobs work properly, move them to periodic to save
some resources.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>