### PR TITLE
Add httpapi file match for network-integration eos

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -156,8 +156,11 @@
               - ^lib/ansible/module_utils/network/eos/.*
               - ^lib/ansible/plugins/action/eos.py
               - ^lib/ansible/plugins/cliconf/eos.py
+              - ^lib/ansible/plugins/connection/httpapi.py
               - ^lib/ansible/plugins/connection/local.py
               - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/httpapi/__init__.py
+              - ^lib/ansible/plugins/httpapi/eos.py
               - ^test/integration/targets/eos_.*
               - ^test/integration/targets/prepare_eos_tests/.*
         - ansible-test-network-integration-eos-python35:
@@ -170,8 +173,11 @@
               - ^lib/ansible/module_utils/network/eos/.*
               - ^lib/ansible/plugins/action/eos.py
               - ^lib/ansible/plugins/cliconf/eos.py
+              - ^lib/ansible/plugins/connection/httpapi.py
               - ^lib/ansible/plugins/connection/local.py
               - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/httpapi/__init__.py
+              - ^lib/ansible/plugins/httpapi/eos.py
               - ^test/integration/targets/eos_.*
               - ^test/integration/targets/prepare_eos_tests/.*
         - ansible-test-network-integration-eos-python36:
@@ -184,8 +190,11 @@
               - ^lib/ansible/module_utils/network/eos/.*
               - ^lib/ansible/plugins/action/eos.py
               - ^lib/ansible/plugins/cliconf/eos.py
+              - ^lib/ansible/plugins/connection/httpapi.py
               - ^lib/ansible/plugins/connection/local.py
               - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/httpapi/__init__.py
+              - ^lib/ansible/plugins/httpapi/eos.py
               - ^test/integration/targets/eos_.*
               - ^test/integration/targets/prepare_eos_tests/.*
         - ansible-test-network-integration-eos-python37:
@@ -198,8 +207,11 @@
               - ^lib/ansible/module_utils/network/eos/.*
               - ^lib/ansible/plugins/action/eos.py
               - ^lib/ansible/plugins/cliconf/eos.py
+              - ^lib/ansible/plugins/connection/httpapi.py
               - ^lib/ansible/plugins/connection/local.py
               - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/httpapi/__init__.py
+              - ^lib/ansible/plugins/httpapi/eos.py
               - ^test/integration/targets/eos_.*
               - ^test/integration/targets/prepare_eos_tests/.*
         - ansible-test-network-integration-ios-python27:
@@ -501,8 +513,11 @@
               - ^lib/ansible/module_utils/network/eos/.*
               - ^lib/ansible/plugins/action/eos.py
               - ^lib/ansible/plugins/cliconf/eos.py
+              - ^lib/ansible/plugins/connection/httpapi.py
               - ^lib/ansible/plugins/connection/local.py
               - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/httpapi/__init__.py
+              - ^lib/ansible/plugins/httpapi/eos.py
               - ^test/integration/targets/eos_.*
               - ^test/integration/targets/prepare_eos_tests/.*
         - ansible-test-network-integration-eos-python35:
@@ -514,8 +529,11 @@
               - ^lib/ansible/module_utils/network/eos/.*
               - ^lib/ansible/plugins/action/eos.py
               - ^lib/ansible/plugins/cliconf/eos.py
+              - ^lib/ansible/plugins/connection/httpapi.py
               - ^lib/ansible/plugins/connection/local.py
               - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/httpapi/__init__.py
+              - ^lib/ansible/plugins/httpapi/eos.py
               - ^test/integration/targets/eos_.*
               - ^test/integration/targets/prepare_eos_tests/.*
         - ansible-test-network-integration-eos-python36:
@@ -527,8 +545,11 @@
               - ^lib/ansible/module_utils/network/eos/.*
               - ^lib/ansible/plugins/action/eos.py
               - ^lib/ansible/plugins/cliconf/eos.py
+              - ^lib/ansible/plugins/connection/httpapi.py
               - ^lib/ansible/plugins/connection/local.py
               - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/httpapi/__init__.py
+              - ^lib/ansible/plugins/httpapi/eos.py
               - ^test/integration/targets/eos_.*
               - ^test/integration/targets/prepare_eos_tests/.*
         - ansible-test-network-integration-eos-python37:
@@ -540,8 +561,11 @@
               - ^lib/ansible/module_utils/network/eos/.*
               - ^lib/ansible/plugins/action/eos.py
               - ^lib/ansible/plugins/cliconf/eos.py
+              - ^lib/ansible/plugins/connection/httpapi.py
               - ^lib/ansible/plugins/connection/local.py
               - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/httpapi/__init__.py
+              - ^lib/ansible/plugins/httpapi/eos.py
               - ^test/integration/targets/eos_.*
               - ^test/integration/targets/prepare_eos_tests/.*
         - ansible-test-network-integration-ios-python27:


### PR DESCRIPTION
This increases our test coverage for httpapi.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>