### PR TITLE
Don't delay 10 seconds for SSH wait_for

### DIFF
--- a/playbooks/ansible-network-appliance-base/pre.yaml
+++ b/playbooks/ansible-network-appliance-base/pre.yaml
@@ -13,7 +13,6 @@
 
     - name: Wait 300 seconds for port tcp/22 on appliance
       wait_for:
-        delay: 10
         host: "{{ hostvars[item].ansible_host }}"
         port: 22
         search_regex: SSH


### PR DESCRIPTION
For images, that are setup properly by nodepool, there is no need to
delay scanning them.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>