### PR TITLE
Add -v to ssh-keyscan

### DIFF
--- a/playbooks/ansible-cloud/appliance-base/pre.yaml
+++ b/playbooks/ansible-cloud/appliance-base/pre.yaml
@@ -23,7 +23,7 @@
         search_regex: SSH
 
     - name: Ensure remote SSH host keys are known
-      shell: "ssh-keyscan {{hostvars[item].ansible_host }} >> ~/.ssh/known_hosts"
+      shell: "ssh-keyscan -v {{hostvars[item].ansible_host }} >> ~/.ssh/known_hosts"
       with_inventory_hostnames: appliance
 
     - name: Create /etc/ansible folder

--- a/playbooks/ansible-network-appliance-base/pre.yaml
+++ b/playbooks/ansible-network-appliance-base/pre.yaml
@@ -40,7 +40,7 @@
         search_regex: SSH
 
     - name: Ensure remote SSH host keys are known
-      shell: "ssh-keyscan -p {{ __ssh_port }} {{ __ssh_ip }} >> ~/.ssh/known_hosts"
+      shell: "ssh-keyscan -v -p {{ __ssh_port }} {{ __ssh_ip }} >> ~/.ssh/known_hosts"
 
     - name: Create /etc/ansible folder
       become: true

--- a/playbooks/ansible-test-network-integration-base/pre.yaml
+++ b/playbooks/ansible-test-network-integration-base/pre.yaml
@@ -20,7 +20,7 @@
         zuul_work_dir: "{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"
 
     - name: Ensure remote NETCONF SSH host keys are known
-      shell: "ssh-keyscan -t rsa -p 830 {{ hostvars[item].ansible_host }} >> ~/.ssh/known_hosts"
+      shell: "ssh-keyscan -v -t rsa -p 830 {{ hostvars[item].ansible_host }} >> ~/.ssh/known_hosts"
       when: hostvars[item].ansible_network_os in ['junos']
       with_inventory_hostnames: appliance
 


### PR DESCRIPTION
Sometime, our keyscan fails. Add -v to collect extra debug information.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>