### PR TITLE
Use collection artifacts for ansible-test base job

### DIFF
--- a/playbooks/ansible-test-network-integration-base/run.yaml
+++ b/playbooks/ansible-test-network-integration-base/run.yaml
@@ -25,13 +25,13 @@
 
     - name: Setup testing for collections
       block:
-        - name: Setup tox role
+        - name: Setup download-artifact-fork role
           include_role:
-            name: tox
+            name: download-artifact-fork
           vars:
-            tox_extra_args: -vv --notest
-            tox_install_siblings: false
-            zuul_work_dir: "{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"
+            download_artifact_directory: ~/downloads
+            download_artifact_type:
+              - ansible_collection
 
         - name: Install jq
           become: true
@@ -42,28 +42,13 @@
         - name: Install ara into virtuelenv
           shell: ~/venv/bin/pip install yq
 
-        - name: network-integration.cfg
-          shell: "cp {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/test/integration/network-integration.cfg {{ ansible_user_dir }}/{{ zuul.project.src_dir }}/tests/integration/network-integration.cfg"
-
-        - name: Generate version number for ansible collection
-          args:
-            chdir: "{{ ansible_user_dir }}/{{ item.src_dir }}"
-          shell: "if test -f 'galaxy.yml'; then {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv/bin/generate-ansible-collection; fi"
-          with_items: "{{ zuul.projects.values() | list }}"
-
-        - name: Build require-project collection using ansible-galaxy
-          args:
-            chdir: "{{ ansible_user_dir }}/{{ item.src_dir }}"
-            executable: /bin/bash
-          shell: "if test -f 'galaxy.yml'; then source ~/venv/bin/activate; {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/bin/ansible-galaxy collection build; fi"
-          with_items: "{{ zuul.projects.values() | list }}"
-
         - name: Install require-project collection using ansible-galaxy
           args:
-            chdir: "{{ ansible_user_dir }}/{{ item.src_dir }}"
+            chdir: "{{ ansible_user_dir }}/downloads"
             executable: /bin/bash
-          shell: "if test -f 'galaxy.yml'; then source ~/venv/bin/activate; {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/bin/ansible-galaxy collection install -p ~/.ansible/collection *.tar.gz; fi"
-          with_items: "{{ zuul.projects.values() | list }}"
+          shell: "source ~/venv/bin/activate; {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/bin/ansible-galaxy collection install -p ~/.ansible/collection {{ item.url | basename }}"
+          with_items: "{{ zuul.artifacts }}"
+          when: "'metadata' in item and 'type' in item.metadata and (item.metadata.type == 'ansible_collection')"
 
         - name: Get collection namespace
           args:
@@ -86,6 +71,9 @@
         - name: Setup location of project
           set_fact:
             _test_location: "~/.ansible/collection/ansible_collections/{{ _collection_namespace.stdout }}/{{ _collection_name.stdout }}"
+
+        - name: network-integration.cfg
+          shell: "cp {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/test/integration/network-integration.cfg {{ _test_location }}/tests/integration/network-integration.cfg"
 
       when: ansible_test_collections | default(False)
 

--- a/roles/download-artifact-fork/README.rst
+++ b/roles/download-artifact-fork/README.rst
@@ -1,0 +1,34 @@
+Download artifacts from a completed build of a Zuul job
+
+Given a change, downloads artifacts from a previous build (by default
+of the current change) into the work directory.  This will download as
+many artifacts as match the selection criteria.
+
+**Role Variables**
+
+.. zuul:rolevar:: download_artifact_api
+
+   The Zuul API endpoint to use.  Example: ``https://zuul.example.org/api/tenant/{{ zuul.tenant }}``
+
+.. zuul:rolevar:: download_artifact_pipeline
+
+   The pipeline in which the previous build ran.
+
+.. zuul:rolevar:: download_artifact_job
+
+   The job of the previous build.
+
+.. zuul:rolevar:: download_artifact_type
+
+   The artifact type.  This is the value of the ``type`` field in the
+   artifact metadata. This can be a string or a list of strings.
+
+.. zuul:rolevar:: download_artifact_query
+   :default: change={{ zuul.change }}&patchset={{ zuul.patchset }}&pipeline={{ download_artifact_pipeline }}&job_name={{ download_artifact_job }}
+
+   The query to use to find the build.  Normally the default is used.
+
+.. zuul:rolevar:: download_artifact_directory
+   :default: {{ zuul.executor.work_root }}
+
+   The directory in which to place the downloaded artifacts.

