### PR TITLE
vcenter: no dep on ansible_memory_mb

### DIFF
--- a/roles/configure-swap/defaults/main.yaml
+++ b/roles/configure-swap/defaults/main.yaml
@@ -1,3 +1,4 @@
 ---
 # Default swap partition/file size, in MiB
 configure_swap_size: 8192
+configure_swap_current_total: "{{ ansible_memory_mb['swap']['total'] }}"

--- a/roles/configure-swap/tasks/main.yaml
+++ b/roles/configure-swap/tasks/main.yaml
@@ -2,7 +2,7 @@
 - include: root.yaml
   static: false
   when:
-    - ansible_memory_mb['swap']['total'] | int + 10 <= configure_swap_size
+    - configure_swap_current_total | int + 10 <= configure_swap_size
 
 # ensure a standard level of swappiness.  Some platforms
 # (rax+centos7) come with swappiness of 0 (presumably because the

--- a/roles/configure-swap/tasks/root.yaml
+++ b/roles/configure-swap/tasks/root.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Calculate required swap
   set_fact:
-    swap_required: "{{ configure_swap_size - ansible_memory_mb['swap']['total'] | int }}"
+    swap_required: "{{ configure_swap_size - configure_swap_current_total | int }}"
 
 - block:
     - name: Get root filesystem


### PR DESCRIPTION
Avoid the hardcoded dependency on `ansible_memory_mb` fact. This because
we reach an OutOfMemory exception when we try to collect it on `vcenter`
VM:

```
2020-01-15 19:54:36.698236 | vcenter | {"rc": 12, "cmd": "/usr/bin/udevadm info --query property --name /dev/vda1", "msg": "[Errno 12] Cannot allocate memory", "failed": true, "invocation": {"module_args": {"gather_subset": ["hardware"], "filter": "*", "fact_path": "/etc/ansible/facts.d", "gather_timeout": 10}}}
```

Signed-off-by: Gonéri Le Bouder <goneri@lebouder.net>