### PR TITLE
Add non-voting ios jobs to thirdparty-check pipeline

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -174,6 +174,50 @@
               - ^lib/ansible/plugins/cliconf/eos.py
               - ^lib/ansible/plugins/connection/network_cli.py
               - ^test/integration/targets/eos_.*
+        - ansible-test-network-integration-ios-python27:
+            voting: false
+            branches:
+              - devel
+            files:
+              - ^lib/ansible/modules/network/ios/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/ios/.*
+              - ^lib/ansible/plugins/cliconf/ios.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/ios_.*
+        - ansible-test-network-integration-ios-python35:
+            voting: false
+            branches:
+              - devel
+            files:
+              - ^lib/ansible/modules/network/ios/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/ios/.*
+              - ^lib/ansible/plugins/cliconf/ios.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/ios_.*
+        - ansible-test-network-integration-ios-python36:
+            voting: false
+            branches:
+              - devel
+            files:
+              - ^lib/ansible/modules/network/ios/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/ios/.*
+              - ^lib/ansible/plugins/cliconf/ios.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/ios_.*
+        - ansible-test-network-integration-ios-python37:
+            voting: false
+            branches:
+              - devel
+            files:
+              - ^lib/ansible/modules/network/ios/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/ios/.*
+              - ^lib/ansible/plugins/cliconf/ios.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/ios_.*
         - ansible-test-network-integration-junos-python27:
             voting: false
             branches:


### PR DESCRIPTION
This is so we can report back on ansible/ansible PRs related to IOS.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>