### PR TITLE
Move job.files for junos network-integration to pipeline stanza

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -133,12 +133,6 @@
     timeout: 7200
     vars:
       ansible_test_network_integration: junos
-    files:
-      - ^lib/ansible/modules/network/junos/.*
-      - ^lib/ansible/module_utils/network/junos/.*
-      - ^lib/ansible/plugins/connection/network_cli.py
-      - ^test/integration/targets/junos_.*
-      - ^test/integration/targets/netconf_.*
 
 - job:
     name: ansible-test-network-integration-junos-python27

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -149,6 +149,12 @@
         - ansible-test-network-integration-junos-python37:
             branches:
               - devel
+            files:
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
         - ansible-test-network-integration-vyos-python27:
             branches:
               - devel


### PR DESCRIPTION
Again, this is to work around a bug with job.files in periodic
pipelines.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>