### PR TITLE
Update vsrx3-18.4R1-python36 to centos-8 node

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -101,9 +101,10 @@
       vsrx3-18.4R1:
         ansible_connection: network_cli
         ansible_network_os: junos
+        ansible_python_interpreter: python
     required-projects:
       - name: github.com/ansible/ansible-zuul-jobs
-    nodeset: vsrx3-18.4R1-python37
+    nodeset: vsrx3-18.4R1-python36
 
 - job:
     name: ansible-network-openvswitch-appliance

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -379,8 +379,8 @@
 - nodeset:
     name: vsrx3-18.4R1-python36
     nodes:
-      - name: ubuntu-bionic
-        label: ubuntu-bionic-1vcpu
+      - name: centos-8
+        label: centos-8-1vcpu
       - name: vsrx3-18.4R1
         label: vsrx3-18.4R1
     groups:
@@ -389,7 +389,7 @@
           - vsrx3-18.4R1
       - name: controller
         nodes:
-          - ubuntu-bionic
+          - centos-8
 
 - nodeset:
     name: vsrx3-18.4R1-python37


### PR DESCRIPTION
Now that we have centos-8 online, we can switch python36 jobs to use it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>