### PR TITLE
Only keyscan for netconf on junos

### DIFF
--- a/playbooks/ansible-test-network-integration-base/pre.yaml
+++ b/playbooks/ansible-test-network-integration-base/pre.yaml
@@ -21,6 +21,7 @@
 
     - name: Ensure remote NETCONF SSH host keys are known
       shell: "ssh-keyscan -t rsa -p 830 {{ hostvars[item].ansible_host }} >> ~/.ssh/known_hosts"
+      when: hostvars[item].ansible_network_os in ['junos']
       with_inventory_hostnames: appliance
 
     - name: Create inventory file


### PR DESCRIPTION
It seems there is a bug or something in ansible, that allows ssh-keyscan
to fail but our ansible shell task to pass. However, under python3 this
actually breaks our jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>