### PR TITLE
Increase verbosity for ansible-test by default

### DIFF
--- a/playbooks/ansible-test-network-integration-base/run.yaml
+++ b/playbooks/ansible-test-network-integration-base/run.yaml
@@ -51,4 +51,4 @@
       args:
         chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
         executable: /bin/bash
-      shell: "source ~/venv/bin/activate; ./test/runner/ansible-test network-integration {{ _test_options }} --python {{ ansible_test_python }} --inventory /home/zuul/inventory {{ _target }} -vv"
+      shell: "source ~/venv/bin/activate; ./test/runner/ansible-test network-integration {{ _test_options }} --python {{ ansible_test_python }} --inventory /home/zuul/inventory -vvv {{ _target }}"


### PR DESCRIPTION
It is helpful to have more debug info, especially when trying to debug
random failures.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>