### PR TITLE
Move job.files for eos into pipeline stanza

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -94,11 +94,6 @@
     timeout: 7200
     vars:
       ansible_test_network_integration: eos
-    files:
-      - ^lib/ansible/modules/network/eos/.*
-      - ^lib/ansible/module_utils/network/eos/.*
-      - ^lib/ansible/plugins/connection/network_cli.py
-      - ^test/integration/targets/eos_.*
 
 - job:
     name: ansible-test-network-integration-eos-python27

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -35,7 +35,6 @@
               - stable-2.7
               - stable-2.6
               - stable-2.5
-            files: []
         - ansible-test-network-integration-eos-python35:
             branches:
               - devel
@@ -43,7 +42,6 @@
               - stable-2.7
               - stable-2.6
               - stable-2.5
-            files: []
         - ansible-test-network-integration-eos-python36:
             branches:
               - devel
@@ -51,7 +49,6 @@
               - stable-2.7
               - stable-2.6
               - stable-2.5
-            files: []
         - ansible-test-network-integration-eos-python37:
             branches:
               - devel
@@ -59,7 +56,6 @@
               - stable-2.7
               - stable-2.6
               - stable-2.5
-            files: []
         - ansible-test-network-integration-junos-python27:
             branches:
               - devel
@@ -125,6 +121,11 @@
               - stable-2.7
               - stable-2.6
               - stable-2.5
+            files:
+              - ^lib/ansible/modules/network/eos/.*
+              - ^lib/ansible/module_utils/network/eos/.*
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/eos_.*
         - ansible-test-network-integration-eos-python35:
             branches:
               - devel
@@ -132,6 +133,11 @@
               - stable-2.7
               - stable-2.6
               - stable-2.5
+            files:
+              - ^lib/ansible/modules/network/eos/.*
+              - ^lib/ansible/module_utils/network/eos/.*
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/eos_.*
         - ansible-test-network-integration-eos-python36:
             branches:
               - devel
@@ -139,6 +145,11 @@
               - stable-2.7
               - stable-2.6
               - stable-2.5
+            files:
+              - ^lib/ansible/modules/network/eos/.*
+              - ^lib/ansible/module_utils/network/eos/.*
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/eos_.*
         - ansible-test-network-integration-eos-python37:
             branches:
               - devel
@@ -146,6 +157,11 @@
               - stable-2.7
               - stable-2.6
               - stable-2.5
+            files:
+              - ^lib/ansible/modules/network/eos/.*
+              - ^lib/ansible/module_utils/network/eos/.*
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/eos_.*
         - ansible-test-network-integration-junos-python37:
             branches:
               - devel


### PR DESCRIPTION
This is to workaround a bug in zuul handling of job.files with periodic
jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>