### PR TITLE
Refactor ansible_galaxy_collection_path path

### DIFF
--- a/roles/upload-ansible-collection-fork/defaults/main.yaml
+++ b/roles/upload-ansible-collection-fork/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-ansible_galaxy_collection_path: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}/*.tar.gz"
+ansible_galaxy_collection_path: "{{ zuul.executor.work_root }}/artifacts/*.tar.gz"
 ansible_galaxy_executable: ansible-galaxy


### PR DESCRIPTION
We should expect this to be run from executor by default.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>