### PR TITLE
vmware: add a vcenter+1esxi job

### DIFF
--- a/playbooks/ansible-cloud/appliance-base/pre.yaml
+++ b/playbooks/ansible-cloud/appliance-base/pre.yaml
@@ -11,19 +11,9 @@
       include_role:
         name: test-setup
 
-    - name: Set SSH interface IP for appliance
-      set_fact:
-        __ssh_ip: "{{ hostvars[item].ansible_host }}"
-      with_inventory_hostnames: appliance
-
-    - name: Wait 300 seconds for port tcp/22 on appliance
-      wait_for:
-        host: "{{ __ssh_ip }}"
-        port: 22
-        search_regex: SSH
-
     - name: Ensure remote SSH host keys are known
-      shell: "ssh-keyscan {{ __ssh_ip }} >> ~/.ssh/known_hosts"
+      shell: "ssh-keyscan {{hostvars[item].ansible_host }} >> ~/.ssh/known_hosts"
+      with_inventory_hostnames: appliance
 
     - name: Create /etc/ansible folder
       become: true

--- a/playbooks/ansible-cloud/appliance-base/pre.yaml
+++ b/playbooks/ansible-cloud/appliance-base/pre.yaml
@@ -11,6 +11,17 @@
       include_role:
         name: test-setup
 
+    - name: Set SSH interface IP for appliance
+      set_fact:
+        __ssh_ip: "{{ hostvars[item].ansible_host }}"
+      with_inventory_hostnames: appliance
+
+    - name: Wait 300 seconds for port tcp/22 on appliance
+      wait_for:
+        host: "{{ __ssh_ip }}"
+        port: 22
+        search_regex: SSH
+
     - name: Ensure remote SSH host keys are known
       shell: "ssh-keyscan {{hostvars[item].ansible_host }} >> ~/.ssh/known_hosts"
       with_inventory_hostnames: appliance

--- a/playbooks/ansible-cloud/vcenter-appliance/files/bootstrap.yaml
+++ b/playbooks/ansible-cloud/vcenter-appliance/files/bootstrap.yaml
@@ -4,7 +4,12 @@
   vars:
     ansible_password: zuul
     ansible_user: zuul
+    authorized_keys_file:
+      esxi1: /etc/ssh/keys-zuul/authorized_keys
+      esxi2: /etc/ssh/keys-zuul/authorized_keys
+      vcenter: /home/zuul/.ssh/authorized_keys
   tasks:
+
     - name: lookup SSH public key
       set_fact:
         _ssh_key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
@@ -14,6 +19,7 @@
         key: "{{ _ssh_key }}"
         state: present
         user: zuul
+        path: "{{ authorized_keys_file[inventory_hostname] }}"
 
     - name: reset ssh connection
       meta: reset_connection
@@ -24,29 +30,17 @@
 
     - name: Generate random password
       set_fact:
-        __password: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters') }}"
+        __password: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters,digits,hexdigits') }}"
       no_log: true
 
-    - name: Change zuul user password
+    - name: Change zuul user password (vcenter)
       become: true
       user:
         name: zuul
         password: "{{ __password | password_hash('sha512') }}"
+      when: inventory_hostname == "vcenter"
 
-- hosts: vcenter
-  gather_facts: false
-  tasks:
-    # NOTE(Gonéri): ok, some explanations here. We can set the hostname of the vcenter node
-    # during the installation, and we can hardly change it after. So we configure the VM
-    # to use dnsmasq internally and use /etc/hosts as a source of trust.
-    # Also, the hostname has to be in the format $hostname.$domain. In addition, some services
-    # use the reverse DNS resolution to know the public IP of the node. So we cannot just go
-    # with "vcenter.test==127.0.0.1", this won't work.
-    - name: Write the /etc/hosts file
-      copy:
-        content: |
-          127.0.0.1  localhost
-          ::1  localhost ipv6-localhost ipv6-loopback
-          {{ hostvars['vcenter']['nodepool']['interface_ip']}} vcenter.test vcenter
-        dest: /etc/hosts
-      become: true
+    - name: Change zuul user password (ESXi)
+      shell: "echo {{ __password }} | passwd -s"
+      no_log: true
+      when: inventory_hostname.startswith("esxi")

