### PR TITLE
Add publish-to-galaxy-master-only job

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1118,6 +1118,15 @@
         - noop
 
 - project-template:
+    name: publish-to-galaxy-master-only
+    description: |
+      Publish an Ansible collection to Ansible Galaxy
+    post:
+      jobs:
+        - release-ansible-collection-galaxy:
+            branches: master
+
+- project-template:
     name: publish-to-galaxy
     description: |
       Publish an Ansible collection to Ansible Galaxy


### PR DESCRIPTION
Until we figure out stable branches, create a jobs to only publish
master branches.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>