### PR TITLE
Refactor network jobs to use ansible_test_integration_targets

### DIFF
--- a/playbooks/ansible-test-network-integration-base/run.yaml
+++ b/playbooks/ansible-test-network-integration-base/run.yaml
@@ -14,15 +14,6 @@
         _test_options: "{{ _test_options }} --no-temp-workdir"
       when: zuul.projects['github.com/ansible/ansible'].checkout not in ["stable-2.6", "stable-2.7"]
 
-    - name: Setup base target for ansible-test
-      set_fact:
-        _target: "{{ ansible_test_network_integration }}_.*"
-
-    - name: Enable netconf_.* target for ansible-test
-      set_fact:
-        _target: "{{ _target }} netconf_.*"
-      when: ansible_test_network_integration in ["iosxr", "junos"]
-
     - name: Setup testing for collections
       block:
         - name: Setup download-artifact-fork role
@@ -64,10 +55,6 @@
           shell: cat galaxy.yml | ~/venv/bin/yq -y .name | tail -n +1 | head -1
           register: _collection_name
 
-        - name: Setup base target for ansible-test
-          set_fact:
-            _target: "{{ ansible_test_network_integration }}_.*"
-
         - name: Setup location of project
           set_fact:
             _test_location: "~/.ansible/collection/ansible_collections/{{ _collection_namespace.stdout }}/{{ _collection_name.stdout }}"
@@ -81,4 +68,4 @@
       args:
         chdir: "{{ _test_location }}"
         executable: /bin/bash
-      shell: "source ~/venv/bin/activate; {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/bin/ansible-test network-integration {{ _test_options }} --python {{ ansible_test_python }} --inventory /home/zuul/inventory -vvvv {{ _target }}"
+      shell: "source ~/venv/bin/activate; {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/bin/ansible-test network-integration {{ _test_options }} --python {{ ansible_test_python }} --inventory /home/zuul/inventory -vvvv {{ ansible_test_integration_targets }}"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -162,7 +162,7 @@
       - name: github.com/ansible/ansible
     timeout: 9000
     vars:
-      ansible_test_network_integration: eos
+      ansible_test_integration_targets: "eos_.*"
 
 - job:
     name: ansible-test-network-integration-eos-python27
@@ -213,7 +213,7 @@
       - name: github.com/ansible/ansible
     timeout: 9000
     vars:
-      ansible_test_network_integration: ios
+      ansible_test_integration_targets: "ios_.*"
 
 - job:
     name: ansible-test-network-integration-ios-python27
@@ -264,7 +264,7 @@
       - name: github.com/ansible/ansible
     timeout: 9000
     vars:
-      ansible_test_network_integration: iosxr
+      ansible_test_integration_targets: "iosxr_.* netconf_.*"
 
 - job:
     name: ansible-test-network-integration-iosxr-python27
@@ -305,25 +305,25 @@
     name: ansible-test-network-integration-iosxr-netconf-python27
     parent: ansible-test-network-integration-iosxr-python27
     vars:
-      ansible_test_network_integration: netconf
+      ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-iosxr-netconf-python35
     parent: ansible-test-network-integration-iosxr-python35
     vars:
-      ansible_test_network_integration: netconf
+      ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-iosxr-netconf-python36
     parent: ansible-test-network-integration-iosxr-python36
     vars:
-      ansible_test_network_integration: netconf
+      ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-iosxr-netconf-python37
     parent: ansible-test-network-integration-iosxr-python37
     vars:
-      ansible_test_network_integration: netconf
+      ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-junos
@@ -339,7 +339,7 @@
       - name: github.com/ansible/ansible
     timeout: 9000
     vars:
-      ansible_test_network_integration: junos
+      ansible_test_integration_targets: "junos_.* netconf_.*"
 
 - job:
     name: ansible-test-network-integration-junos-python27
@@ -380,25 +380,25 @@
     name: ansible-test-network-integration-junos-netconf-python27
     parent: ansible-test-network-integration-junos-python27
     vars:
-      ansible_test_network_integration: netconf
+      ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-junos-netconf-python35
     parent: ansible-test-network-integration-junos-python35
     vars:
-      ansible_test_network_integration: netconf
+      ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-junos-netconf-python36
     parent: ansible-test-network-integration-junos-python36
     vars:
-      ansible_test_network_integration: netconf
+      ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-junos-netconf-python37
     parent: ansible-test-network-integration-junos-python37
     vars:
-      ansible_test_network_integration: netconf
+      ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-openvswitch
@@ -411,7 +411,7 @@
       - name: github.com/ansible/ansible
     timeout: 3600
     vars:
-      ansible_test_network_integration: openvswitch
+      ansible_test_integration_targets: "openvswitch_.*"
 
 - job:
     name: ansible-test-network-integration-openvswitch-python27
@@ -462,7 +462,7 @@
       - name: github.com/ansible/ansible
     timeout: 7200
     vars:
-      ansible_test_network_integration: vyos
+      ansible_test_integration_targets: "vyos_.*"
 
 - job:
     name: ansible-test-network-integration-vyos-python27


### PR DESCRIPTION
This is one more step to closer integration with our cloud jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>