### PR TITLE
Add all eos network-integration tests to third-party-check

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -118,9 +118,34 @@
               - stable-2.5
     third-party-check:
       jobs:
+        - ansible-test-network-integration-eos-python27:
+            branches:
+              - devel
+              - stable-2.8
+              - stable-2.7
+              - stable-2.6
+              - stable-2.5
+        - ansible-test-network-integration-eos-python35:
+            branches:
+              - devel
+              - stable-2.8
+              - stable-2.7
+              - stable-2.6
+              - stable-2.5
+        - ansible-test-network-integration-eos-python36:
+            branches:
+              - devel
+              - stable-2.8
+              - stable-2.7
+              - stable-2.6
+              - stable-2.5
         - ansible-test-network-integration-eos-python37:
             branches:
               - devel
+              - stable-2.8
+              - stable-2.7
+              - stable-2.6
+              - stable-2.5
         - ansible-test-network-integration-vyos-python27:
             branches:
               - devel


### PR DESCRIPTION
Now that eos is working properly on ansible/ansible, run all our tests.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>