### PR TITLE
Define reusable molecule jobs

### DIFF
--- a/playbooks/ansible-tox-molecule/pre.yaml
+++ b/playbooks/ansible-tox-molecule/pre.yaml
@@ -1,5 +1,20 @@
 ---
 - hosts: all
   tasks:
+
     - name: Reset SSH connection for new group
       meta: reset_connection
+
+    # TODO(ssbarnea): remove hack once upstream patch merges:
+    # https://review.opendev.org/#/c/703053/
+    - name: Workaround for yum --nobest with docker-ce
+      when:
+        - ansible_distribution == "CentOS"
+        - ansible_distribution_major_version == "8"
+      become: true
+      yum:
+        name: https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.6-3.3.el7.x86_64.rpm
+
+    - name: Install docker
+      include_role:
+        name: install-docker

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -22,10 +22,26 @@
     nodeset: centos-8-1vcpu
 
 - job:
-    name: ansible-tox-molecule
-    parent: tox-molecule
+    name: ansible-tox-docs
+    parent: tox-docs
+    nodeset: centos-8-1vcpu
+
+- job: &ansible-tox-molecule-base
+    name: ansible-tox-molecule-base
+    # Stub job used to define only properties specific to molecule jobs,
+    # expected to decorate other job definitions via anchors. To avoid overrides
+    # it does *not* have: nodeset, abstract, description
     pre-run: playbooks/ansible-tox-molecule/pre.yaml
     post-run: playbooks/ansible-tox-molecule/post.yaml
+    timeout: 5400  # 1.5h as they are expected to be slower by nature
+
+- job:
+    <<: *ansible-tox-molecule-base
+    name: ansible-tox-molecule
+    description: |
+      Generic molecule jobs that does not specify which python version will
+      be using, recommended when that is not important.
+    parent: tox-molecule
     vars:
       tox_envlist: molecule
     nodeset: fedora-latest-1vcpu
@@ -592,3 +608,42 @@
     nodeset: vyos-1.1.8-python38
     vars:
       ansible_test_python: 3.8
+
+# molecule- prefixed jobs match ansible- ones but also enable extra
+# virtualization services that are use by molecule, like docker, podman (TBD)
+# or libvirt (TBD).
+
+- job:
+    <<: *ansible-tox-molecule-base
+    name: molecule-tox-linters
+    parent: ansible-tox-linters
+
+- job:
+    <<: *ansible-tox-molecule-base
+    name: molecule-tox-docs
+    parent: ansible-tox-docs
+
+- job:
+    <<: *ansible-tox-molecule-base
+    name: molecule-tox-py27
+    parent: ansible-tox-py27
+
+- job:
+    <<: *ansible-tox-molecule-base
+    name: molecule-tox-py35
+    parent: ansible-tox-py35
+
+- job:
+    <<: *ansible-tox-molecule-base
+    name: molecule-tox-py36
+    parent: ansible-tox-py36
+
+- job:
+    <<: *ansible-tox-molecule-base
+    name: molecule-tox-py37
+    parent: ansible-tox-py37
+
+- job:
+    <<: *ansible-tox-molecule-base
+    name: molecule-tox-py38
+    parent: ansible-tox-py38


### PR DESCRIPTION
These jobs should match ansible- ones but also run with docker
enabled.

They rely on YAML 1.1 merge keys feature,... hoping that it will work.
http://blogs.perl.org/users/tinita/2019/05/reusing-data-with-yaml-anchors-aliases-and-merge-keys.html

Needed-By: https://github.com/ansible/molecule/pull/2486