### PR TITLE
Add ansible-test-network-integration-junos-python37 to third-party-check

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -138,6 +138,12 @@
     timeout: 7200
     vars:
       ansible_test_network_integration: junos
+    files:
+      - ^lib/ansible/modules/network/junos/.*
+      - ^lib/ansible/module_utils/network/junos/.*
+      - ^lib/ansible/plugins/connection/network_cli.py
+      - ^test/integration/targets/junos_.*
+      - ^test/integration/targets/netconf_.*
 
 - job:
     name: ansible-test-network-integration-junos-python27

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -146,6 +146,9 @@
               - stable-2.7
               - stable-2.6
               - stable-2.5
+        - ansible-test-network-integration-junos-python37:
+            branches:
+              - devel
         - ansible-test-network-integration-vyos-python27:
             branches:
               - devel


### PR DESCRIPTION
Start pre-merge testing on ansible/ansible of junos.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>