### PR TITLE
Create integrated queue for ansible-network collections

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -41,6 +41,7 @@
             vars:
               ansible_test_collections: true
     gate:
+      queue: integrated
       jobs:
         - ansible-test-network-integration-eos-python27:
             vars:
@@ -72,6 +73,7 @@
             vars:
               ansible_test_collections: true
     gate:
+      queue: integrated
       jobs:
         - ansible-test-network-integration-ios-python27:
             vars:
@@ -103,6 +105,7 @@
             vars:
               ansible_test_collections: true
     gate:
+      queue: integrated
       jobs:
         - ansible-test-network-integration-iosxr-python27:
             vars:
@@ -134,6 +137,7 @@
             vars:
               ansible_test_collections: true
     gate:
+      queue: integrated
       jobs:
         - ansible-test-network-integration-junos-python27:
             vars:
@@ -165,6 +169,7 @@
             vars:
               ansible_test_collections: true
     gate:
+      queue: integrated
       jobs:
         - ansible-test-network-integration-vyos-python27:
             vars:


### PR DESCRIPTION
This allows us to gate all commits for our network collections together,
to help avoid one project breaking another.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>