### PR TITLE
Add ansible-network-openvswitch-appliance job

### DIFF
--- a/playbooks/ansible-network-appliance-base/pre.yaml
+++ b/playbooks/ansible-network-appliance-base/pre.yaml
@@ -13,7 +13,7 @@
 
     - name: Ensure remote SSH host keys are known
       shell: "ssh-keyscan -t rsa {{ hostvars[item].ansible_host }} >> ~/.ssh/known_hosts"
-      with_inventory_hostnames: appliance
+      with_inventory_hostnames: appliance:openvswitch
 
     - name: Create /etc/ansible folder
       become: true

--- a/playbooks/ansible-network-openvswitch-appliance/files/bootstrap.yaml
+++ b/playbooks/ansible-network-openvswitch-appliance/files/bootstrap.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: openvswitch
+  tasks:
+    - name: Install openvswitch package
+      become: true
+      package:
+        name: openvswitch-switch
+        state: installed

--- a/playbooks/ansible-network-openvswitch-appliance/pre.yaml
+++ b/playbooks/ansible-network-openvswitch-appliance/pre.yaml
@@ -1,0 +1,10 @@
+---
+- hosts: controller
+  tasks:
+    - name: Setup tox role
+      include_role:
+        name: tox
+      vars:
+        tox_extra_args: -vv -- ansible-playbook -v playbooks/ansible-network-openvswitch-appliance/files/bootstrap.yaml
+        tox_install_siblings: false
+        zuul_work_dir: "{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"

--- a/playbooks/ansible-network-openvswitch-appliance/run.yaml
+++ b/playbooks/ansible-network-openvswitch-appliance/run.yaml
@@ -1,0 +1,3 @@
+---
+- hosts: all
+  tasks: []

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -84,6 +84,18 @@
     nodeset: vsrx3-18.4R1-python37
 
 - job:
+    name: ansible-network-openvswitch-appliance
+    parent: ansible-network-appliance-base
+    pre-run: playbooks/ansible-network-openvswitch-appliance/pre.yaml
+    run: playbooks/ansible-network-openvswitch-appliance/run.yaml
+    host-vars:
+      openvswitch-2.9.0:
+        ansible_network_os: openvswitch
+    required-projects:
+      - name: github.com/ansible/ansible-zuul-jobs
+    nodeset: openvswitch-2.9.0-python37
+
+- job:
     name: ansible-network-vyos-appliance
     parent: ansible-network-appliance-base
     pre-run: playbooks/ansible-network-vyos-appliance/pre.yaml

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -145,6 +145,66 @@
           - fedora-29
 
 - nodeset:
+    name: openvswitch-2.9.0-python27
+    nodes:
+      - name: ubuntu-bionic
+        label: ubuntu-bionic-1vcpu
+      - name: openvswitch-2.9.0
+        label: ubuntu-bionic-1vcpu
+    groups:
+      - name: openvswitch
+        nodes:
+          - openvswitch-2.9.0
+      - name: controller
+        nodes:
+          - ubuntu-bionic
+
+- nodeset:
+    name: openvswitch-2.9.0-python35
+    nodes:
+      - name: ubuntu-xenial
+        label: ubuntu-xenial-1vcpu
+      - name: openvswitch-2.9.0
+        label: ubuntu-bionic-1vcpu
+    groups:
+      - name: openvswitch
+        nodes:
+          - openvswitch-2.9.0
+      - name: controller
+        nodes:
+          - ubuntu-xenial
+
+- nodeset:
+    name: openvswitch-2.9.0-python36
+    nodes:
+      - name: ubuntu-bionic
+        label: ubuntu-bionic-1vcpu
+      - name: openvswitch-2.9.0
+        label: ubuntu-bionic-1vcpu
+    groups:
+      - name: openvswitch
+        nodes:
+          - openvswitch-2.9.0
+      - name: controller
+        nodes:
+          - ubuntu-bionic
+
+- nodeset:
+    name: openvswitch-2.9.0-python37
+    nodes:
+      - name: fedora-29
+        label: fedora-29-1vcpu
+      - name: openvswitch-2.9.0
+        label: ubuntu-bionic-1vcpu
+    groups:
+      - name: openvswitch
+        nodes:
+          - openvswitch-2.9.0
+      - name: controller
+        nodes:
+          - fedora-29
+
+- nodeset:
     name: vsrx3-18.4R1-python27
     nodes:
       - name: ubuntu-bionic

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -7,10 +7,12 @@
         - ansible-network-eos-appliance
         - ansible-network-ios-appliance
         - ansible-network-junos-appliance
+        - ansible-network-openvswitch-appliance
         - ansible-network-vyos-appliance
     gate:
       jobs:
         - ansible-network-eos-appliance
         - ansible-network-ios-appliance
         - ansible-network-junos-appliance
+        - ansible-network-openvswitch-appliance
         - ansible-network-vyos-appliance


### PR DESCRIPTION
We want to test openvswitch on ansible/ansible, this is the parent job
to allow for that.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>