### PR TITLE
Switch ansible-tox-py36 to centos-8

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -29,7 +29,7 @@
 - job:
     name: ansible-tox-py36
     parent: tox-py36
-    nodeset: fedora-latest-1vcpu
+    nodeset: centos-8-1vcpu
 
 - job:
     name: ansible-tox-py37


### PR DESCRIPTION
Migrate away from fedora, in favor of centos-8.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>