--- a/playbooks/ansible-cloud/vcenter-appliance/files/bootstrap.yaml
+++ b/playbooks/ansible-cloud/vcenter-appliance/files/bootstrap.yaml
@@ -23,24 +23,3 @@
 
     - name: reset ssh connection
       meta: reset_connection
-
-- hosts: appliance
-  gather_facts: false
-  tasks:
-
-    - name: Generate random password
-      set_fact:
-        __password: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters,digits,hexdigits') }}"
-      no_log: true
-
-    - name: Change zuul user password (vcenter)
-      become: true
-      user:
-        name: zuul
-        password: "{{ __password | password_hash('sha512') }}"
-      when: inventory_hostname == "vcenter"
-
-    - name: Change zuul user password (ESXi)
-      shell: "echo {{ __password }} | passwd -s"
-      no_log: true
-      when: inventory_hostname.startswith("esxi")

--- a/playbooks/ansible-cloud/vcenter-appliance/pre.yaml
+++ b/playbooks/ansible-cloud/vcenter-appliance/pre.yaml
@@ -1,4 +1,14 @@
 ---
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - set_fact:
+        vmware_ci_set_passwords_passwords:
+          # the trailing 56 are here to be sure the password is valie (ascii+digits)
+          root: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters,digits,hexdigits') }}56"
+          zuul: "{{ lookup('password', '/dev/null length=15 chars=ascii_letters,digits,hexdigits') }}56"
+      no_log: true
+
 - hosts: controller
   tasks:
     - name: Ensure sshpass is present
@@ -16,14 +26,29 @@
         tox_install_siblings: false
         zuul_work_dir: "{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"
 
-    - name: "wait for the vcenter service"
-      uri:
-        url: "https://{{ hostvars['vcenter']['nodepool']['interface_ip'] }}"
-        validate_certs: false
-        return_content: true
-      register: result
-      until:
-        - "result.status == 200"
-        - "'vmc-documentation-link' in result.content"
-      retries: 100
-      delay: 5
+- hosts: all
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: vmware-ci-write-etc-hosts
+      vars:
+        vmware_ci_write_etc_hosts_mapping:
+          vcenter: "{{ hostvars['vcenter']['nodepool']['interface_ip']}}"
+          esxi1: "{{ 'esxi1' in hostvars and hostvars['esxi1']['nodepool']['interface_ip']}}"
+          esxi2: "{{ 'esxi2' in hostvars and hostvars['esxi2']['nodepool']['interface_ip']}}"
+          datastore: "{{ hostvars[groups['controller'][0]]['nodepool']['interface_ip']}}"
+
+- hosts: appliance
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: vmware-ci-set-passwords
+      vars:
+        vmware_ci_set_passwords_secret_dir: '{{ zuul.executor.work_root }}'
+
+- hosts: appliance
+  gather_facts: false
+  tasks:
+    - name: Ensure the ESXi will reboot if they get a BlueScreenOfDeath
+      command: esxcfg-advcfg -s 1 /Misc/BlueScreenTimeout
+      when: inventory_hostname.startswith("esxi")

--- a/playbooks/ansible-test-cloud-integration-base/pre.yaml
+++ b/playbooks/ansible-test-cloud-integration-base/pre.yaml
@@ -12,6 +12,33 @@
         tox_install_siblings: false
         zuul_work_dir: "{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"
 
