### PR TITLE
Fix iosxr inventory template

### DIFF
--- a/playbooks/ansible-test-network-integration-base/templates/inventory-iosxr.j2
+++ b/playbooks/ansible-test-network-integration-base/templates/inventory-iosxr.j2
@@ -7,7 +7,6 @@ iosxr-6.1.3 ansible_port=22 ansible_host={{ hostvars['iosxr-6.1.3'].ansible_host
 [iosxr:vars]
 ansible_become=true
 ansible_become_method=enable
-ansible_connection=network_cli
 ansible_network_os=iosxr
 ansible_python_interpreter=/home/zuul/venv/bin/python
 ansible_ssh_private_key_file=/home/zuul/.ssh/id_rsa
@@ -21,7 +20,6 @@ iosxr-6.1.3 ansible_port=22 ansible_host={{ hostvars['iosxr-6.1.3'].ansible_host
 [netconf:vars]
 ansible_become=true
 ansible_become_method=enable
-ansible_connection=network_cli
 ansible_network_os=iosxr
 ansible_python_interpreter=/home/zuul/venv/bin/python
 ansible_ssh_private_key_file=/home/zuul/.ssh/id_rsa


### PR DESCRIPTION
*  Remove ansible_connection value from the inventory file
   as the appropirate connection type is set in the iosxr testcase
   for based on the modules that support either both or one of the
   connection type from network_cli and netconf