### PR TITLE
Switch vyos-1.1.8-python36 to centos-8

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -129,7 +129,7 @@
         ansible_python_interpreter: python
     required-projects:
       - name: github.com/ansible/ansible-zuul-jobs
-    nodeset: vyos-1.1.8-python37
+    nodeset: vyos-1.1.8-python36
 
 - job:
     name: ansible-test-network-integration-eos

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -454,8 +454,8 @@
 - nodeset:
     name: vyos-1.1.8-python36
     nodes:
-      - name: ubuntu-bionic
-        label: ubuntu-bionic-1vcpu
+      - name: centos-8
+        label: centos-8-1vcpu
       - name: vyos-1.1.8
         label: vyos-1.1.8-1vcpu
     groups:
@@ -464,7 +464,7 @@
           - vyos-1.1.8
       - name: controller
         nodes:
-          - ubuntu-bionic
+          - centos-8
 
 - nodeset:
     name: vyos-1.1.8-python37


### PR DESCRIPTION
Now that we have centos-8 nodes online, we can use it for python36.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>