### PR TITLE
Add ios network-integration jobs for stable-2.8

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -448,6 +448,46 @@
               - ^lib/ansible/plugins/cliconf/eos.py
               - ^lib/ansible/plugins/connection/network_cli.py
               - ^test/integration/targets/eos_.*
+        - ansible-test-network-integration-ios-python27:
+            branches:
+              - stable-2.8
+            files:
+              - ^lib/ansible/modules/network/ios/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/ios/.*
+              - ^lib/ansible/plugins/cliconf/ios.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/ios_.*
+        - ansible-test-network-integration-ios-python35:
+            branches:
+              - stable-2.8
+            files:
+              - ^lib/ansible/modules/network/ios/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/ios/.*
+              - ^lib/ansible/plugins/cliconf/ios.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/ios_.*
+        - ansible-test-network-integration-ios-python36:
+            branches:
+              - stable-2.8
+            files:
+              - ^lib/ansible/modules/network/ios/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/ios/.*
+              - ^lib/ansible/plugins/cliconf/ios.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/ios_.*
+        - ansible-test-network-integration-ios-python37:
+            branches:
+              - stable-2.8
+            files:
+              - ^lib/ansible/modules/network/ios/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/ios/.*
+              - ^lib/ansible/plugins/cliconf/ios.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^test/integration/targets/ios_.*
         - ansible-test-network-integration-junos-python27:
             branches:
               - stable-2.8


### PR DESCRIPTION
Start running ios jobs on stable-2.8 to confirm jobs are passing, we'll
them move to third-party-check once everything is green.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>