### PR TITLE
Add github-workflows job

### DIFF
--- a/playbooks/github-workflows/run.yaml
+++ b/playbooks/github-workflows/run.yaml
@@ -1,0 +1,15 @@
+---
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Check if project's .github/workflows exists
+      stat:
+        path: "{{ zuul.executor.src_root }}/{{ zuul.project.canonical_name }}/.github/workflows"
+      register: p
+
+    - name: File check failed
+      fail:
+        msg: "Your project contains GitHub workflow files (eg: .github/workflows). Unfortuantly,  GitHub does not allow GitHub applications the ability merge changes to these files. As a result, Zuul will not be able to merge your pull requests.  Please delete this folder."
+      when:
+        - p.stat.exists
+        - p.stat.isdir

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -9,6 +9,14 @@
     pre-run: playbooks/base/pre.yaml
 
 - job:
+    name: github-workflows
+    description: |
+      A job to validate no github workflow directory are found.
+    run: playbooks/github-workflows/run.yaml
+    nodeset:
+      nodes: []
+
+- job:
     name: ansible-tox-linters
     parent: tox-linters
     nodeset: centos-8-1vcpu

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1151,7 +1151,11 @@
     # Include a check queue so that initially every repo has a check queue
     # and we can report invalid zuul.yaml files.
     check:
-      jobs: []
+      jobs:
+        - github-workflows
+    gate:
+      jobs:
+        - github-workflows
     merge-check:
       jobs:
         - noop


### PR DESCRIPTION
All projects in github will have to run this job moving forward.
Basically, zuul will not be able to merge PRs with contain changes to
these files (.github/workflows). This appears to be a security feature
in github, but break automated gating in of commits in zuul.  This is
still true, if we completly disable github actions on repos.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>