### PR TITLE
add ansible-test-cloud-integration-vcsa-python36 job

### DIFF
--- a/playbooks/ansible-cloud/vcsa-appliance/files/bootstrap.yaml
+++ b/playbooks/ansible-cloud/vcsa-appliance/files/bootstrap.yaml
@@ -15,9 +15,19 @@
         state: present
         user: zuul
 
+    - name: Setup zuul user
+      authorized_key:
+        key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCyiXfE1zHKdj6odbysr917Cn88ov0VQaPJtLKJyMNuRYAeMOFQHd50X8JO4dfZbmSo3YdJlVfz9FLRxE64mqj9bkN8hPFbkTG2F1AWXGPON5cmm4uiLPfQkWhX/LnClrhzZpNtMJYs5AEFeDs0POijcRugZsQA+wvLi0lSlhOfkqtjAJKpPUwy1wrJFDdvqdQBjpNQh/LB8c15XfQV2JT/3NX26dQe8zvHhL6NvfhBnAikodYkBr7UjSl36CBk0cPebZMZEBBiHdo76xORVkpmqDvkhFByXXeAsvRa2YWS4wxpiNJFswlRhjubGau7LrT113WMcPvgYXHYHf2IYJWD goneri@redhat.com"
+        state: present
+        user: zuul
+
+    - name: reset ssh connection
+      meta: reset_connection
+
 - hosts: appliance
   gather_facts: false
   tasks:
+
     - name: Generate random password
       set_fact:
         __password: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}"

--- a/playbooks/ansible-cloud/vcsa-appliance/files/bootstrap.yaml
+++ b/playbooks/ansible-cloud/vcsa-appliance/files/bootstrap.yaml
@@ -15,12 +15,6 @@
         state: present
         user: zuul
 
-    - name: Setup zuul user
-      authorized_key:
-        key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCyiXfE1zHKdj6odbysr917Cn88ov0VQaPJtLKJyMNuRYAeMOFQHd50X8JO4dfZbmSo3YdJlVfz9FLRxE64mqj9bkN8hPFbkTG2F1AWXGPON5cmm4uiLPfQkWhX/LnClrhzZpNtMJYs5AEFeDs0POijcRugZsQA+wvLi0lSlhOfkqtjAJKpPUwy1wrJFDdvqdQBjpNQh/LB8c15XfQV2JT/3NX26dQe8zvHhL6NvfhBnAikodYkBr7UjSl36CBk0cPebZMZEBBiHdo76xORVkpmqDvkhFByXXeAsvRa2YWS4wxpiNJFswlRhjubGau7LrT113WMcPvgYXHYHf2IYJWD goneri@redhat.com"
-        state: present
-        user: zuul
-
     - name: reset ssh connection
       meta: reset_connection
 

--- a/playbooks/ansible-test-cloud-integration-base/files/bootstrap-vcsa.yaml
+++ b/playbooks/ansible-test-cloud-integration-base/files/bootstrap-vcsa.yaml
@@ -1,0 +1,33 @@
+---
+- hosts: appliance
+  gather_facts: false
+  tasks:
+    - name: Write the /etc/hosts file
+      copy:
+        content: |
+          127.0.0.1  localhost
+          ::1  localhost ipv6-localhost ipv6-loopback
+          {{ hostvars['vmware-vcsa-6.7.0']['nodepool']['interface_ip']}} vcenter.test vcenter
+        dest: /etc/hosts
+      become: true
+      register: hosts_status
+
+    - command: hostnamectl set-hostname vcenter.test
+      become: true
+
+    - name: Unconditionally reboot the machine with all defaults
+      reboot:
+      become: true
+      when: hosts_status.changed
+
+    - name: "wait for the vcenter service"
+      uri:
+        url: "https://127.0.0.1"
+        validate_certs: false
+        return_content: true
+      register: result
+      until:
+        - "result.status == 200"
+        - "'vmc-documentation-link' in result.content"
+      retries: 100
+      delay: 5

--- a/playbooks/ansible-test-cloud-integration-base/post.yaml
+++ b/playbooks/ansible-test-cloud-integration-base/post.yaml
@@ -1,0 +1,10 @@
+---
+- hosts: controller
+  tasks:
+    - name: Ensure controller directory exists
+      file:
+        path: "{{ ansible_user_dir }}/zuul-output/logs/controller/ara-report"
+        state: directory
+
+    - name: Copy ansible log file
+      shell: "cp {{ ansible_user_dir }}/ansible-debug.txt {{ ansible_user_dir }}/zuul-output/logs/controller"

