### PR TITLE
Add network-integration OVS jobs to thirdparty-ci-slient

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -388,6 +388,34 @@
               - ^lib/ansible/plugins/connection/network_cli.py
               - ^test/integration/targets/junos_.*
               - ^test/integration/targets/netconf_.*
+        - ansible-test-network-integration-openvswitch-python27:
+            branches:
+              - stable-2.8
+            files:
+              - ^lib/ansible/modules/network/ovs/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^test/integration/targets/openvswitch_.*
+        - ansible-test-network-integration-openvswitch-python35:
+            branches:
+              - stable-2.8
+            files:
+              - ^lib/ansible/modules/network/ovs/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^test/integration/targets/openvswitch_.*
+        - ansible-test-network-integration-openvswitch-python36:
+            branches:
+              - stable-2.8
+            files:
+              - ^lib/ansible/modules/network/ovs/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^test/integration/targets/openvswitch_.*
+        - ansible-test-network-integration-openvswitch-python37:
+            branches:
+              - stable-2.8
+            files:
+              - ^lib/ansible/modules/network/ovs/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^test/integration/targets/openvswitch_.*
 
 - project-template:
     name: noop-jobs


### PR DESCRIPTION
This allows us to confirm jobs are green before reporting results back
to github.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>