### PR TITLE
Install ansible into venv for ansible-test

### DIFF
--- a/playbooks/ansible-test-network-integration-base/pre.yaml
+++ b/playbooks/ansible-test-network-integration-base/pre.yaml
@@ -34,6 +34,11 @@
     - name: Install ara into virtuelenv
       shell: ~/venv/bin/pip install "ara<1.0.0"
 
+    - name: Install ansible into virtuelenv
+      args:
+        executable: /bin/bash
+      shell: "~/venv/bin/pip install {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
+
     - name: Enable ARA callback plugin
       ini_file:
         path: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/test/integration/network-integration.cfg"


### PR DESCRIPTION
This stops depending on ansible-test to manage this, needed for when we
move to collections testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>