### PR TITLE
Update ios-15.6-2T-python36 to centos-8

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -75,9 +75,10 @@
       ios-15.6-2T:
         ansible_connection: network_cli
         ansible_network_os: ios
+        ansible_python_interpreter: python
     required-projects:
       - name: github.com/ansible/ansible-zuul-jobs
-    nodeset: ios-15.6-2T-python37
+    nodeset: ios-15.6-2T-python36
 
 - job:
     name: ansible-network-iosxr-appliance

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -154,8 +154,8 @@
 - nodeset:
     name: ios-15.6-2T-python36
     nodes:
-      - name: ubuntu-bionic
-        label: ubuntu-bionic-1vcpu
+      - name: centos-8
+        label: centos-8-1vcpu
       - name: ios-15.6-2T
         label: ios-15.6-2T
     groups:
@@ -164,7 +164,7 @@
           - ios-15.6-2T
       - name: controller
         nodes:
-          - ubuntu-bionic
+          - centos-8
 
 - nodeset:
     name: ios-15.6-2T-python37


### PR DESCRIPTION
With centos-8 online, now we can use it for python36 support.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>