### PR TITLE
Add support for ansible-collections-cisco-iosxr-netconf

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -249,6 +249,30 @@
       ansible_test_python: 3.7
 
 - job:
+    name: ansible-test-network-integration-iosxr-netconf-python27
+    parent: ansible-test-network-integration-iosxr-python27
+    vars:
+      ansible_test_network_integration: netconf
+
+- job:
+    name: ansible-test-network-integration-iosxr-netconf-python35
+    parent: ansible-test-network-integration-iosxr-python35
+    vars:
+      ansible_test_network_integration: netconf
+
+- job:
+    name: ansible-test-network-integration-iosxr-netconf-python36
+    parent: ansible-test-network-integration-iosxr-python36
+    vars:
+      ansible_test_network_integration: netconf
+
+- job:
+    name: ansible-test-network-integration-iosxr-netconf-python37
+    parent: ansible-test-network-integration-iosxr-python37
+    vars:
+      ansible_test_network_integration: netconf
+
+- job:
     name: ansible-test-network-integration-junos
     parent: ansible-network-junos-appliance
     pre-run: playbooks/ansible-test-network-integration-base/pre.yaml
@@ -293,28 +317,24 @@
     name: ansible-test-network-integration-junos-netconf-python27
     parent: ansible-test-network-integration-junos-python27
     vars:
-      ansible_test_python: 2.7
       ansible_test_network_integration: netconf
 
 - job:
     name: ansible-test-network-integration-junos-netconf-python35
     parent: ansible-test-network-integration-junos-python35
     vars:
-      ansible_test_python: 3.5
       ansible_test_network_integration: netconf
 
 - job:
     name: ansible-test-network-integration-junos-netconf-python36
     parent: ansible-test-network-integration-junos-python36
     vars:
-      ansible_test_python: 3.6
       ansible_test_network_integration: netconf
 
 - job:
     name: ansible-test-network-integration-junos-netconf-python37
     parent: ansible-test-network-integration-junos-python37
     vars:
-      ansible_test_python: 3.7
       ansible_test_network_integration: netconf
 
 - job:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -94,6 +94,29 @@
       queue: integrated
 
 - project-template:
+    name: ansible-collections-cisco-iosxr-netconf
+    check:
+      jobs:
+        - ansible-test-network-integration-iosxr-netconf-python27:
+            voting: false
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-iosxr-netconf-python35:
+            voting: false
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-iosxr-netconf-python36:
+            voting: false
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-iosxr-netconf-python37:
+            voting: false
+            vars:
+              ansible_test_collections: true
+    gate:
+      queue: integrated
+
+- project-template:
     name: ansible-collections-juniper-junos
     check:
       jobs:


### PR DESCRIPTION
We'll be using this with our network.netconf collection.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>