### PR TITLE
Add all ansible-network vyos integration tests to third-party-check

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -125,6 +125,27 @@
         - ansible-test-network-integration-eos-python37:
             branches:
               - devel
+        - ansible-test-network-integration-vyos-python27:
+            branches:
+              - devel
+              - stable-2.8
+              - stable-2.7
+              - stable-2.6
+              - stable-2.5
+        - ansible-test-network-integration-vyos-python35:
+            branches:
+              - devel
+              - stable-2.8
+              - stable-2.7
+              - stable-2.6
+              - stable-2.5
+        - ansible-test-network-integration-vyos-python36:
+            branches:
+              - devel
+              - stable-2.8
+              - stable-2.7
+              - stable-2.6
+              - stable-2.5
         - ansible-test-network-integration-vyos-python37:
             branches:
               - devel


### PR DESCRIPTION
Now what we know vyos is passing properly, start running all of our
testing against ansible/ansible PRs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>