### PR TITLE
Update build-python-tarball jobs

### DIFF
--- a/playbooks/ansible-build-python-tarball/pre.yaml
+++ b/playbooks/ansible-build-python-tarball/pre.yaml
@@ -1,6 +1,11 @@
 ---
 - hosts: all
   tasks:
+    - name: Run bindep role
+      include_role:
+        name: bindep
+
+    # NOTE(pabelanger): We should consider pushing this into bindep.txt file, as build dependency.
     - name: Ensure python3-wheel is installed
       become: true
       package:

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -82,7 +82,7 @@
       Test building python tarballs / wheels and the packaging metadata
     pre-run: playbooks/ansible-build-python-tarball/pre.yaml
     run: playbooks/ansible-build-python-tarball/run.yaml
-    nodeset: fedora-latest-1vcpu
+    nodeset: centos-8-1vcpu
     vars:
       release_python: python3
       bdist_wheel_xargs: "--universal"


### PR DESCRIPTION
We can now move to centos-8 as nodeset for building wheels, this is
becauea of python3 support.  Also, drop custom package install in favor
of bindep.txt files.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>