+
+    - name: Restore the cache files for the NFS datastore
+      block:
+        - name: Create the ISO directory
+          file:
+            path: /srv/share/isos
+            state: directory
+          become: true
+
+        - name: Move the cached files
+          shell: |
+             mv /opt/cache/files/CentOS-8-x86_64-1905-dvd1.iso /srv/share/isos/centos.iso
+             mv /opt/cache/files/Fedora-Workstation-Live-x86_64-30-1.2.iso /srv/share/isos/fedora.iso
+          args:
+            creates: /srv/share/isos/fedora.iso
+          become: true
+
+        - name: Adjust the ownership
+          file:
+            path: /srv/share/isos
+            state: directory
+            recurse: true
+            owner: '1000'
+            group: '1000'
+          become: true
+
+
     - name: Prepare the NFS datastore
       import_role:
         name: vmware-ci-nfs-share

--- a/playbooks/ansible-test-cloud-integration-base/pre.yaml
+++ b/playbooks/ansible-test-cloud-integration-base/pre.yaml
@@ -23,8 +23,8 @@
 
         - name: Move the cached files
           shell: |
-             mv /opt/cache/files/CentOS-8-x86_64-1905-dvd1.iso /srv/share/isos/centos.iso
-             mv /opt/cache/files/Fedora-Workstation-Live-x86_64-30-1.2.iso /srv/share/isos/fedora.iso
+             mv /opt/cache/files/CentOS-8-x86_64-1905-boot.iso /srv/share/isos/centos.iso
+             mv /opt/cache/files/Fedora-Workstation-Live-x86_64-31-1.9.iso /srv/share/isos/fedora.iso
           args:
             creates: /srv/share/isos/fedora.iso
           become: true

--- a/playbooks/ansible-test-cloud-integration-base/pre.yaml
+++ b/playbooks/ansible-test-cloud-integration-base/pre.yaml
@@ -1,6 +1,9 @@
 ---
+
 - hosts: controller
+  gather_facts: false
   tasks:
+
     - name: Setup tox role
       include_role:
         name: tox
@@ -9,11 +12,27 @@
         tox_install_siblings: false
         zuul_work_dir: "{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"
 
-    - copy:
-        content: |
-            [DEFAULT]
-            vcenter_username: administrator@vsphere.local
-            vcenter_password: !234AaAa56
-            vcenter_hostname: {{ hostvars['vcenter']['nodepool']['interface_ip']}}
-            vmware_validate_certs: false
-        dest: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/test/integration/cloud-config-vcenter.ini"
+    - import_role:
+        name: vmware-ci-nfs-share
+      vars:
+        vmware_ci_nfs_share_allow_ips:
+          - "{{ hostvars['esxi1']['nodepool']['interface_ip'] }}"
+      when: "'esxi1' in hostvars"
+
+    - import_role:
+        name: vmware-ci-configure-ansible-test
+      vars:
+        vmware_ci_configure_ansible_test_ansible_path: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
+        vmware_ci_set_passwords_secret_dir: '{{ zuul.executor.work_root }}'
+
+    - name: "wait for the vcenter service"
+      uri:
+        url: "https://vcenter.test"
+        validate_certs: false
+        return_content: true
+      register: result
+      until:
+        - "result.status == 200"
+        - "'vmc-documentation-link' in result.content"
+      retries: 100
+      delay: 5

--- a/playbooks/ansible-test-cloud-integration-base/pre.yaml
+++ b/playbooks/ansible-test-cloud-integration-base/pre.yaml
@@ -12,20 +12,22 @@
         tox_install_siblings: false
         zuul_work_dir: "{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"
 
-    - import_role:
+    - name: Prepare the NFS datastore
+      import_role:
         name: vmware-ci-nfs-share
       vars:
         vmware_ci_nfs_share_allow_ips:
           - "{{ hostvars['esxi1']['nodepool']['interface_ip'] }}"
       when: "'esxi1' in hostvars"
 
-    - import_role:
+    - name: Write the configuration for ansible-test
+      import_role:
         name: vmware-ci-configure-ansible-test
       vars:
         vmware_ci_configure_ansible_test_ansible_path: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
         vmware_ci_set_passwords_secret_dir: '{{ zuul.executor.work_root }}'
 
-    - name: "wait for the vcenter service"
+    - name: wait for the vcenter service
       uri:
         url: "https://vcenter.test"
         validate_certs: false

