### PR TITLE
Enable ansible-test-network-integration-vyos-python37 to stable

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -128,6 +128,10 @@
         - ansible-test-network-integration-vyos-python37:
             branches:
               - devel
+              - stable-2.8
+              - stable-2.7
+              - stable-2.6
+              - stable-2.5
 
 - project-template:
     name: noop-jobs


### PR DESCRIPTION
This now runs vyos jobs on all stable branches.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>