### PR TITLE
Run ansible-test from virtualenv

### DIFF
--- a/playbooks/ansible-test-integration-base/run.yaml
+++ b/playbooks/ansible-test-integration-base/run.yaml
@@ -79,4 +79,4 @@
         chdir: "{{ _test_location }}"
         executable: /bin/bash
       environment: "{{ ansible_test_environment | default({}) }}"
-      shell: "source ~/venv/bin/activate; {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/bin/ansible-test {{ ansible_test_command }} {{ _test_options }} --python {{ ansible_test_python }} -vvvv {{ ansible_test_integration_targets }}"
+      shell: "source ~/venv/bin/activate; ansible-test {{ ansible_test_command }} {{ _test_options }} --python {{ ansible_test_python }} -vvvv {{ ansible_test_integration_targets }}"

--- a/playbooks/ansible-test-network-integration-base/post.yaml
+++ b/playbooks/ansible-test-network-integration-base/post.yaml
@@ -1,0 +1,10 @@
+---
+- hosts: controller
+  tasks:
+    - name: Ensure controller directory exists
+      file:
+        path: "{{ ansible_user_dir }}/zuul-output/logs/controller/"
+        state: directory
+
+    - name: Copy appliance inventory file
+      shell: "cp {{ ansible_user_dir }}/inventory {{ ansible_user_dir }}/zuul-output/logs/controller/inventory"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -159,7 +159,9 @@
       - playbooks/ansible-test-integration-base/pre.yaml
       - playbooks/ansible-test-network-integration-base/pre.yaml
     run: playbooks/ansible-test-integration-base/run.yaml
-    post-run: playbooks/ansible-test-integration-base/post.yaml
+    post-run:
+      - playbooks/ansible-test-network-integration-base/post.yaml
+      - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
     timeout: 9000
@@ -213,7 +215,9 @@
       - playbooks/ansible-test-integration-base/pre.yaml
       - playbooks/ansible-test-network-integration-base/pre.yaml
     run: playbooks/ansible-test-integration-base/run.yaml
-    post-run: playbooks/ansible-test-integration-base/post.yaml
+    post-run:
+      - playbooks/ansible-test-network-integration-base/post.yaml
+      - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
     timeout: 9000
@@ -267,7 +271,9 @@
       - playbooks/ansible-test-integration-base/pre.yaml
       - playbooks/ansible-test-network-integration-base/pre.yaml
     run: playbooks/ansible-test-integration-base/run.yaml
-    post-run: playbooks/ansible-test-integration-base/post.yaml
+    post-run:
+      - playbooks/ansible-test-network-integration-base/post.yaml
+      - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
     timeout: 9000
@@ -345,7 +351,9 @@
       - playbooks/ansible-test-integration-base/pre.yaml
       - playbooks/ansible-test-network-integration-base/pre.yaml
     run: playbooks/ansible-test-integration-base/run.yaml
-    post-run: playbooks/ansible-test-integration-base/post.yaml
+    post-run:
+      - playbooks/ansible-test-network-integration-base/post.yaml
+      - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
     timeout: 9000
@@ -423,7 +431,9 @@
       - playbooks/ansible-test-integration-base/pre.yaml
       - playbooks/ansible-test-network-integration-base/pre.yaml
     run: playbooks/ansible-test-integration-base/run.yaml
-    post-run: playbooks/ansible-test-integration-base/post.yaml
+    post-run:
+      - playbooks/ansible-test-network-integration-base/post.yaml
+      - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
     timeout: 10800
@@ -447,7 +457,9 @@
       - playbooks/ansible-test-integration-base/pre.yaml
       - playbooks/ansible-test-network-integration-base/pre.yaml
     run: playbooks/ansible-test-integration-base/run.yaml
-    post-run: playbooks/ansible-test-integration-base/post.yaml
+    post-run:
+      - playbooks/ansible-test-network-integration-base/post.yaml
+      - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
     timeout: 3600
@@ -501,7 +513,9 @@
       - playbooks/ansible-test-integration-base/pre.yaml
       - playbooks/ansible-test-network-integration-base/pre.yaml
     run: playbooks/ansible-test-integration-base/run.yaml
-    post-run: playbooks/ansible-test-integration-base/post.yaml
+    post-run:
+      - playbooks/ansible-test-network-integration-base/post.yaml
+      - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
     timeout: 7200


### PR DESCRIPTION
We now upgrade ansible within the venv to latest speclative version, so
ansible-test can now be used from there too.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>