### PR TITLE
Increase testing of junos network-integration

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -170,6 +170,42 @@
               - ^lib/ansible/plugins/cliconf/eos.py
               - ^lib/ansible/plugins/connection/network_cli.py
               - ^test/integration/targets/eos_.*
+        - ansible-test-network-integration-junos-python27:
+            voting: false
+            branches:
+              - devel
+            files:
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/plugins/cliconf/junos.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
+        - ansible-test-network-integration-junos-python35:
+            voting: false
+            branches:
+              - devel
+            files:
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/plugins/cliconf/junos.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
+        - ansible-test-network-integration-junos-python36:
+            voting: false
+            branches:
+              - devel
+            files:
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/plugins/cliconf/junos.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
         - ansible-test-network-integration-junos-python37:
             voting: false
             branches:
@@ -280,6 +316,58 @@
               - ^lib/ansible/plugins/cliconf/eos.py
               - ^lib/ansible/plugins/connection/network_cli.py
               - ^test/integration/targets/eos_.*
+        - ansible-test-network-integration-junos-python27:
+            branches:
+              - stable-2.8
+              - stable-2.7
+              - stable-2.6
+            files:
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/plugins/cliconf/junos.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
+        - ansible-test-network-integration-junos-python35:
+            branches:
+              - stable-2.8
+              - stable-2.7
+              - stable-2.6
+            files:
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/plugins/cliconf/junos.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
+        - ansible-test-network-integration-junos-python36:
+            branches:
+              - stable-2.8
+              - stable-2.7
+              - stable-2.6
+            files:
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/plugins/cliconf/junos.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
+        - ansible-test-network-integration-junos-python37:
+            branches:
+              - stable-2.8
+              - stable-2.7
+              - stable-2.6
+            files:
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/plugins/cliconf/junos.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
 
 - project-template:
     name: noop-jobs


### PR DESCRIPTION
Now that we have PRs being created to fix issues, we should run all
junos tests.  stable branches are not reporting back to github, until
green.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>