### PR TITLE
Add all network integration jobs to experimental

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -216,19 +216,73 @@
     name: ansible-test-network-integration
     experimental:
       jobs:
+        - ansible-test-network-integration-eos-python27:
+            branches:
+              - devel
+        - ansible-test-network-integration-eos-python35:
+            branches:
+              - devel
+        - ansible-test-network-integration-eos-python36:
+            branches:
+              - devel
         - ansible-test-network-integration-eos-python37:
+            branches:
+              - devel
+        - ansible-test-network-integration-ios-python27:
+            branches:
+              - devel
+        - ansible-test-network-integration-ios-python35:
+            branches:
+              - devel
+        - ansible-test-network-integration-ios-python36:
             branches:
               - devel
         - ansible-test-network-integration-ios-python37:
             branches:
               - devel
+        - ansible-test-network-integration-iosxr-python27:
+            branches:
+              - devel
+        - ansible-test-network-integration-iosxr-python35:
+            branches:
+              - devel
+        - ansible-test-network-integration-iosxr-python36:
+            branches:
+              - devel
         - ansible-test-network-integration-iosxr-python37:
+            branches:
+              - devel
+        - ansible-test-network-integration-junos-python27:
+            branches:
+              - devel
+        - ansible-test-network-integration-junos-python35:
+            branches:
+              - devel
+        - ansible-test-network-integration-junos-python36:
             branches:
               - devel
         - ansible-test-network-integration-junos-python37:
             branches:
               - devel
+        - ansible-test-network-integration-openvswitch-python27:
+            branches:
+              - devel
+        - ansible-test-network-integration-openvswitch-python35:
+            branches:
+              - devel
+        - ansible-test-network-integration-openvswitch-python36:
+            branches:
+              - devel
         - ansible-test-network-integration-openvswitch-python37:
+            branches:
+              - devel
+        - ansible-test-network-integration-vyos-python27:
+            branches:
+              - devel
+        - ansible-test-network-integration-vyos-python35:
+            branches:
+              - devel
+        - ansible-test-network-integration-vyos-python36:
             branches:
               - devel
         - ansible-test-network-integration-vyos-python37:


### PR DESCRIPTION
This allows us to run adhoc jobs for PRs, when file matchers don't
match.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>