### PR TITLE
Revert "Add files options to ansible-test-network-integration-vyos"

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -173,11 +173,6 @@
     timeout: 3600
     vars:
       ansible_test_network_integration: vyos
-    files:
-      - ^lib/ansible/modules/network/vyos/.*
-      - ^lib/ansible/module_utils/network/vyos/.*
-      - ^lib/ansible/plugins/connection/network_cli.py
-      - ^test/integration/targets/vyos_.*
 
 - job:
     name: ansible-test-network-integration-vyos-python27


### PR DESCRIPTION
This reverts commit cfd3188938dd19d3866083cd0dd415e84bce7c34.