--- a/roles/download-artifact-fork/defaults/main.yaml
+++ b/roles/download-artifact-fork/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+download_artifact_query: "change={{ zuul.change }}&patchset={{ zuul.patchset }}&pipeline={{ download_artifact_pipeline }}&job_name={{ download_artifact_job }}"
+download_artifact_directory: "{{ zuul.executor.work_root }}"

--- a/roles/download-artifact-fork/tasks/main.yaml
+++ b/roles/download-artifact-fork/tasks/main.yaml
@@ -1,0 +1,33 @@
+---
+- name: Query inventory for artifact information
+  block:
+    - name: Parse inventory response
+      set_fact:
+        _artifacts: "{{ zuul.artifacts }}"
+  when: zuul.artifacts is defined
+
+- name: Query Zuul API for artifact information
+  block:
+    - name: Fetch info from Zuul API
+      uri:
+        url: "{{ download_artifact_api }}/builds?{{ download_artifact_query }}"
+      register: build
+
+    - name: Parse build response
+      set_fact:
+        _artifacts: "{{ build.json[0].artifacts }}"
+  when: download_artifact_api is defined
+
+- name: Ensure artifacts directory exists
+  file:
+    path: "{{ download_artifact_directory }}"
+    state: directory
+
+- name: Download archive by type
+  uri:
+    url: "{{ artifact.url }}"
+    dest: "{{ download_artifact_directory }}"
+  loop: "{{ _artifacts }}"
+  loop_control:
+    loop_var: artifact
+  when: "'metadata' in artifact and 'type' in artifact.metadata and (artifact.metadata.type == download_artifact_type or ((download_artifact_type | type_debug) == 'list' and artifact.metadata.type in download_artifact_type))"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -133,14 +133,16 @@
 
 - job:
     name: ansible-test-network-integration-eos
+    abstract: true
+    dependencies:
+      - name: build-ansible-collection
+        soft: true
     parent: ansible-network-eos-appliance
     pre-run: playbooks/ansible-test-network-integration-base/pre.yaml
     run: playbooks/ansible-test-network-integration-base/run.yaml
     post-run: playbooks/ansible-test-network-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
-      - name: github.com/ansible-network/ansible_collections.network.cli
-      - name: github.com/ansible-network/releases
     timeout: 9000
     vars:
       ansible_test_network_integration: eos
@@ -183,14 +185,15 @@
 - job:
     name: ansible-test-network-integration-ios
     abstract: true
+    dependencies:
+      - name: build-ansible-collection
+        soft: true
     parent: ansible-network-ios-appliance
     pre-run: playbooks/ansible-test-network-integration-base/pre.yaml
     run: playbooks/ansible-test-network-integration-base/run.yaml
     post-run: playbooks/ansible-test-network-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
-      - name: github.com/ansible-network/ansible_collections.network.cli
-      - name: github.com/ansible-network/releases
     timeout: 9000
     vars:
       ansible_test_network_integration: ios
@@ -233,14 +236,15 @@
 - job:
     name: ansible-test-network-integration-iosxr
     abstract: true
+    dependencies:
+      - name: build-ansible-collection
+        soft: true
     parent: ansible-network-iosxr-appliance
     pre-run: playbooks/ansible-test-network-integration-base/pre.yaml
     run: playbooks/ansible-test-network-integration-base/run.yaml
     post-run: playbooks/ansible-test-network-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
