### PR TITLE
Remove --user flag from pip for iosxr bootstrap

### DIFF
--- a/playbooks/ansible-network-iosxr-appliance/files/bootstrap.yaml
+++ b/playbooks/ansible-network-iosxr-appliance/files/bootstrap.yaml
@@ -8,7 +8,6 @@
         name:
           - paramiko
           - pexpect
-        extra_args: --user
 
 - hosts: controller
   gather_facts: false

--- a/playbooks/ansible-test-network-integration-base/files/bootstrap-eos.yaml
+++ b/playbooks/ansible-test-network-integration-base/files/bootstrap-eos.yaml
@@ -18,7 +18,6 @@
     - name: Install pexpect requirement
       pip:
         name: pexpect
-        extra_args: --user
 
 - hosts: controller
   gather_facts: false


### PR DESCRIPTION
This shouldn't be needed, as we are already inside a virtualenv.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>