--- a/playbooks/ansible-test-cloud-integration-base/pre.yaml
+++ b/playbooks/ansible-test-cloud-integration-base/pre.yaml
@@ -1,0 +1,53 @@
+---
+- hosts: controller
+  tasks:
+    - name: Setup tox role
+      include_role:
+        name: tox
+      vars:
+        tox_extra_args: "-vv -- ansible-playbook -v playbooks/ansible-test-cloud-integration-base/files/bootstrap-vcsa.yaml"
+        tox_install_siblings: false
+        zuul_work_dir: "{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"
+
+    - name: Setup base virtualenv_options
+      set_fact:
+        _virtualenv_options: "--python python{{ ansible_test_python }}"
+
+    - name: Enable --system-site-packages for virtualenv_options
+      set_fact:
+        _virtualenv_options: "{{ _virtualenv_options }} --system-site-packages"
+      when: ansible_os_family == "RedHat"
+
+    - name: Create virtualenv for ansible-test
+      shell: "virtualenv {{ _virtualenv_options }} ~/venv"
+
+    - name: Install ara into virtuelenv
+      shell: ~/venv/bin/pip install "ara<1.0.0"
+
+    - name: Upgrade six for vap-runtime (workaround)
+      shell: ~/venv/bin/pip install --upgrade "six>=1.12"
+
+
+    - name: Install ansible into virtuelenv
+      shell: "~/venv/bin/pip install {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
+
+    - name: Enable ARA callback plugin
+      ini_file:
+        path: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/test/integration/integration.cfg"
+        section: defaults
+        option: callback_plugins
+        value: "{{ ansible_user_dir }}/venv/lib/python{{ ansible_test_python}}/site-packages/ara/plugins/callbacks"
+
+    - name: Enable persistent connection logging
+      ini_file:
+        path: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/test/integration/integration.cfg"
+        section: persistent_connection
+        option: log_messages
+        value: true
+
+    - name: Set ansible log path
+      ini_file:
+        path: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/test/integration/integration.cfg"
+        section: defaults
+        option: log_path
+        value: ~/ansible-debug.txt

--- a/playbooks/ansible-test-cloud-integration-base/pre.yaml
+++ b/playbooks/ansible-test-cloud-integration-base/pre.yaml
@@ -15,7 +15,7 @@
 
     - name: Enable --system-site-packages for virtualenv_options
       set_fact:
-        _virtualenv_options: "{{ _virtualenv_options }} --system-site-packages"
+        _virtualenv_options: "{{ _virtualenv_options }}"
       when: ansible_os_family == "RedHat"
 
     - name: Create virtualenv for ansible-test
@@ -23,10 +23,6 @@
 
     - name: Install ara into virtuelenv
       shell: ~/venv/bin/pip install "ara<1.0.0"
-
-    - name: Upgrade six for vap-runtime (workaround)
-      shell: ~/venv/bin/pip install --upgrade "six>=1.12"
-
 
     - name: Install ansible into virtuelenv
       shell: "~/venv/bin/pip install {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"

--- a/playbooks/ansible-test-cloud-integration-base/run.yaml
+++ b/playbooks/ansible-test-cloud-integration-base/run.yaml
@@ -27,6 +27,6 @@
       args:
         chdir: "{{ _test_location }}"
         executable: /bin/bash
-      shell: "source ~/venv/bin/activate; {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/bin/ansible-test integration {{ _test_options }} --python {{ ansible_test_python }} -vvvv {{ ansible_test_integration_target }}"
+      shell: "source ~/venv/bin/activate; {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/bin/ansible-test integration {{ _test_options }} --python {{ ansible_test_python }} -vvvv {{ ansible_test_integration_targets }}"
       environment:
         VMWARE_TEST_PLATFORM: static

