### PR TITLE
Create ansible-tox-docs job

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -17,6 +17,11 @@
       nodes: []
 
 - job:
+    name: ansible-tox-docs
+    parent: tox-docs
+    nodeset: centos-8-1vcpu
+
+- job:
     name: ansible-tox-linters
     parent: tox-linters
     nodeset: centos-8-1vcpu


### PR DESCRIPTION
This will be used by various projects to build documentation using tox
-edocs entry point.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>