### PR TITLE
Add ansible-test-network-integration-vyos-python37 to third-party-check

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -116,6 +116,11 @@
               - stable-2.6
               - stable-2.5
             files: []
+    third-party-check:
+      jobs:
+        - ansible-test-network-integration-vyos-python37:
+            branches:
+              - devel
 
 - project-template:
     name: noop-jobs


### PR DESCRIPTION
This should get us to start pre-merge testing on vyos related PRs on
ansible/ansible.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>