### PR TITLE
Add junipernetworks.junos to iosxr-netconf jobs

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -166,16 +166,18 @@
             voting: false
         - build-ansible-collection:
             required-projects:
-              - name: github.com/ansible-network/ansible_collections.cisco.iosxr
               - name: github.com/ansible-network/ansible_collections.ansible.netcommon
+              - name: github.com/ansible-network/ansible_collections.cisco.iosxr
+              - name: github.com/ansible-network/ansible_collections.junipernetworks.junos
         - build-ansible-minimal
     gate:
       queue: integrated
       jobs:
         - build-ansible-collection:
             required-projects:
-              - name: github.com/ansible-network/ansible_collections.cisco.iosxr
               - name: github.com/ansible-network/ansible_collections.ansible.netcommon
+              - name: github.com/ansible-network/ansible_collections.cisco.iosxr
+              - name: github.com/ansible-network/ansible_collections.junipernetworks.junos
         - build-ansible-minimal
 
 - project-template:


### PR DESCRIPTION
This is a requirement right now, to run netconf tests.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>