### PR TITLE
Don't gate on iosxr jobs

### DIFF
--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -6,7 +6,8 @@
       jobs:
         - ansible-network-eos-appliance
         - ansible-network-ios-appliance
-        - ansible-network-iosxr-appliance
+        - ansible-network-iosxr-appliance:
+            voting: false
         - ansible-network-junos-appliance
         - ansible-network-openvswitch-appliance
         - ansible-network-vyos-appliance
@@ -14,7 +15,6 @@
       jobs:
         - ansible-network-eos-appliance
         - ansible-network-ios-appliance
-        - ansible-network-iosxr-appliance
         - ansible-network-junos-appliance
         - ansible-network-openvswitch-appliance
         - ansible-network-vyos-appliance


### PR DESCRIPTION
Until we can run iosxr in more then 1 region, we cannot gate on it. This
is a safety precaution to avoid wedging the gate pipeline when this
region is down.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>