### PR TITLE
Set ansible-test-network-integration-junos-python37 non-voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -167,6 +167,7 @@
               - ^lib/ansible/plugins/connection/network_cli.py
               - ^test/integration/targets/eos_.*
         - ansible-test-network-integration-junos-python37:
+            voting: false
             branches:
               - devel
             files:


### PR DESCRIPTION
This isn't passing yet on ansible/ansible devel, but we want results.
Set it non-voting for now.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>