### PR TITLE
Move stable network-integration jobs to third-party-check-silent

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -111,33 +111,9 @@
               - ^lib/ansible/plugins/cliconf/eos.py
               - ^lib/ansible/plugins/connection/network_cli.py
               - ^test/integration/targets/eos_.*
-        - ansible-test-network-integration-eos-python27:
-            voting: false
-            branches:
-              - stable-2.8
-              - stable-2.7
-              - stable-2.6
-            files:
-              - ^lib/ansible/modules/network/eos/.*
-              - ^lib/ansible/module_utils/network/eos/.*
-              - ^lib/ansible/plugins/cliconf/eos.py
-              - ^lib/ansible/plugins/connection/network_cli.py
-              - ^test/integration/targets/eos_.*
         - ansible-test-network-integration-eos-python35:
             branches:
               - devel
-            files:
-              - ^lib/ansible/modules/network/eos/.*
-              - ^lib/ansible/module_utils/network/eos/.*
-              - ^lib/ansible/plugins/cliconf/eos.py
-              - ^lib/ansible/plugins/connection/network_cli.py
-              - ^test/integration/targets/eos_.*
-        - ansible-test-network-integration-eos-python35:
-            voting: false
-            branches:
-              - stable-2.8
-              - stable-2.7
-              - stable-2.6
             files:
               - ^lib/ansible/modules/network/eos/.*
               - ^lib/ansible/module_utils/network/eos/.*
@@ -153,33 +129,9 @@
               - ^lib/ansible/plugins/cliconf/eos.py
               - ^lib/ansible/plugins/connection/network_cli.py
               - ^test/integration/targets/eos_.*
-        - ansible-test-network-integration-eos-python36:
-            voting: false
-            branches:
-              - stable-2.8
-              - stable-2.7
-              - stable-2.6
-            files:
-              - ^lib/ansible/modules/network/eos/.*
-              - ^lib/ansible/module_utils/network/eos/.*
-              - ^lib/ansible/plugins/cliconf/eos.py
-              - ^lib/ansible/plugins/connection/network_cli.py
-              - ^test/integration/targets/eos_.*
         - ansible-test-network-integration-eos-python37:
             branches:
               - devel
-            files:
-              - ^lib/ansible/modules/network/eos/.*
-              - ^lib/ansible/module_utils/network/eos/.*
-              - ^lib/ansible/plugins/cliconf/eos.py
-              - ^lib/ansible/plugins/connection/network_cli.py
-              - ^test/integration/targets/eos_.*
-        - ansible-test-network-integration-eos-python37:
-            voting: false
-            branches:
-              - stable-2.8
-              - stable-2.7
-              - stable-2.6
             files:
               - ^lib/ansible/modules/network/eos/.*
               - ^lib/ansible/module_utils/network/eos/.*
@@ -199,6 +151,87 @@
         - ansible-test-network-integration-vyos-python27:
             branches:
               - devel
+            files:
+              - ^lib/ansible/modules/network/vyos/.*
+              - ^lib/ansible/module_utils/network/vyos/.*
+              - ^lib/ansible/plugins/cliconf/vyos.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/vyos_.*
+        - ansible-test-network-integration-vyos-python35:
+            branches:
+              - devel
+            files:
+              - ^lib/ansible/modules/network/vyos/.*
+              - ^lib/ansible/module_utils/network/vyos/.*
+              - ^lib/ansible/plugins/cliconf/vyos.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/vyos_.*
+        - ansible-test-network-integration-vyos-python36:
+            branches:
+              - devel
+            files:
+              - ^lib/ansible/modules/network/vyos/.*
+              - ^lib/ansible/module_utils/network/vyos/.*
+              - ^lib/ansible/plugins/cliconf/vyos.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/vyos_.*
+        - ansible-test-network-integration-vyos-python37:
+            branches:
+              - devel
+            files:
+              - ^lib/ansible/modules/network/vyos/.*
+              - ^lib/ansible/module_utils/network/vyos/.*
+              - ^lib/ansible/plugins/cliconf/vyos.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/vyos_.*
+    third-party-check-silent:
+      jobs:
+        - ansible-test-network-integration-eos-python27:
+            branches:
+              - stable-2.8
+              - stable-2.7
+              - stable-2.6
+            files:
+              - ^lib/ansible/modules/network/eos/.*
+              - ^lib/ansible/module_utils/network/eos/.*
+              - ^lib/ansible/plugins/cliconf/eos.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/eos_.*
+        - ansible-test-network-integration-eos-python35:
+            branches:
+              - stable-2.8
+              - stable-2.7
+              - stable-2.6
+            files:
+              - ^lib/ansible/modules/network/eos/.*
+              - ^lib/ansible/module_utils/network/eos/.*
+              - ^lib/ansible/plugins/cliconf/eos.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/eos_.*
+        - ansible-test-network-integration-eos-python36:
+            branches:
+              - stable-2.8
+              - stable-2.7
+              - stable-2.6
+            files:
+              - ^lib/ansible/modules/network/eos/.*
+              - ^lib/ansible/module_utils/network/eos/.*
+              - ^lib/ansible/plugins/cliconf/eos.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/eos_.*
+        - ansible-test-network-integration-eos-python37:
+            branches:
+              - stable-2.8
+              - stable-2.7
+              - stable-2.6
+            files:
+              - ^lib/ansible/modules/network/eos/.*
+              - ^lib/ansible/module_utils/network/eos/.*
+              - ^lib/ansible/plugins/cliconf/eos.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/eos_.*
+        - ansible-test-network-integration-vyos-python27:
+            branches:
               - stable-2.8
               - stable-2.7
               - stable-2.6
@@ -210,7 +243,6 @@
               - ^test/integration/targets/vyos_.*
         - ansible-test-network-integration-vyos-python35:
             branches:
-              - devel
               - stable-2.8
               - stable-2.7
               - stable-2.6
@@ -222,7 +254,6 @@
               - ^test/integration/targets/vyos_.*
         - ansible-test-network-integration-vyos-python36:
             branches:
-              - devel
               - stable-2.8
               - stable-2.7
               - stable-2.6
@@ -234,7 +265,6 @@
               - ^test/integration/targets/vyos_.*
         - ansible-test-network-integration-vyos-python37:
             branches:
-              - devel
               - stable-2.8
               - stable-2.7
               - stable-2.6


### PR DESCRIPTION
Until we have these tests working properly, don't report results to
github.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>