### PR TITLE
Mark ansible-collections-juniper-junos-netconf voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -121,23 +121,32 @@
     check:
       jobs:
         - ansible-test-network-integration-junos-python27:
-            voting: false
             vars:
               ansible_test_collections: true
         - ansible-test-network-integration-junos-python35:
-            voting: false
             vars:
               ansible_test_collections: true
         - ansible-test-network-integration-junos-python36:
-            voting: false
             vars:
               ansible_test_collections: true
         - ansible-test-network-integration-junos-python37:
-            voting: false
             vars:
               ansible_test_collections: true
     gate:
       queue: integrated
+      jobs:
+        - ansible-test-network-integration-junos-python27:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-junos-python35:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-junos-python36:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-junos-python37:
+            vars:
+              ansible_test_collections: true
 
 - project-template:
     name: ansible-collections-juniper-junos-netconf


### PR DESCRIPTION
Our juniper.junos collection is passing integration tests, lets start
gating on them.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>