### PR TITLE
Default to ansible 2.8 for zuul jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -3,6 +3,7 @@
     name: base
     parent: base-minimal
     abstract: true
+    ansible-version: 2.8
     description: |
       The base job for the Ansible installation of Zuul.
     pre-run: playbooks/base/pre.yaml


### PR DESCRIPTION
Now that we are using zuul 3.9.0, we can switch out jobs to ansible 2.8
by default. This will allow us to report issues upstream to zuul
community.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/155
Signed-off-by: Paul Belanger <pabelanger@redhat.com>