-      - name: github.com/ansible-network/ansible_collections.network.cli
-      - name: github.com/ansible-network/releases
     timeout: 9000
     vars:
       ansible_test_network_integration: iosxr
@@ -283,53 +287,39 @@
 - job:
     name: ansible-test-network-integration-iosxr-netconf-python27
     parent: ansible-test-network-integration-iosxr-python27
-    required-projects:
-      - name: github.com/ansible-network/ansible_collections.cisco.iosxr
-      - name: github.com/ansible-network/ansible_collections.juniper.junos
-      - name: github.com/ansible-network/releases
     vars:
       ansible_test_network_integration: netconf
 
 - job:
     name: ansible-test-network-integration-iosxr-netconf-python35
     parent: ansible-test-network-integration-iosxr-python35
-    required-projects:
-      - name: github.com/ansible-network/ansible_collections.cisco.iosxr
-      - name: github.com/ansible-network/ansible_collections.juniper.junos
-      - name: github.com/ansible-network/releases
     vars:
       ansible_test_network_integration: netconf
 
 - job:
     name: ansible-test-network-integration-iosxr-netconf-python36
     parent: ansible-test-network-integration-iosxr-python36
-    required-projects:
-      - name: github.com/ansible-network/ansible_collections.cisco.iosxr
-      - name: github.com/ansible-network/ansible_collections.juniper.junos
-      - name: github.com/ansible-network/releases
     vars:
       ansible_test_network_integration: netconf
 
 - job:
     name: ansible-test-network-integration-iosxr-netconf-python37
     parent: ansible-test-network-integration-iosxr-python37
-    required-projects:
-      - name: github.com/ansible-network/ansible_collections.cisco.iosxr
-      - name: github.com/ansible-network/ansible_collections.juniper.junos
-      - name: github.com/ansible-network/releases
     vars:
       ansible_test_network_integration: netconf
 
 - job:
     name: ansible-test-network-integration-junos
+    abstract: true
+    dependencies:
+      - name: build-ansible-collection
+        soft: true
     parent: ansible-network-junos-appliance
     pre-run: playbooks/ansible-test-network-integration-base/pre.yaml
     run: playbooks/ansible-test-network-integration-base/run.yaml
     post-run: playbooks/ansible-test-network-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
-      - name: github.com/ansible-network/ansible_collections.network.cli
-      - name: github.com/ansible-network/releases
     timeout: 9000
     vars:
       ansible_test_network_integration: junos
@@ -372,40 +362,24 @@
 - job:
     name: ansible-test-network-integration-junos-netconf-python27
     parent: ansible-test-network-integration-junos-python27
-    required-projects:
-      - name: github.com/ansible-network/ansible_collections.cisco.iosxr
-      - name: github.com/ansible-network/ansible_collections.juniper.junos
-      - name: github.com/ansible-network/releases
     vars:
       ansible_test_network_integration: netconf
 
 - job:
     name: ansible-test-network-integration-junos-netconf-python35
     parent: ansible-test-network-integration-junos-python35
-    required-projects:
-      - name: github.com/ansible-network/ansible_collections.cisco.iosxr
-      - name: github.com/ansible-network/ansible_collections.juniper.junos
-      - name: github.com/ansible-network/releases
     vars:
       ansible_test_network_integration: netconf
 
 - job:
     name: ansible-test-network-integration-junos-netconf-python36
     parent: ansible-test-network-integration-junos-python36
-    required-projects:
-      - name: github.com/ansible-network/ansible_collections.cisco.iosxr
-      - name: github.com/ansible-network/ansible_collections.juniper.junos
-      - name: github.com/ansible-network/releases
     vars:
       ansible_test_network_integration: netconf
 
 - job:
     name: ansible-test-network-integration-junos-netconf-python37
     parent: ansible-test-network-integration-junos-python37
-    required-projects:
-      - name: github.com/ansible-network/ansible_collections.cisco.iosxr
-      - name: github.com/ansible-network/ansible_collections.juniper.junos
-      - name: github.com/ansible-network/releases
     vars:
       ansible_test_network_integration: netconf
 
