### PR TITLE
Add periodic-1hr job to test files matcher

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -26,6 +26,13 @@
 
 - project-template:
     name: ansible-test-network-integration
+    periodic-1hr:
+      jobs:
+        - ansible-test-network-integration-eos-python27:
+            branches:
+              - devel
+            files:
+              - ^.*
     periodic:
       jobs:
         - ansible-test-network-integration-eos-python27:


### PR DESCRIPTION
We want to override the file matchers we set in the base job, so we can
run periodic jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>