### PR TITLE
Increase vyos platform timeout

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -369,7 +369,7 @@
     required-projects:
       - name: github.com/ansible/ansible
       - name: github.com/ansible-network/ansible_collections.network.cli
-    timeout: 7200
+    timeout: 9000
     vars:
       ansible_test_network_integration: vyos
 


### PR DESCRIPTION
In order to test timeouts that had happened for vyos platform, this
commit increases vyos timeouts to 9000. Further issues would be fixed by
parallelizing rather than getting more increases on the timeout itself.