### PR TITLE
Reduce rsync output for ara-report in ansible-network jobs

### DIFF
--- a/playbooks/ansible-network-appliance-base/post.yaml
+++ b/playbooks/ansible-network-appliance-base/post.yaml
@@ -16,6 +16,7 @@
     # TODO: Migrate to fetch-zuul-logs when
     # https://review.openstack.org/#/c/583346/ is merged.
     - name: Collect log output
+      no_log: true
       synchronize:
         dest: "{{ zuul.executor.log_root }}/"
         mode: pull


### PR DESCRIPTION
We really don't need to know the details of ara-report rsync.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>