### PR TITLE
NXOS: Make `titanium` var bool

### DIFF
--- a/playbooks/ansible-test-network-integration-base/templates/inventory-nxos.j2
+++ b/playbooks/ansible-test-network-integration-base/templates/inventory-nxos.j2
@@ -26,4 +26,4 @@ nxos_int2="Ethernet1/2"
 nxos_int3="Ethernet1/3"
 platform="N9K"
 prepare_nxos_tests_task=false
-titanium=false
+titanium=False


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

- Ansible was considering `titanium` to be `str` instead of `bool`, which was breaking conditionals.