### PR TITLE
Add back some non-voting jobs for collections

### DIFF
--- a/playbooks/ansible-test-integration-base/pre.yaml
+++ b/playbooks/ansible-test-integration-base/pre.yaml
@@ -27,7 +27,12 @@
       shell: ~/venv/bin/pip install "ara<1.0.0"
 
     - name: Install ansible into virtualenv
+      shell: "~/venv/bin/pip install {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-collection-migration/ansible-minimal'].src_dir }}"
+      when: ansible_test_collections is defined
+
+    - name: Install ansible into virtualenv
       shell: "~/venv/bin/pip install {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
+      when: ansible_test_collections is not defined
 
     - name: Enable ARA callback plugin
       ini_file:

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -164,6 +164,7 @@
       - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible-collection-migration/ansible-minimal
     timeout: 9000
     vars:
       ansible_test_command: network-integration
@@ -220,6 +221,7 @@
       - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible-collection-migration/ansible-minimal
     timeout: 9000
     vars:
       ansible_test_command: network-integration
@@ -276,6 +278,7 @@
       - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible-collection-migration/ansible-minimal
     timeout: 9000
     vars:
       ansible_test_command: network-integration
@@ -356,6 +359,7 @@
       - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible-collection-migration/ansible-minimal
     timeout: 9000
     vars:
       ansible_test_command: network-integration
@@ -436,6 +440,7 @@
       - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible-collection-migration/ansible-minimal
     timeout: 10800
     vars:
       ansible_test_command: network-integration
@@ -462,6 +467,7 @@
       - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible-collection-migration/ansible-minimal
     timeout: 3600
     vars:
       ansible_test_command: network-integration
@@ -518,6 +524,7 @@
       - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible-collection-migration/ansible-minimal
     timeout: 7200
     vars:
       ansible_test_command: network-integration


### PR DESCRIPTION
Start with arista.eos and cisco.ios as non-voting jobs, now that we have
collections in place.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>