### PR TITLE
Fix ansible-tox-molecule

### DIFF
--- a/playbooks/ansible-tox-molecule/post.yaml
+++ b/playbooks/ansible-tox-molecule/post.yaml
@@ -1,0 +1,12 @@
+---
+- hosts: all
+  tasks:
+    - name: Return artifact to Zuul
+      zuul_return:
+        data:
+          zuul:
+            artifacts:
+              - name: "Molecule report"
+                url: "tox/reports.html"
+                metadata:
+                  type: html_report

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -23,8 +23,9 @@
 
 - job:
     name: ansible-tox-molecule
-    parent: tox
+    parent: tox-molecule
     pre-run: playbooks/ansible-tox-molecule/pre.yaml
+    post-run: playbooks/ansible-tox-molecule/post.yaml
     vars:
       tox_envlist: molecule
     nodeset: fedora-latest-1vcpu


### PR DESCRIPTION
- corrects its parent to tox-molecule which also installs docker,
  the most common backend used by molecule
- adds post collection of html report made by tox -e molecule