--- a/playbooks/ansible-test-cloud-integration-base/templates/cloud-config-vcenter.ini.j2
+++ b/playbooks/ansible-test-cloud-integration-base/templates/cloud-config-vcenter.ini.j2
@@ -1,0 +1,15 @@
+[DEFAULT]
+vcenter_username: administrator@vsphere.local
+vcenter_password: {{ lookup('file', '{{ zuul.executor.work_root }}/vcenter/tmp/vcenter_password.txt') }}
+vcenter_hostname: vcenter.test
+vmware_validate_certs: false
+{% if 'esxi1' in hostvars %}
+esxi1_username: zuul
+esxi1_hostname: esxi1.test
+esxi1_password: {{ lookup('file', '{{ zuul.executor.work_root }}/vcenter/tmp/esxi_password_zuul.txt') }}
+{% endif %}
+{% if 'esxi2' in hostvars %}
+esxi2_username: zuul
+esxi2_hostname: esxi2.test
+esxi2_password: {{ lookup('file', '{{ zuul.executor.work_root }}/vcenter/tmp/esxi_password_zuul.txt') }}
+{% endif %}

--- a/playbooks/ansible-test-integration-base/run.yaml
+++ b/playbooks/ansible-test-integration-base/run.yaml
@@ -33,6 +33,11 @@
         _test_options: "{{ _test_options }} --inventory /home/zuul/inventory"
       when: ansible_test_command == 'network-integration'
 
+    - name: Enable --retry-on-error
+      set_fact:
+        _test_options: "{{ _test_options }} --retry-on-error"
+      when: ansible_test_retry_on_error | default(False)
+
     - name: Setup testing for collections
       block:
         - name: Setup download-artifact-fork role

--- a/roles/vmware-ci-configure-ansible-test/defaults/main.yaml
+++ b/roles/vmware-ci-configure-ansible-test/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+vmware_ci_set_passwords_secret_dir: /tmp

--- a/roles/vmware-ci-configure-ansible-test/tasks/main.yaml
+++ b/roles/vmware-ci-configure-ansible-test/tasks/main.yaml
@@ -1,0 +1,6 @@
+---
+- name: Save the password in the vcenter configuration file (ansible-test)
+  template:
+    src: cloud-config-vcenter.ini.j2
+    dest: "{{ vmware_ci_configure_ansible_test_ansible_path }}/test/integration/cloud-config-vcenter.ini"
+    mode: 0644

--- a/roles/vmware-ci-configure-ansible-test/templates/cloud-config-vcenter.ini.j2
+++ b/roles/vmware-ci-configure-ansible-test/templates/cloud-config-vcenter.ini.j2
@@ -1,0 +1,15 @@
+[DEFAULT]
+vcenter_username: administrator@vsphere.local
+vcenter_password: {{ lookup('file', vmware_ci_set_passwords_secret_dir + '/vcenter/tmp/vcenter_password.txt') }}
+vcenter_hostname: vcenter.test
+vmware_validate_certs: false
+{% if 'esxi1' in hostvars %}
+esxi1_username: zuul
+esxi1_hostname: esxi1.test
+esxi1_password: {{ lookup('file', vmware_ci_set_passwords_secret_dir + '/vcenter/tmp/esxi_password_zuul.txt') }}
+{% endif %}
+{% if 'esxi2' in hostvars %}
+esxi2_username: zuul
+esxi2_hostname: esxi2.test
+esxi2_password: {{ lookup('file', vmware_ci_set_passwords_secret_dir + '/vcenter/tmp/esxi_password_zuul.txt') }}
+{% endif %}

--- a/roles/vmware-ci-nfs-share/defaults/main.yaml
+++ b/roles/vmware-ci-nfs-share/defaults/main.yaml
@@ -1,4 +1,11 @@
 ---
 vmware_ci_nfs_share_allowed_ips: []
