### PR TITLE
Cap ARA<1.0.0 for ansible-test-network-integration

### DIFF
--- a/playbooks/ansible-test-network-integration-base/run.yaml
+++ b/playbooks/ansible-test-network-integration-base/run.yaml
@@ -20,7 +20,7 @@
       shell: "virtualenv {{ _virtualenv_options }} ~/venv"
 
     - name: Install ara into virtuelenv
-      shell: ~/venv/bin/pip install ara
+      shell: ~/venv/bin/pip install ara<1.0.0
 
     - name: Enable ARA callback plugin
       ini_file:


### PR DESCRIPTION
We haven't looked to see what is needed to use ARA 1.0.0, so just cap it
for now.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>