### PR TITLE
Enable ARA for ansible-test integration testing

### DIFF
--- a/playbooks/ansible-test-network-integration-base/run.yaml
+++ b/playbooks/ansible-test-network-integration-base/run.yaml
@@ -19,6 +19,16 @@
     - name: Create virtualenv for ansible-test
       shell: "virtualenv {{ _virtualenv_options }} ~/venv"
 
+    - name: Install ara into virtuelenv
+      shell: ~/venv/bin/pip install ara
+
+    - name: Enable ARA callback plugin
+      ini_file:
+        path: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/test/integration/network-integration.cfg"
+        section: defaults
+        option: callback_plugins
+        value: "{{ ansible_user_dir }}/venv/lib/python{{ ansible_test_python}}/site-packages/ara/plugins/callbacks"
+
     - name: Setup base test_options
       set_fact:
         _test_options: "--continue-on-error --diff --requirements"


### PR DESCRIPTION
It is helpful to give more info about ansible, in this case install ARA
and we will generate reports.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>