### PR TITLE
Add non-voting jobs for arista.eos / cisco.ios collections

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -35,6 +35,26 @@
     name: ansible-collections-arista-eos
     check:
       jobs:
+        - ansible-test-network-integration-eos-python27:
+            vars:
+              ansible_test_collections: true
+            voting: false
+        - ansible-test-network-integration-eos-python35:
+            vars:
+              ansible_test_collections: true
+            voting: false
+        - ansible-test-network-integration-eos-python36:
+            vars:
+              ansible_test_collections: true
+            voting: false
+        - ansible-test-network-integration-eos-python37:
+            vars:
+              ansible_test_collections: true
+            voting: false
+        - ansible-test-network-integration-eos-python38:
+            vars:
+              ansible_test_collections: true
+            voting: false
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-network/ansible_collections.ansible.netcommon
@@ -49,6 +69,26 @@
     name: ansible-collections-cisco-ios
     check:
       jobs:
+        - ansible-test-network-integration-ios-python27:
+            vars:
+              ansible_test_collections: true
+            voting: false
+        - ansible-test-network-integration-ios-python35:
+            vars:
+              ansible_test_collections: true
+            voting: false
+        - ansible-test-network-integration-ios-python36:
+            vars:
+              ansible_test_collections: true
+            voting: false
+        - ansible-test-network-integration-ios-python37:
+            vars:
+              ansible_test_collections: true
+            voting: false
+        - ansible-test-network-integration-ios-python38:
+            vars:
+              ansible_test_collections: true
+            voting: false
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-network/ansible_collections.ansible.netcommon


### PR DESCRIPTION
We are now ready to start running tests again.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/279
Signed-off-by: Paul Belanger <pabelanger@redhat.com>