### PR TITLE
Add files options to ansible-test-network-integration-vyos

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -173,6 +173,11 @@
     timeout: 3600
     vars:
       ansible_test_network_integration: vyos
+    files:
+      - ^lib/ansible/modules/network/vyos/.*
+      - ^lib/ansible/module_utils/network/vyos/.*
+      - ^lib/ansible/plugins/connection/network_cli.py
+      - ^test/integration/targets/vyos_.*
 
 - job:
     name: ansible-test-network-integration-vyos-python27


### PR DESCRIPTION
This will allows use to start filtering PRs against ansible/ansible,
something that is needed if we want to do pre-merge testing for
network-integration.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>