### PR TITLE
Use ansible_network_os for ansible-test base jobs

### DIFF
--- a/playbooks/ansible-test-network-integration-base/pre.yaml
+++ b/playbooks/ansible-test-network-integration-base/pre.yaml
@@ -5,7 +5,7 @@
       include_role:
         name: tox
       vars:
-        tox_extra_args: "-vv -- ansible-playbook -v playbooks/ansible-test-network-integration-base/files/bootstrap-{{ ansible_test_network_integration }}.yaml"
+        tox_extra_args: "-vv -- ansible-playbook -v playbooks/ansible-test-network-integration-base/files/bootstrap-{{ hostvars[groups['appliance'][0]]['ansible_network_os'] }}.yaml"
         tox_install_siblings: false
         zuul_work_dir: "{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"
 
@@ -15,7 +15,7 @@
 
     - name: Create inventory file
       template:
-        src: "inventory-{{ ansible_test_network_integration }}.j2"
+        src: "inventory-{{ hostvars[groups['appliance'][0]]['ansible_network_os'] }}.j2"
         dest: ~/inventory
         mode: 0644
 


### PR DESCRIPTION
This will help when we refactor for junos-netconf specific testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>