### PR TITLE
Fix ansible-test on stable-2.8 jobs

### DIFF
--- a/playbooks/ansible-test-integration-base/run.yaml
+++ b/playbooks/ansible-test-integration-base/run.yaml
@@ -5,6 +5,15 @@
       set_fact:
         _test_location: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
 
+    - name: Setup location of ansible-test
+      set_fact:
+        _test_executable: "ansible-test"
+
+    - name: Setup location of ansible-test
+      set_fact:
+        _test_executable: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/bin/ansible-test"
+      when: zuul.projects['github.com/ansible/ansible'].checkout in ["stable-2.8"]
+
     - name: Setup base test_options
       set_fact:
         _test_options: "--continue-on-error --diff --requirements"
@@ -79,4 +88,4 @@
         chdir: "{{ _test_location }}"
         executable: /bin/bash
       environment: "{{ ansible_test_environment | default({}) }}"
-      shell: "source ~/venv/bin/activate; ansible-test {{ ansible_test_command }} {{ _test_options }} --python {{ ansible_test_python }} -vvvv {{ ansible_test_integration_targets }}"
+      shell: "source ~/venv/bin/activate; {{ _test_executable }} {{ ansible_test_command }} {{ _test_options }} --python {{ ansible_test_python }} -vvvv {{ ansible_test_integration_targets }}"


### PR DESCRIPTION
This fixes a regression in stable-2.8 jobs.
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/283

Signed-off-by: Paul Belanger <pabelanger@redhat.com>