### PR TITLE
Create ansible-test-network-integration-netconf-junos

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -290,6 +290,34 @@
       ansible_test_python: 3.7
 
 - job:
+    name: ansible-test-network-integration-junos-netconf-python27
+    parent: ansible-test-network-integration-junos-python27
+    vars:
+      ansible_test_python: 2.7
+      ansible_test_network_integration: netconf
+
+- job:
+    name: ansible-test-network-integration-junos-netconf-python35
+    parent: ansible-test-network-integration-junos-python35
+    vars:
+      ansible_test_python: 3.5
+      ansible_test_network_integration: netconf
+
+- job:
+    name: ansible-test-network-integration-junos-netconf-python36
+    parent: ansible-test-network-integration-junos-python36
+    vars:
+      ansible_test_python: 3.6
+      ansible_test_network_integration: netconf
+
+- job:
+    name: ansible-test-network-integration-junos-netconf-python37
+    parent: ansible-test-network-integration-junos-python37
+    vars:
+      ansible_test_python: 3.7
+      ansible_test_network_integration: netconf
+
+- job:
     name: ansible-test-network-integration-openvswitch
     abstract: true
     parent: ansible-network-openvswitch-appliance

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -117,6 +117,29 @@
       queue: integrated
 
 - project-template:
+    name: ansible-collections-juniper-junos-netconf
+    check:
+      jobs:
+        - ansible-test-network-integration-junos-netconf-python27:
+            voting: false
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-junos-netconf-python35:
+            voting: false
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-junos-netconf-python36:
+            voting: false
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-junos-netconf-python37:
+            voting: false
+            vars:
+              ansible_test_collections: true
+    gate:
+      queue: integrated
+
+- project-template:
     name: ansible-collections-vyos-vyos
     check:
       jobs:


### PR DESCRIPTION
We'll need a new job, specific for network.netconf. This is because we
are moving the jobs out from each provider, into network.netconf.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>