@@ -418,8 +392,6 @@
     post-run: playbooks/ansible-test-network-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
-      - name: github.com/ansible-network/ansible_collections.network.cli
-      - name: github.com/ansible-network/releases
     timeout: 3600
     vars:
       ansible_test_network_integration: openvswitch
@@ -462,14 +434,15 @@
 - job:
     name: ansible-test-network-integration-vyos
     abstract: true
+    dependencies:
+      - name: build-ansible-collection
+        soft: true
     parent: ansible-network-vyos-appliance
     pre-run: playbooks/ansible-test-network-integration-base/pre.yaml
     run: playbooks/ansible-test-network-integration-base/run.yaml
     post-run: playbooks/ansible-test-network-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
-      - name: github.com/ansible-network/ansible_collections.network.cli
-      - name: github.com/ansible-network/releases
     timeout: 7200
     vars:
       ansible_test_network_integration: vyos

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -45,6 +45,9 @@
               - devel
             vars:
               ansible_test_collections: true
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-network/ansible_collections.network.cli
     gate:
       queue: integrated
       jobs:
@@ -65,6 +68,9 @@
               - devel
             vars:
               ansible_test_collections: true
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-network/ansible_collections.network.cli
 
 - project-template:
     name: ansible-collections-cisco-ios
@@ -87,6 +93,9 @@
               - devel
             vars:
               ansible_test_collections: true
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-network/ansible_collections.network.cli
     gate:
       queue: integrated
       jobs:
@@ -107,6 +116,9 @@
               - devel
             vars:
               ansible_test_collections: true
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-network/ansible_collections.network.cli
 
 - project-template:
     name: ansible-collections-cisco-iosxr
@@ -134,8 +146,15 @@
             vars:
               ansible_test_collections: true
             voting: false
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-network/ansible_collections.network.cli
     gate:
       queue: integrated
+      jobs:
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-network/ansible_collections.network.cli
 
 - project-template:
     name: ansible-collections-cisco-iosxr-netconf
@@ -157,8 +176,17 @@
             vars:
               ansible_test_collections: true
             voting: false
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-network/ansible_collections.cisco.iosxr
+              - name: github.com/ansible-network/ansible_collections.network.cli
     gate:
       queue: integrated
+      jobs:
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-network/ansible_collections.cisco.iosxr
+              - name: github.com/ansible-network/ansible_collections.network.cli
 
 - project-template:
     name: ansible-collections-juniper-junos
@@ -181,6 +209,9 @@
               - devel
             vars:
               ansible_test_collections: true
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-network/ansible_collections.network.cli
     gate:
       queue: integrated
       jobs:
@@ -201,6 +232,9 @@
               - devel
             vars:
               ansible_test_collections: true
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-network/ansible_collections.network.cli
 
 - project-template:
     name: ansible-collections-juniper-junos-netconf
@@ -218,6 +252,10 @@
         - ansible-test-network-integration-junos-netconf-python37:
             vars:
               ansible_test_collections: true
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-network/ansible_collections.juniper.junos
+              - name: github.com/ansible-network/ansible_collections.network.cli
     gate:
       queue: integrated
       jobs:
@@ -233,6 +271,10 @@
         - ansible-test-network-integration-junos-netconf-python37:
             vars:
               ansible_test_collections: true
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-network/ansible_collections.juniper.junos
+              - name: github.com/ansible-network/ansible_collections.network.cli
 
 - project-template:
     name: ansible-collections-vyos-vyos
@@ -255,6 +297,9 @@
               - devel
             vars:
               ansible_test_collections: true
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-network/ansible_collections.network.cli
     gate:
       queue: integrated
       jobs:
@@ -275,6 +320,9 @@
               - devel
             vars:
               ansible_test_collections: true
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-network/ansible_collections.network.cli
 
 
 - project-template:


### PR DESCRIPTION
We now have the ability to use the artifact handler from Zuul. This is
one step towards creating a buildset-galaxy job for properly testing
speclative collections.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>