### PR TITLE
Migrate python36 network jobs to fedora-31

### DIFF
--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -125,8 +125,8 @@
 - nodeset:
     name: eos-4.20.10-python37
     nodes:
-      - name: fedora-30
-        label: fedora-30-1vcpu
+      - name: fedora-31
+        label: fedora-31-1vcpu
       - name: eos-4.20.10
         label: eos-4.20.10
     groups:
@@ -135,7 +135,7 @@
           - eos-4.20.10
       - name: controller
         nodes:
-          - fedora-30
+          - fedora-31
 
 - nodeset:
     name: eos-4.20.10-python38
@@ -200,8 +200,8 @@
 - nodeset:
     name: ios-15.6-2T-python37
     nodes:
-      - name: fedora-30
-        label: fedora-30-1vcpu
+      - name: fedora-31
+        label: fedora-31-1vcpu
       - name: ios-15.6-2T
         label: ios-15.6-2T
     groups:
@@ -210,7 +210,7 @@
           - ios-15.6-2T
       - name: controller
         nodes:
-          - fedora-30
+          - fedora-31
 
 - nodeset:
     name: ios-15.6-2T-python38
@@ -275,8 +275,8 @@
 - nodeset:
     name: iosxr-6.1.3-python37
     nodes:
-      - name: fedora-30
-        label: fedora-30-1vcpu
+      - name: fedora-31
+        label: fedora-31-1vcpu
       - name: iosxr-6.1.3
         label: iosxrv-6.1.3
     groups:
@@ -285,7 +285,7 @@
           - iosxr-6.1.3
       - name: controller
         nodes:
-          - fedora-30
+          - fedora-31
 
 - nodeset:
     name: iosxr-6.1.3-python38
@@ -365,8 +365,8 @@
 - nodeset:
     name: openvswitch-2.9.0-python37
     nodes:
-      - name: fedora-30
-        label: fedora-30-1vcpu
+      - name: fedora-31
+        label: fedora-31-1vcpu
       - name: openvswitch-2.9.0
         label: ubuntu-bionic-1vcpu
     groups:
@@ -375,7 +375,7 @@
           - openvswitch-2.9.0
       - name: controller
         nodes:
-          - fedora-30
+          - fedora-31
 
 - nodeset:
     name: openvswitch-2.9.0-python38
@@ -440,8 +440,8 @@
 - nodeset:
     name: vqfx-18.1R3-python37
     nodes:
-      - name: fedora-30
-        label: fedora-30-1vcpu
+      - name: fedora-31
+        label: fedora-31-1vcpu
       - name: vqfx-18.1R3
         label: vqfx-18.1R3
     groups:
@@ -450,7 +450,7 @@
           - vqfx-18.1R3
       - name: controller
         nodes:
-          - fedora-30
+          - fedora-31
 
 - nodeset:
     name: vqfx-18.1R3-python38
@@ -515,8 +515,8 @@
 - nodeset:
     name: vsrx3-18.4R1-python37
     nodes:
-      - name: fedora-30
-        label: fedora-30-1vcpu
+      - name: fedora-31
+        label: fedora-31-1vcpu
       - name: vsrx3-18.4R1
         label: vsrx3-18.4R1
     groups:
@@ -525,7 +525,7 @@
           - vsrx3-18.4R1
       - name: controller
         nodes:
-          - fedora-30
+          - fedora-31
 
 - nodeset:
     name: vsrx3-18.4R1-python38
@@ -590,8 +590,8 @@
 - nodeset:
     name: vyos-1.1.8-python37
     nodes:
-      - name: fedora-30
-        label: fedora-30-1vcpu
+      - name: fedora-31
+        label: fedora-31-1vcpu
       - name: vyos-1.1.8
         label: vyos-1.1.8-1vcpu
     groups:
@@ -600,7 +600,7 @@
           - vyos-1.1.8
       - name: controller
         nodes:
-          - fedora-30
+          - fedora-31
 
 - nodeset:
     name: vyos-1.1.8-python38


### PR DESCRIPTION
We are preparing to remove fedora-30, as fedora-31 is latest stable.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>