### PR TITLE
Make ios network-integration jobs voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -191,7 +191,6 @@
               - ^lib/ansible/plugins/connection/network_cli.py
               - ^test/integration/targets/eos_.*
         - ansible-test-network-integration-ios-python27:
-            voting: false
             branches:
               - devel
             files:
@@ -202,7 +201,6 @@
               - ^lib/ansible/plugins/connection/network_cli.py
               - ^test/integration/targets/ios_.*
         - ansible-test-network-integration-ios-python35:
-            voting: false
             branches:
               - devel
             files:
@@ -213,7 +211,6 @@
               - ^lib/ansible/plugins/connection/network_cli.py
               - ^test/integration/targets/ios_.*
         - ansible-test-network-integration-ios-python36:
-            voting: false
             branches:
               - devel
             files:
@@ -224,7 +221,6 @@
               - ^lib/ansible/plugins/connection/network_cli.py
               - ^test/integration/targets/ios_.*
         - ansible-test-network-integration-ios-python37:
-            voting: false
             branches:
               - devel
             files:


### PR DESCRIPTION
We've fixed all the IOS jobs failures, and now everything passes
properly.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>