-vmware_ci_nfs_share_owner_uid: 1000
-vmware_ci_nfs_share_owner_gid: 1000
+vmware_ci_nfs_share_owner_uid: '1000'
+vmware_ci_nfs_share_owner_gid: '1000'
+vmware_ci_nfs_share_iso_files:
+    fedora.iso:
+        url: https://download.fedoraproject.org/pub/fedora/linux/releases/30/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-30-1.2.iso
+        checksum: sha256:1d73ce30bfb96274c53b09013ea23320f0f64a1b0c663217110a5baf0b2c6528
+    centos.iso:
+        url: http://isoredirect.centos.org/centos/8/isos/x86_64/CentOS-8-x86_64-1905-dvd1.iso
+        checksum: sha256:a7993a0d4b7fef2433e0d4f53530b63c715d3aadbe91f152ee5c3621139a2cbc

--- a/roles/vmware-ci-nfs-share/defaults/main.yaml
+++ b/roles/vmware-ci-nfs-share/defaults/main.yaml
@@ -7,5 +7,5 @@ vmware_ci_nfs_share_iso_files:
         url: https://mirror.csclub.uwaterloo.ca/fedora/linux/releases/31/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-31-1.9.iso
         checksum: sha256:1d73ce30bfb96274c53b09013ea23320f0f64a1b0c663217110a5baf0b2c6528
     centos.iso:
-        url: http://isoredirect.centos.org/centos/8/isos/x86_64/CentOS-8-x86_64-1905-boot.iso
+        url: http://mirror.csclub.uwaterloo.ca/centos/8.0.1905/isos/x86_64/CentOS-8-x86_64-1905-boot.iso
         checksum: sha256:a7993a0d4b7fef2433e0d4f53530b63c715d3aadbe91f152ee5c3621139a2cbc

--- a/roles/vmware-ci-nfs-share/defaults/main.yaml
+++ b/roles/vmware-ci-nfs-share/defaults/main.yaml
@@ -1,0 +1,4 @@
+---
+vmware_ci_nfs_share_allowed_ips: []
+vmware_ci_nfs_share_owner_uid: 1000
+vmware_ci_nfs_share_owner_gid: 1000

--- a/roles/vmware-ci-nfs-share/defaults/main.yaml
+++ b/roles/vmware-ci-nfs-share/defaults/main.yaml
@@ -4,8 +4,8 @@ vmware_ci_nfs_share_owner_uid: '1000'
 vmware_ci_nfs_share_owner_gid: '1000'
 vmware_ci_nfs_share_iso_files:
     fedora.iso:
-        url: https://download.fedoraproject.org/pub/fedora/linux/releases/30/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-30-1.2.iso
+        url: https://mirror.csclub.uwaterloo.ca/fedora/linux/releases/31/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-31-1.9.iso
         checksum: sha256:1d73ce30bfb96274c53b09013ea23320f0f64a1b0c663217110a5baf0b2c6528
     centos.iso:
-        url: http://isoredirect.centos.org/centos/8/isos/x86_64/CentOS-8-x86_64-1905-dvd1.iso
+        url: http://isoredirect.centos.org/centos/8/isos/x86_64/CentOS-8-x86_64-1905-boot.iso
         checksum: sha256:a7993a0d4b7fef2433e0d4f53530b63c715d3aadbe91f152ee5c3621139a2cbc

--- a/roles/vmware-ci-nfs-share/handlers/main.yaml
+++ b/roles/vmware-ci-nfs-share/handlers/main.yaml
@@ -1,0 +1,7 @@
+---
+- name: Restart nfs-server
+  systemd:
+    state: restarted
+    enabled: true
+    name: nfs-server
+  become: true

--- a/roles/vmware-ci-nfs-share/tasks/main.yaml
+++ b/roles/vmware-ci-nfs-share/tasks/main.yaml
@@ -12,19 +12,16 @@
 
 - name: Download ISO
   get_url:
