### PR TITLE
Add pre-release / release jobs for galaxy publishing

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1125,6 +1125,14 @@
       jobs:
         - release-ansible-collection-galaxy:
             branches: master
+    pre-release:
+      jobs:
+        - release-ansible-collection-galaxy:
+            branches: master
+    release:
+      jobs:
+        - release-ansible-collection-galaxy:
+            branches: master
 
 - project-template:
     name: publish-to-galaxy
@@ -1133,12 +1141,24 @@
     post:
       jobs:
         - release-ansible-collection-galaxy
+    pre-release:
+      jobs:
+        - release-ansible-collection-galaxy
+    release:
+      jobs:
+        - release-ansible-collection-galaxy
 
 - project-template:
     name: publish-to-galaxy-dev
     description: |
       Publish an Ansible collection to Ansible Galaxy Dev
     post:
+      jobs:
+        - release-ansible-collection-galaxy-dev
+    post-release:
+      jobs:
+        - release-ansible-collection-galaxy-dev
+    release:
       jobs:
         - release-ansible-collection-galaxy-dev
 


### PR DESCRIPTION
Now that we have confirmed tagging works, we can enable jobs for
pre-release / release piplines.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>