### PR TITLE
Add dependency to build-ansible-minimal for collection jobs

### DIFF
--- a/playbooks/ansible-test-integration-base/pre.yaml
+++ b/playbooks/ansible-test-integration-base/pre.yaml
@@ -27,10 +27,6 @@
       shell: ~/venv/bin/pip install "ara<1.0.0"
 
     - name: Install ansible into virtualenv
-      shell: "~/venv/bin/pip install {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-collection-migration/ansible-minimal'].src_dir }}"
-      when: ansible_test_collections is defined
-
-    - name: Install ansible into virtualenv
       shell: "~/venv/bin/pip install {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
       when: ansible_test_collections is not defined
 

--- a/playbooks/ansible-test-integration-base/run.yaml
+++ b/playbooks/ansible-test-integration-base/run.yaml
@@ -42,6 +42,14 @@
             download_artifact_directory: ~/downloads
             download_artifact_type:
               - ansible_collection
+              - python_sdist
+
+        - name: Install ansible-minimal
+          args:
+            chdir: "{{ ansible_user_dir }}/downloads"
+          shell: "~/venv/bin/pip install {{ item.url | basename }}"
+          with_items: "{{ zuul.artifacts }}"
+          when: "'metadata' in item and 'type' in item.metadata and (item.metadata.type == 'python_sdist')"
 
         - name: Install jq
           become: true

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -154,6 +154,8 @@
     dependencies:
       - name: build-ansible-collection
         soft: true
+      - name: build-ansible-minimal
+        soft: true
     parent: ansible-network-eos-appliance
     pre-run:
       - playbooks/ansible-test-integration-base/pre.yaml
@@ -164,7 +166,6 @@
       - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
-      - name: github.com/ansible-collection-migration/ansible-minimal
     timeout: 9000
     vars:
       ansible_test_command: network-integration
@@ -211,6 +212,8 @@
     dependencies:
       - name: build-ansible-collection
         soft: true
+      - name: build-ansible-minimal
+        soft: true
     parent: ansible-network-ios-appliance
     pre-run:
       - playbooks/ansible-test-integration-base/pre.yaml
@@ -221,7 +224,6 @@
       - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
-      - name: github.com/ansible-collection-migration/ansible-minimal
     timeout: 9000
     vars:
       ansible_test_command: network-integration
@@ -268,6 +270,8 @@
     dependencies:
       - name: build-ansible-collection
         soft: true
+      - name: build-ansible-minimal
+        soft: true
     parent: ansible-network-iosxr-appliance
     pre-run:
       - playbooks/ansible-test-integration-base/pre.yaml
@@ -278,7 +282,6 @@
       - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
-      - name: github.com/ansible-collection-migration/ansible-minimal
     timeout: 9000
     vars:
       ansible_test_command: network-integration
@@ -349,6 +352,8 @@
     dependencies:
       - name: build-ansible-collection
         soft: true
+      - name: build-ansible-minimal
+        soft: true
     parent: ansible-network-junos-appliance
     pre-run:
       - playbooks/ansible-test-integration-base/pre.yaml
@@ -359,7 +364,6 @@
       - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
-      - name: github.com/ansible-collection-migration/ansible-minimal
     timeout: 9000
     vars:
       ansible_test_command: network-integration
@@ -430,6 +434,8 @@
     dependencies:
       - name: build-ansible-collection
         soft: true
+      - name: build-ansible-minimal
+        soft: true
     parent: ansible-network-nxos-appliance
     pre-run:
       - playbooks/ansible-test-integration-base/pre.yaml
@@ -440,7 +446,6 @@
       - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
-      - name: github.com/ansible-collection-migration/ansible-minimal
     timeout: 10800
     vars:
       ansible_test_command: network-integration
@@ -467,7 +472,6 @@
       - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
-      - name: github.com/ansible-collection-migration/ansible-minimal
     timeout: 3600
     vars:
       ansible_test_command: network-integration
@@ -514,6 +518,8 @@
     dependencies:
       - name: build-ansible-collection
         soft: true
+      - name: build-ansible-minimal
+        soft: true
     parent: ansible-network-vyos-appliance
     pre-run:
       - playbooks/ansible-test-integration-base/pre.yaml
@@ -524,7 +530,6 @@
       - playbooks/ansible-test-integration-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
-      - name: github.com/ansible-collection-migration/ansible-minimal
     timeout: 7200
     vars:
       ansible_test_command: network-integration

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -58,6 +58,7 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-network/ansible_collections.ansible.netcommon
+        - build-ansible-minimal
     gate:
       queue: integrated
       jobs:
@@ -92,6 +93,7 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-network/ansible_collections.ansible.netcommon
+        - build-ansible-minimal
     gate:
       queue: integrated
       jobs:


### PR DESCRIPTION
This now allows us to test proposed PRs to ansible/ansible and validate
ansible-minimal works as expected.

Depends-On: https://github.com/ansible-network/network_collections_migration/pull/28
Signed-off-by: Paul Belanger <pabelanger@redhat.com>