### PR TITLE
Update iosxr file matcher to include netconf

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -244,44 +244,60 @@
               - devel
             files:
               - ^lib/ansible/modules/network/iosxr/.*
+              - ^lib/ansible/modules/network/netconf/.*
               - ^lib/ansible/module_utils/network/common/.*
               - ^lib/ansible/module_utils/network/iosxr/.*
+              - ^lib/ansible/module_utils/network/netconf/.*
               - ^lib/ansible/plugins/cliconf/iosxr.py
+              - ^lib/ansible/plugins/connection/netconf.py
               - ^lib/ansible/plugins/connection/network_cli.py
               - ^test/integration/targets/iosxr_.*
+              - ^test/integration/targets/netconf_.*
         - ansible-test-network-integration-iosxr-python35:
             voting: false
             branches:
               - devel
             files:
               - ^lib/ansible/modules/network/iosxr/.*
+              - ^lib/ansible/modules/network/netconf/.*
               - ^lib/ansible/module_utils/network/common/.*
               - ^lib/ansible/module_utils/network/iosxr/.*
+              - ^lib/ansible/module_utils/network/netconf/.*
               - ^lib/ansible/plugins/cliconf/iosxr.py
+              - ^lib/ansible/plugins/connection/netconf.py
               - ^lib/ansible/plugins/connection/network_cli.py
               - ^test/integration/targets/iosxr_.*
+              - ^test/integration/targets/netconf_.*
         - ansible-test-network-integration-iosxr-python36:
             voting: false
             branches:
               - devel
             files:
               - ^lib/ansible/modules/network/iosxr/.*
+              - ^lib/ansible/modules/network/netconf/.*
               - ^lib/ansible/module_utils/network/common/.*
               - ^lib/ansible/module_utils/network/iosxr/.*
+              - ^lib/ansible/module_utils/network/netconf/.*
               - ^lib/ansible/plugins/cliconf/iosxr.py
+              - ^lib/ansible/plugins/connection/netconf.py
               - ^lib/ansible/plugins/connection/network_cli.py
               - ^test/integration/targets/iosxr_.*
+              - ^test/integration/targets/netconf_.*
         - ansible-test-network-integration-iosxr-python37:
             voting: false
             branches:
               - devel
             files:
               - ^lib/ansible/modules/network/iosxr/.*
+              - ^lib/ansible/modules/network/netconf/.*
               - ^lib/ansible/module_utils/network/common/.*
               - ^lib/ansible/module_utils/network/iosxr/.*
+              - ^lib/ansible/module_utils/network/netconf/.*
               - ^lib/ansible/plugins/cliconf/iosxr.py
+              - ^lib/ansible/plugins/connection/netconf.py
               - ^lib/ansible/plugins/connection/network_cli.py
               - ^test/integration/targets/iosxr_.*
+              - ^test/integration/targets/netconf_.*
         - ansible-test-network-integration-junos-python27:
             branches:
               - devel


### PR DESCRIPTION
This is because we test netconf also with iosxr.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>