### PR TITLE
Add python38 vyos network integration job

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -2,6 +2,9 @@
 # see http://docs.openstack.org/infra/bindep/ for additional information.
 
 gcc-c++ [test platform:rpm]
+libffi-dev [test platform:ubuntu-bionic]
+libxml2-dev [test platform:ubuntu-bionic]
+libxslt1-dev [test platform:ubuntu-bionic]
 python2.7-dev [test platform:dpkg]
 python3-devel [test !platform:centos-7 platform:rpm]
 python3-dev [test platform:dpkg]

--- a/playbooks/ansible-test-network-integration-base/pre.yaml
+++ b/playbooks/ansible-test-network-integration-base/pre.yaml
@@ -1,6 +1,25 @@
 ---
 - hosts: controller
   tasks:
+    - name: Add ppa:deadsnakes/ppa for python38 support
+      block:
+        - name: Add deadsnakes PPA
+          become: true
+          apt_repository:
+            repo: ppa:deadsnakes/ppa
+            state: present
+
+        - name: Ensure python3.8 is installed
+          become: true
+          package:
+            name:
+              - python3.8-dev
+              - python3.8-distutils
+            state: installed
+      when:
+        - ansible_os_family == "Debian"
+        - ansible_test_python is version('3.8', '==')
+
     - name: Select proper ansible_network_os
       set_fact:
         _network_os: "{{ hostvars[groups['appliance'][0]]['ansible_network_os'] }}"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -444,3 +444,10 @@
     nodeset: vyos-1.1.8-python37
     vars:
       ansible_test_python: 3.7
+
+- job:
+    name: ansible-test-network-integration-vyos-python38
+    parent: ansible-test-network-integration-vyos
+    nodeset: vyos-1.1.8-python38
+    vars:
+      ansible_test_python: 3.8

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -383,3 +383,18 @@
       - name: controller
         nodes:
           - fedora-29
+
+- nodeset:
+    name: vyos-1.1.8-python38
+    nodes:
+      - name: ubuntu-bionic
+        label: ubuntu-bionic-1vcpu
+      - name: vyos-1.1.8
+        label: vyos-1.1.8-1vcpu
+    groups:
+      - name: appliance
+        nodes:
+          - vyos-1.1.8
+      - name: controller
+        nodes:
+          - ubuntu-bionic

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -214,6 +214,11 @@
         - ansible-test-network-integration-vyos-python37:
             vars:
               ansible_test_collections: true
+        - ansible-test-network-integration-vyos-python38:
+            branches:
+              - devel
+            vars:
+              ansible_test_collections: true
     gate:
       queue: integrated
       jobs:
@@ -229,6 +234,12 @@
         - ansible-test-network-integration-vyos-python37:
             vars:
               ansible_test_collections: true
+        - ansible-test-network-integration-vyos-python38:
+            branches:
+              - devel
+            vars:
+              ansible_test_collections: true
+
 
 - project-template:
     name: ansible-test-network-integration
@@ -304,6 +315,9 @@
             branches:
               - devel
         - ansible-test-network-integration-vyos-python37:
+            branches:
+              - devel
+        - ansible-test-network-integration-vyos-python38:
             branches:
               - devel
     periodic:
@@ -428,6 +442,9 @@
               - devel
               - stable-2.9
               - stable-2.8
+        - ansible-test-network-integration-vyos-python38:
+            branches:
+              - devel
     third-party-check:
       jobs:
         - ansible-test-network-integration-eos-python27:
@@ -873,6 +890,22 @@
               - devel
               - stable-2.9
               - stable-2.8
+            files:
+              - ^lib/ansible/modules/network/cli/.*
+              - ^lib/ansible/modules/network/vyos/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/vyos/.*
+              - ^lib/ansible/plugins/action/vyos.py
+              - ^lib/ansible/plugins/cliconf/vyos.py
+              - ^lib/ansible/plugins/connection/local.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/terminal/__init__.py
+              - ^lib/ansible/plugins/terminal/vyos.py
+              - ^test/integration/targets/vyos_.*
+              - ^test/integration/targets/prepare_vyos_tests/.*
+        - ansible-test-network-integration-vyos-python38:
+            branches:
+              - devel
             files:
               - ^lib/ansible/modules/network/cli/.*
               - ^lib/ansible/modules/network/vyos/.*


### PR DESCRIPTION
Now that we have an image online that support python38, start testing
with it for devel only.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>