### PR TITLE
Add more job.file matches for network-integration

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -130,6 +130,7 @@
             branches:
               - devel
             files:
+              - ^lib/ansible/modules/network/common/.*
               - ^lib/ansible/modules/network/eos/.*
               - ^lib/ansible/module_utils/network/eos/.*
               - ^lib/ansible/plugins/cliconf/eos.py
@@ -139,6 +140,7 @@
             branches:
               - devel
             files:
+              - ^lib/ansible/modules/network/common/.*
               - ^lib/ansible/modules/network/eos/.*
               - ^lib/ansible/module_utils/network/eos/.*
               - ^lib/ansible/plugins/cliconf/eos.py
@@ -148,6 +150,7 @@
             branches:
               - devel
             files:
+              - ^lib/ansible/modules/network/common/.*
               - ^lib/ansible/modules/network/eos/.*
               - ^lib/ansible/module_utils/network/eos/.*
               - ^lib/ansible/plugins/cliconf/eos.py
@@ -157,6 +160,7 @@
             branches:
               - devel
             files:
+              - ^lib/ansible/modules/network/common/.*
               - ^lib/ansible/modules/network/eos/.*
               - ^lib/ansible/module_utils/network/eos/.*
               - ^lib/ansible/plugins/cliconf/eos.py
@@ -166,6 +170,7 @@
             branches:
               - devel
             files:
+              - ^lib/ansible/modules/network/common/.*
               - ^lib/ansible/modules/network/junos/.*
               - ^lib/ansible/module_utils/network/junos/.*
               - ^lib/ansible/plugins/cliconf/junos.py
@@ -176,6 +181,7 @@
             branches:
               - devel
             files:
+              - ^lib/ansible/modules/network/common/.*
               - ^lib/ansible/modules/network/vyos/.*
               - ^lib/ansible/module_utils/network/vyos/.*
               - ^lib/ansible/plugins/cliconf/vyos.py
@@ -185,6 +191,7 @@
             branches:
               - devel
             files:
+              - ^lib/ansible/modules/network/common/.*
               - ^lib/ansible/modules/network/vyos/.*
               - ^lib/ansible/module_utils/network/vyos/.*
               - ^lib/ansible/plugins/cliconf/vyos.py
@@ -194,6 +201,7 @@
             branches:
               - devel
             files:
+              - ^lib/ansible/modules/network/common/.*
               - ^lib/ansible/modules/network/vyos/.*
               - ^lib/ansible/module_utils/network/vyos/.*
               - ^lib/ansible/plugins/cliconf/vyos.py
@@ -203,6 +211,7 @@
             branches:
               - devel
             files:
+              - ^lib/ansible/modules/network/common/.*
               - ^lib/ansible/modules/network/vyos/.*
               - ^lib/ansible/module_utils/network/vyos/.*
               - ^lib/ansible/plugins/cliconf/vyos.py
@@ -216,6 +225,7 @@
               - stable-2.7
               - stable-2.6
             files:
+              - ^lib/ansible/modules/network/common/.*
               - ^lib/ansible/modules/network/eos/.*
               - ^lib/ansible/module_utils/network/eos/.*
               - ^lib/ansible/plugins/cliconf/eos.py
@@ -227,6 +237,7 @@
               - stable-2.7
               - stable-2.6
             files:
+              - ^lib/ansible/modules/network/common/.*
               - ^lib/ansible/modules/network/eos/.*
               - ^lib/ansible/module_utils/network/eos/.*
               - ^lib/ansible/plugins/cliconf/eos.py
@@ -238,6 +249,7 @@
               - stable-2.7
               - stable-2.6
             files:
+              - ^lib/ansible/modules/network/common/.*
               - ^lib/ansible/modules/network/eos/.*
               - ^lib/ansible/module_utils/network/eos/.*
               - ^lib/ansible/plugins/cliconf/eos.py
@@ -249,6 +261,7 @@
               - stable-2.7
               - stable-2.6
             files:
+              - ^lib/ansible/modules/network/common/.*
               - ^lib/ansible/modules/network/eos/.*
               - ^lib/ansible/module_utils/network/eos/.*
               - ^lib/ansible/plugins/cliconf/eos.py
@@ -260,6 +273,7 @@
               - stable-2.7
               - stable-2.6
             files:
+              - ^lib/ansible/modules/network/common/.*
               - ^lib/ansible/modules/network/vyos/.*
               - ^lib/ansible/module_utils/network/vyos/.*
               - ^lib/ansible/plugins/cliconf/vyos.py
@@ -271,6 +285,7 @@
               - stable-2.7
               - stable-2.6
             files:
+              - ^lib/ansible/modules/network/common/.*
               - ^lib/ansible/modules/network/vyos/.*
               - ^lib/ansible/module_utils/network/vyos/.*
               - ^lib/ansible/plugins/cliconf/vyos.py
@@ -282,6 +297,7 @@
               - stable-2.7
               - stable-2.6
             files:
+              - ^lib/ansible/modules/network/common/.*
               - ^lib/ansible/modules/network/vyos/.*
               - ^lib/ansible/module_utils/network/vyos/.*
               - ^lib/ansible/plugins/cliconf/vyos.py
@@ -293,6 +309,7 @@
               - stable-2.7
               - stable-2.6
             files:
+              - ^lib/ansible/modules/network/common/.*
               - ^lib/ansible/modules/network/vyos/.*
               - ^lib/ansible/module_utils/network/vyos/.*
               - ^lib/ansible/plugins/cliconf/vyos.py


### PR DESCRIPTION
We want to run jobs when we update module_utils/network/common.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>