### PR TITLE
Revert "Switch fedora mirrors, as it looks to be done"

### DIFF
--- a/roles/configure-mirrors-fork/vars/Fedora.yaml
+++ b/roles/configure-mirrors-fork/vars/Fedora.yaml
@@ -1,2 +1,2 @@
 ---
-package_mirror: http://pubmirror2.math.uh.edu/fedora-buffet/fedora/linux
+package_mirror: http://pubmirror1.math.uh.edu/fedora-buffet/fedora/linux


### PR DESCRIPTION
Revert back to original mirror, as we seem to be having some issues with
'new' one.

This reverts commit 2ecc486d50022f9274d63a966465fb8f064f9964.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>