### PR TITLE
configure-swap: create the swapfile only once

### DIFF
--- a/roles/configure-swap/tasks/main.yaml
+++ b/roles/configure-swap/tasks/main.yaml
@@ -1,7 +1,13 @@
 ---
+- name: Check if swapfile exists
+  stat:
+    path: /root/swapfile
+  become: true
+  register: swapfile_result
 - include: root.yaml
   static: false
   when:
+    - not swapfile_result.stat.exists
     - configure_swap_current_total | int + 10 <= configure_swap_size
 
 # ensure a standard level of swappiness.  Some platforms


### PR DESCRIPTION
Do not try (and fail) to recreate the swapfile if it already exists.

Signed-off-by: Gonéri Le Bouder <goneri@lebouder.net>