### PR TITLE
Enable --debug for ara generate html

### DIFF
--- a/playbooks/ansible-network-appliance-base/post.yaml
+++ b/playbooks/ansible-network-appliance-base/post.yaml
@@ -8,7 +8,7 @@
 
     - block:
         - name: Generate ARA HTML output
-          shell: ".tox/venv/bin/ara generate html {{ ansible_user_dir }}/zuul-output/logs/controller/ara-report"
+          shell: ".tox/venv/bin/ara --debug generate html {{ ansible_user_dir }}/zuul-output/logs/controller/ara-report"
           args:
             chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"
           environment:


### PR DESCRIPTION
When there is an ARA failure, we don't get much info. Add the --debug
flag to get more info.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>