### PR TITLE
Update openvswitch-2.9.0-python36 to centos-8

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -117,7 +117,7 @@
         ansible_network_os: openvswitch
     required-projects:
       - name: github.com/ansible/ansible-zuul-jobs
-    nodeset: openvswitch-2.9.0-python37
+    nodeset: openvswitch-2.9.0-python36
 
 - job:
     name: ansible-network-vyos-appliance

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -304,8 +304,8 @@
 - nodeset:
     name: openvswitch-2.9.0-python36
     nodes:
-      - name: ubuntu-bionic
-        label: ubuntu-bionic-1vcpu
+      - name: centos-8
+        label: centos-8-1vcpu
       - name: openvswitch-2.9.0
         label: ubuntu-bionic-1vcpu
     groups:
@@ -314,7 +314,7 @@
           - openvswitch-2.9.0
       - name: controller
         nodes:
-          - ubuntu-bionic
+          - centos-8
 
 - nodeset:
     name: openvswitch-2.9.0-python37


### PR DESCRIPTION
Switch to centos-8 for python36, now that it is online.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>