-    url: '{{ item.url }}'
-    dest: '/srv/share/isos/{{ item.name }}'
+    url: '{{ item.value.url }}'
+    dest: '/srv/share/isos/{{ item.key }}'
+    checksum: '{{ item.value.checksum }}'
     mode: '0644'
-  with_items:
-    - name: fedora.iso
-      url: https://download.fedoraproject.org/pub/fedora/linux/releases/30/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-30-1.2.iso
-    - name: centos.iso
-      url: http://isoredirect.centos.org/centos/8/isos/x86_64/CentOS-8-x86_64-1905-dvd1.iso
+  with_dict: "{{ vmware_ci_nfs_share_iso_files }}"
 
 - name: Install nfs-utils
   package:
     name: nfs-utils
-    state: latest
+    state: present
   become: true
   notify:
     - Restart nfs-server

--- a/roles/vmware-ci-nfs-share/tasks/main.yaml
+++ b/roles/vmware-ci-nfs-share/tasks/main.yaml
@@ -1,0 +1,38 @@
+---
+- name: Prepare the NFS shares
+  file:
+    path: '{{ item }}'
+    state: directory
+    owner: '{{ vmware_ci_nfs_share_owner_uid }}'
+    group: '{{ vmware_ci_nfs_share_owner_gid }}'
+  with_items:
+    - /srv/share/vms
+    - /srv/share/isos
+  become: true
+
+- name: Download ISO
+  get_url:
+    url: '{{ item.url }}'
+    dest: '/srv/share/isos/{{ item.name }}'
+    mode: '0644'
+  with_items:
+    - name: fedora.iso
+      url: https://download.fedoraproject.org/pub/fedora/linux/releases/30/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-30-1.2.iso
+    - name: centos.iso
+      url: http://isoredirect.centos.org/centos/8/isos/x86_64/CentOS-8-x86_64-1905-dvd1.iso
+
+- name: Install nfs-utils
+  package:
+    name: nfs-utils
+    state: latest
+  become: true
+  notify:
+    - Restart nfs-server
+
+- name: Prepare the /etc/exports file
+  template:
+    src: exports.j2
+    dest: /etc/exports
+  become: true
+  notify:
+    - Restart nfs-server

--- a/roles/vmware-ci-nfs-share/templates/exports.j2
+++ b/roles/vmware-ci-nfs-share/templates/exports.j2
@@ -1,0 +1,3 @@
+/srv/share/isos {% for allowed_ip in vmware_ci_nfs_share_allow_ips -%}{{ allowed_ip }}(ro,anonuid={{ vmware_ci_nfs_share_owner_uid }},anongid={{ vmware_ci_nfs_share_owner_gid }}) {% endfor %}
+
+/srv/share/vms {% for allowed_ip in vmware_ci_nfs_share_allow_ips -%}{{ allowed_ip }}(rw,anonuid={{ vmware_ci_nfs_share_owner_uid }},anongid={{ vmware_ci_nfs_share_owner_gid }}) {% endfor %}

--- a/roles/vmware-ci-set-passwords/defaults/main.yaml
+++ b/roles/vmware-ci-set-passwords/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+vmware_ci_set_passwords_secret_dir: /tmp

