### PR TITLE
Add build-ansible-minimal to collections

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -65,6 +65,7 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-network/ansible_collections.ansible.netcommon
+        - build-ansible-minimal
 
 - project-template:
     name: ansible-collections-cisco-ios
@@ -100,6 +101,7 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-network/ansible_collections.ansible.netcommon
+        - build-ansible-minimal
 
 - project-template:
     name: ansible-collections-cisco-iosxr
@@ -133,12 +135,14 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-network/ansible_collections.ansible.netcommon
+        - build-ansible-minimal
     gate:
       queue: integrated
       jobs:
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-network/ansible_collections.ansible.netcommon
+        - build-ansible-minimal
 
 - project-template:
     name: ansible-collections-cisco-iosxr-netconf
@@ -163,12 +167,14 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-network/ansible_collections.ansible.netcommon
+        - build-ansible-minimal
     gate:
       queue: integrated
       jobs:
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-network/ansible_collections.ansible.netcommon
+        - build-ansible-minimal
 
 - project-template:
     name: ansible-collections-juniper-junos-netconf
@@ -213,13 +219,14 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-network/ansible_collections.ansible.netcommon
+        - build-ansible-minimal
     gate:
       queue: integrated
       jobs:
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-network/ansible_collections.ansible.netcommon
-
+        - build-ansible-minimal
 
 - project-template:
     name: ansible-test-network-integration


### PR DESCRIPTION
Until new ansible version is released, we need to build minimal version
for collection testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>