--- a/playbooks/ansible-test-cloud-integration-base/run.yaml
+++ b/playbooks/ansible-test-cloud-integration-base/run.yaml
@@ -1,0 +1,32 @@
+---
+- hosts: controller
+  tasks:
+    - name: Setup location of project
+      set_fact:
+        _test_location: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
+
+    - name: Setup base test_options
+      set_fact:
+        _test_options: "--continue-on-error --diff --requirements"
+
+    - name: Enable --no-temp-workdir for test_options
+      set_fact:
+        _test_options: "{{ _test_options }} --no-temp-workdir"
+      when: zuul.projects['github.com/ansible/ansible'].checkout not in ["stable-2.6", "stable-2.7"]
+
+    - copy:
+        content: |
+            [DEFAULT]
+            vcenter_username: administrator@vsphere.local
+            vcenter_password: !234AaAa56
+            vcenter_hostname: {{ hostvars['vmware-vcsa-6.7.0']['nodepool']['interface_ip']}}
+            vmware_validate_certs: false
+        dest: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/test/integration/cloud-config-vcenter.ini"
+
+    - name: Run the integration test suite
+      args:
+        chdir: "{{ _test_location }}"
+        executable: /bin/bash
+      shell: "source ~/venv/bin/activate; {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/bin/ansible-test integration {{ _test_options }} --python {{ ansible_test_python }} -vvvv {{ ansible_test_integration_target }}"
+      environment:
+        VMWARE_TEST_PLATFORM: static

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -33,5 +33,4 @@
     nodeset: vmware-vcsa-6.7.0-python36
     vars:
       ansible_test_python: 3.6
-      ansible_test_integration_target: zuul/vmware/vcenter_only/
-    attempts: 1
+      ansible_test_integration_targets: zuul/vmware/vcenter_only/

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -15,3 +15,23 @@
     required-projects:
       - name: github.com/ansible/ansible-zuul-jobs
     nodeset: vmware-vcsa-6.7.0-python36
+
+- job:
+    name: ansible-test-cloud-integration-vcsa
+    abstract: true
+    parent: ansible-cloud-vcsa-appliance
+    pre-run: playbooks/ansible-test-cloud-integration-base/pre.yaml
+    run: playbooks/ansible-test-cloud-integration-base/run.yaml
+    post-run: playbooks/ansible-test-cloud-integration-base/post.yaml
+    required-projects:
+      - name: github.com/ansible/ansible
+    timeout: 3600
+
+- job:
+    name: ansible-test-cloud-integration-vcsa-python36
+    parent: ansible-test-cloud-integration-vcsa
+    nodeset: vmware-vcsa-6.7.0-python36
+    vars:
+      ansible_test_python: 3.6
+      ansible_test_integration_target: zuul/vmware/vcenter_only/
+    attempts: 1

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1149,6 +1149,14 @@
               - ^lib/ansible/plugins/terminal/vyos.py
               - ^test/integration/targets/vyos_.*
               - ^test/integration/targets/prepare_vyos_tests/.*
+        - ansible-test-cloud-integration-vcsa-python36:
+            branches:
+              - devel
+            files:
+              - ^lib/ansible/modules/cloud/vmware/.*
+              - ^test/integration/targets/vcenter_.*
+              - ^test/integration/targets/.*vmware_.*
+            voting: false
 
 - project-template:
     name: noop-jobs

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -13,6 +13,10 @@
             voting: false
         - ansible-network-openvswitch-appliance
         - ansible-network-vyos-appliance
+        - ansible-test-cloud-integration-vcsa-python36:
+            vars:
+              ansible_test_integration_target: vcenter_folder
+
     gate:
       jobs:
         - ansible-cloud-vcsa-appliance

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -13,10 +13,6 @@
             voting: false
         - ansible-network-openvswitch-appliance
         - ansible-network-vyos-appliance
-        - ansible-test-cloud-integration-vcsa-python36:
-            vars:
-              ansible_test_integration_target: vcenter_folder
-
     gate:
       jobs:
         - ansible-cloud-vcsa-appliance


### PR DESCRIPTION
add ansible-test-cloud-integration-vcsa-python36 job
  
Add the new `ansible-test-cloud-integration-vcsa-python36` as a
non-voting job.

It only checks the integration roles that don't need any ESXi, just a
vcenter instance. It uses the new `zuul/vmware/vcenter_only` target
to target them.

There is still a couple of things that can be improved later:

- the vcenter appliance uses a vcenter.test FQDN, it should instead use
  origin VM hostname instead
- we reboot the vcenter to reload the configuration, this takes about 30s,
  and can probably be skipped
- in addition, there is several potential improvements that have been
  identified during the reviews.