### PR TITLE
Add network jobs to experimental pipeline

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -26,6 +26,26 @@
 
 - project-template:
     name: ansible-test-network-integration
+    experimental:
+      jobs:
+        - ansible-test-network-integration-eos-python37:
+            branches:
+              - devel
+        - ansible-test-network-integration-ios-python37:
+            branches:
+              - devel
+        - ansible-test-network-integration-iosxr-python37:
+            branches:
+              - devel
+        - ansible-test-network-integration-junos-python37:
+            branches:
+              - devel
+        - ansible-test-network-integration-openvswitch-python37:
+            branches:
+              - devel
+        - ansible-test-network-integration-vyos-python37:
+            branches:
+              - devel
     periodic:
       jobs:
         - ansible-test-network-integration-eos-python27:


### PR DESCRIPTION
Add our network integration tests to the experimental pipeline, for
adhoc testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>