### PR TITLE
Add ansible-test-network-integration-eos to third-party-check

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -94,6 +94,11 @@
     timeout: 7200
     vars:
       ansible_test_network_integration: eos
+    files:
+      - ^lib/ansible/modules/network/eos/.*
+      - ^lib/ansible/module_utils/network/eos/.*
+      - ^lib/ansible/plugins/connection/network_cli.py
+      - ^test/integration/targets/eos_.*
 
 - job:
     name: ansible-test-network-integration-eos-python27

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -35,6 +35,7 @@
               - stable-2.7
               - stable-2.6
               - stable-2.5
+            files: []
         - ansible-test-network-integration-eos-python35:
             branches:
               - devel
@@ -42,6 +43,7 @@
               - stable-2.7
               - stable-2.6
               - stable-2.5
+            files: []
         - ansible-test-network-integration-eos-python36:
             branches:
               - devel
@@ -49,6 +51,7 @@
               - stable-2.7
               - stable-2.6
               - stable-2.5
+            files: []
         - ansible-test-network-integration-eos-python37:
             branches:
               - devel
@@ -56,6 +59,7 @@
               - stable-2.7
               - stable-2.6
               - stable-2.5
+            files: []
         - ansible-test-network-integration-junos-python27:
             branches:
               - devel
@@ -118,6 +122,9 @@
             files: []
     third-party-check:
       jobs:
+        - ansible-test-network-integration-eos-python37:
+            branches:
+              - devel
         - ansible-test-network-integration-vyos-python37:
             branches:
               - devel


### PR DESCRIPTION
This starts to run 3pci on ansible/ansible for eos appliances.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>