### PR TITLE
Rename version_compare to version

### DIFF
--- a/roles/configure-mirrors-fork/templates/fedora/etc/yum.repos.d/fedora-updates.repo.j2
+++ b/roles/configure-mirrors-fork/templates/fedora/etc/yum.repos.d/fedora-updates.repo.j2
@@ -2,7 +2,7 @@
 [updates]
 name=Fedora $releasever - $basearch - Updates
 failovermethod=priority
-{% if ansible_distribution_version | version_compare('28', '<') %}
+{% if ansible_distribution_version | version('28', '<') %}
 baseurl={{ package_mirror }}/updates/$releasever/$basearch/
 {% else %}
 baseurl={{ package_mirror }}/updates/$releasever/Everything/$basearch/
@@ -18,7 +18,7 @@ skip_if_unavailable=False
 [updates-debuginfo]
 name=Fedora $releasever - $basearch - Updates - Debug
 failovermethod=priority
-{% if ansible_distribution_version | version_compare('28', '<') %}
+{% if ansible_distribution_version | version('28', '<') %}
 baseurl={{ package_mirror }}/updates/$releasever/$basearch/debug/
 {% else %}
 baseurl={{ package_mirror }}/updates/$releasever/Everything/$basearch/debug/tree/
@@ -34,7 +34,7 @@ skip_if_unavailable=False
 [updates-source]
 name=Fedora $releasever - Updates Source
 failovermethod=priority
-{% if ansible_distribution_version | version_compare('28', '<') %}
+{% if ansible_distribution_version | version('28', '<') %}
 baseurl={{ package_mirror }}/updates/$releasever/SRPMS/
 {% else %}
 baseurl={{ package_mirror }}/updates/$releasever/Everything/source/tree/


### PR DESCRIPTION
This was done in ansible 2.5 and removed in ansible 2.9.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>