### PR TITLE
Default zuul jobs to ansible 2.9

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -3,7 +3,7 @@
     name: base
     parent: base-minimal
     abstract: true
-    ansible-version: 2.8
+    ansible-version: 2.9
     description: |
       The base job for the Ansible installation of Zuul.
     pre-run: playbooks/base/pre.yaml


### PR DESCRIPTION
Lets switch to ansible 2.9, as this is the latest stable version.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>