### PR TITLE
Add dco-license job to system-required project-template

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1152,9 +1152,11 @@
     # and we can report invalid zuul.yaml files.
     check:
       jobs:
+        - dco-license
         - github-workflows
     gate:
       jobs:
+        - dco-license
         - github-workflows
     merge-check:
       jobs:


### PR DESCRIPTION
All commits to projects in zuul.ansible.com, should have dco-license
check.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>