### PR TITLE
Fix ansible 2.9 error for OVS

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,3 +1,4 @@
+---
 extends: default
 
 ignore: |

--- a/playbooks/ansible-network-openvswitch-appliance/files/bootstrap.yaml
+++ b/playbooks/ansible-network-openvswitch-appliance/files/bootstrap.yaml
@@ -5,4 +5,4 @@
       become: true
       package:
         name: openvswitch-switch
-        state: installed
+        state: present


### PR DESCRIPTION
Installed is no longer a valid option :(

Signed-off-by: Paul Belanger <pabelanger@redhat.com>