### PR TITLE
Enable netconf tests for iosxr

### DIFF
--- a/playbooks/ansible-test-network-integration-base/run.yaml
+++ b/playbooks/ansible-test-network-integration-base/run.yaml
@@ -45,7 +45,7 @@
     - name: Enable netconf_.* target for ansible-test
       set_fact:
         _target: "{{ _target }} netconf_.*"
-      when: ansible_test_network_integration in ["iosxrv", "junos"]
+      when: ansible_test_network_integration in ["iosxr", "junos"]
 
     - name: Run the integration test suite
       args:


### PR DESCRIPTION
We had a typo in our netconf tests logic for network-integration jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>