### PR TITLE
Fix ansible-test location

### DIFF
--- a/playbooks/ansible-test-network-integration-base/run.yaml
+++ b/playbooks/ansible-test-network-integration-base/run.yaml
@@ -65,4 +65,4 @@
       args:
         chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
         executable: /bin/bash
-      shell: "source ~/venv/bin/activate; ./test/runner/ansible-test network-integration {{ _test_options }} --python {{ ansible_test_python }} --inventory /home/zuul/inventory -vvvv {{ _target }}"
+      shell: "source ~/venv/bin/activate; ./bin/ansible-test network-integration {{ _test_options }} --python {{ ansible_test_python }} --inventory /home/zuul/inventory -vvvv {{ _target }}"


### PR DESCRIPTION
As of lately, there has been some commits moving ansible-test location
on ansible/ansible [1][2]. This commit fixes it in zuul so it doesn't
fail when running the integration tests.

[1] https://github.com/ansible/ansible/pull/60114
[2] https://github.com/ansible/ansible/pull/60110