### PR TITLE
Make iosxr jobs in thirdparty-check non voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -626,6 +626,7 @@
               - ^test/integration/targets/iosxr_.*
               - ^test/integration/targets/netconf_.*
               - ^test/integration/targets/prepare_iosxr_tests/.*
+            voting: false
         - ansible-test-network-integration-iosxr-python35:
             branches:
               - devel
@@ -648,6 +649,7 @@
               - ^test/integration/targets/iosxr_.*
               - ^test/integration/targets/netconf_.*
               - ^test/integration/targets/prepare_iosxr_tests/.*
+            voting: false
         - ansible-test-network-integration-iosxr-python36:
             branches:
               - devel
@@ -670,6 +672,7 @@
               - ^test/integration/targets/iosxr_.*
               - ^test/integration/targets/netconf_.*
               - ^test/integration/targets/prepare_iosxr_tests/.*
+            voting: false
         - ansible-test-network-integration-iosxr-python37:
             branches:
               - devel
@@ -692,6 +695,7 @@
               - ^test/integration/targets/iosxr_.*
               - ^test/integration/targets/netconf_.*
               - ^test/integration/targets/prepare_iosxr_tests/.*
+            voting: false
         - ansible-test-network-integration-junos-python27:
             branches:
               - devel


### PR DESCRIPTION
This is due to the SSH daemon crashing on the remote side, which right
now we don't have control over.  The next steps are to use a newer
version of the appliance, and maybe increase the memory on the appliance
to 8GB.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>