--- a/roles/vmware-ci-set-passwords/files/vcenter_set_password
+++ b/roles/vmware-ci-set-passwords/files/vcenter_set_password
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+#
+# Copyright 2019-2020 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import subprocess
+
+import time
+
+
+def set_new_pw():
+    p = subprocess.Popen(['/usr/lib/vmware-vmdir/bin/vdcadmintool'], bufsize=1024,
+                    stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    (child_stdin, child_stdout, child_stderr) = (p.stdin, p.stdout, p.stderr)
+
+    buff = ''
+
+    while True:
+        p.poll()
+        if p.returncode is not None:
+            break
+        line = child_stderr.read(1)
+        buff += line.decode()
+        if buff[-50:] == ' Get vmdir log level and mask\n==================\n\n':
+            buff = ''
+            child_stdin.write(b"3\n")
+            child_stdin.flush()
+        if buff[-50:] == '  Please enter account UPN : ':
+            child_stdin.write(b"administrator@vsphere.local\n\n")
+            child_stdin.flush()
+            child_stdout.readline()
+            new_pw = child_stdout.readline()
+            return new_pw.decode().rstrip()
+
+while True:
+    new_pw = set_new_pw()
+    if '"' not in new_pw and "'" not in new_pw:
+        print(new_pw)
+        exit(0)
+    time.sleep(1)

--- a/roles/vmware-ci-set-passwords/tasks/main.yaml
+++ b/roles/vmware-ci-set-passwords/tasks/main.yaml
@@ -45,4 +45,5 @@
       fetch:
         src: "/tmp/esxi_password_{{ item.key }}.txt"
         dest: "{{ vmware_ci_set_passwords_secret_dir }}/"
+      no_log: true
       with_dict: "{{ hostvars.localhost.vmware_ci_set_passwords_passwords }}"

--- a/roles/vmware-ci-set-passwords/tasks/main.yaml
+++ b/roles/vmware-ci-set-passwords/tasks/main.yaml
@@ -1,0 +1,48 @@
+---
+- setup:
+    gather_subset: '!all'
+
+- name: Change users password (vcenter)
+  user:
+    name: "{{ item.key }}"
+    password: "{{ item.value | password_hash('sha512') }}"
+  no_log: true
+  with_dict: "{{ hostvars.localhost.vmware_ci_set_passwords_passwords }}"
+  become: true
+  when: ansible_system != 'VMkernel'
+
+- name: Change users password (ESXi)
+  shell: "echo {{ item.value }} | passwd -s {{ item.key }}"
+  with_dict: "{{ hostvars.localhost.vmware_ci_set_passwords_passwords }}"
+  no_log: true
+  when: ansible_system == 'VMkernel'
+
+- when: inventory_hostname == 'vcenter'
+  block:
+    - copy:
+        src: vcenter_set_password
+        dest: /tmp/vcenter_set_password
+        mode: '0700'
+      become: true
+
+    - copy:
+        content: "{{ item.value }}"
+        dest: "/tmp/esxi_password_{{ item.key }}.txt"
+      no_log: true
+      with_dict: "{{ hostvars.localhost.vmware_ci_set_passwords_passwords }}"
+
+    - name: Change the vCenter admin password
+      shell: "python /tmp/vcenter_set_password > /tmp/vcenter_password.txt"
+      become: true
+      no_log: true
+
+    - name: Collect the vcenter password
+      fetch:
+        src: "/tmp/vcenter_password.txt"
+        dest: "{{ vmware_ci_set_passwords_secret_dir }}/"
+
+    - name: Collect the ESXi password(s)
+      fetch:
+        src: "/tmp/esxi_password_{{ item.key }}.txt"
+        dest: "{{ vmware_ci_set_passwords_secret_dir }}/"
+      with_dict: "{{ hostvars.localhost.vmware_ci_set_passwords_passwords }}"

--- a/roles/vmware-ci-write-etc-hosts/handlers/main.yaml
+++ b/roles/vmware-ci-write-etc-hosts/handlers/main.yaml
@@ -1,0 +1,6 @@
+---
+- name: reboot vcenter
+  reboot:
+  become: true
+  when:
+    - inventory_hostname == 'vcenter'

--- a/roles/vmware-ci-write-etc-hosts/tasks/main.yaml
+++ b/roles/vmware-ci-write-etc-hosts/tasks/main.yaml
@@ -1,0 +1,31 @@
+---
+- setup:
+    gather_subset: '!all'
+
+- copy:
+    content: |
+      127.0.0.1 localhost
+      ::1 localhost
+      {% for host in ['datastore', 'esxi1', 'esxi2', 'esxi3', 'vcenter'] %}
+      {% if host in vmware_ci_write_etc_hosts_mapping and vmware_ci_write_etc_hosts_mapping[host] %}
+      {{ vmware_ci_write_etc_hosts_mapping[host] }} {{ host }}.test {{ host }}
+
+      {% endif %}
+      {% endfor %}
+    dest: /etc/hosts
+  register: etc_hosts_result
+  notify: reboot vcenter
+  become: "{{ ansible_system != 'VMkernel' }}"
+
+- when: ansible_hostname != inventory_hostname
+  block:
+    - name: set the correct ESXi hostname
+      command: "esxcli system hostname set --fqdn={{ inventory_hostname }}.test"
+      when: inventory_hostname.startswith("esxi")
+
+    - name: set the vCenter hostname
+      command: "hostnamectl set-hostname {{ inventory_hostname }}.test"
+      notify: reboot vcenter
+      when: inventory_hostname == 'vcenter'
+
+- meta: flush_handlers

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -50,5 +50,4 @@
       ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_1esxi/
       ansible_test_retry_on_error: true
-    attempts: 1
     timeout: 7200

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -40,3 +40,15 @@
     vars:
       ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_only/
+      ansible_test_retry_on_error: true
+
+- job:
+    name: ansible-test-cloud-integration-vcenter_1esxi-python36
+    parent: ansible-test-cloud-integration-vcenter
+    nodeset: vmware-vcsa_1esxi-6.7.0-python36
+    vars:
+      ansible_test_python: 3.6
+      ansible_test_integration_targets: zuul/vmware/vcenter_1esxi/
+      ansible_test_retry_on_error: true
+    attempts: 1
+    timeout: 7200

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -40,7 +40,6 @@
     vars:
       ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_only/
-      ansible_test_retry_on_error: true
 
 - job:
     name: ansible-test-cloud-integration-vcenter_1esxi-python36
@@ -49,5 +48,4 @@
     vars:
       ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_1esxi/
-      ansible_test_retry_on_error: true
     timeout: 10000

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -50,4 +50,4 @@
       ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_1esxi/
       ansible_test_retry_on_error: true
-    timeout: 7200
+    timeout: 10000

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -57,6 +57,25 @@
         nodes:
           - centos-8
 
+
+- nodeset:
+    name: vmware-vcsa_1esxi-6.7.0-python36
+    nodes:
+      - name: centos-8
+        label: centos-8-1vcpu
+      - name: vcenter
+        label: vmware-vcsa-6.7.0
+      - name: esxi1
+        label: esxi-6.7.0
+    groups:
+      - name: appliance
+        nodes:
+          - vcenter
+          - esxi1
+      - name: controller
+        nodes:
+          - centos-8
+
 # Ansible network appliance nodesets
 - nodeset:
     name: eos-4.20.10-python27

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1062,6 +1062,14 @@
               - ^test/integration/targets/vcenter_.*
               - ^test/integration/targets/.*vmware_.*
             voting: false
+        - ansible-test-cloud-integration-vcenter_1esxi-python36:
+            branches:
+              - devel
+            files:
+              - ^lib/ansible/modules/cloud/vmware/.*
+              - ^test/integration/targets/vcenter_.*
+              - ^test/integration/targets/.*vmware_.*
+            voting: false
 
 - project-template:
     name: noop-jobs


### PR DESCRIPTION
This rather large commit introduce a new vcenter job. This time, we have
an ESXi instance and this allow us to run most of the missing test
roles.

- We use the `zuul` of the ESXi instead of the classic `root`. This
  because the root account get hammered by SSH connection attempts, and
  ultimately... locked (in a couple seconds actually :-P).
- Some weird gymnastic around the vcenter password. vCenter generates it
  admin password itself, we cannot set one that we've generated before.
  The logic is wrapped in a role, this way we can reproduce/test out of
  Zuul.
- host names are enforced via /etc/hosts. vCenter is pathological picky
  with host reverse DNS. By changing the /etc/hosts, we can keep
  everything under control and reproductible. Here again, the logic is
  in a role.
- NFS server is also deployed using a role, to improve the resilience we
  should set-up some cache somewhere for the ISO images.
- The test-suite itself is known to fail. So `attempt` will remain at 1
  for now.