### PR TITLE
Revert "Add dco-license job to system-required project-template"

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1152,11 +1152,9 @@
     # and we can report invalid zuul.yaml files.
     check:
       jobs:
-        - dco-license
         - github-workflows
     gate:
       jobs:
-        - dco-license
         - github-workflows
     merge-check:
       jobs:


### PR DESCRIPTION
Revert for now until we notifiy all projects we'll be enabling this.

This reverts commit 89cb5bfce2b4bda3c2a1dda233cac4b57e523024.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>