### PR TITLE
vmware: use a group to find the ESXi IP

### DIFF
--- a/playbooks/ansible-test-cloud-integration-base/pre.yaml
+++ b/playbooks/ansible-test-cloud-integration-base/pre.yaml
@@ -12,8 +12,8 @@
         tox_install_siblings: false
         zuul_work_dir: "{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"
 
-
     - name: Restore the cache files for the NFS datastore
+      when: "'esxis' in groups"
       block:
         - name: Create the ISO directory
           file:
@@ -38,14 +38,11 @@
             group: '1000'
           become: true
 
-
-    - name: Prepare the NFS datastore
-      import_role:
-        name: vmware-ci-nfs-share
-      vars:
-        vmware_ci_nfs_share_allow_ips:
-          - "{{ hostvars['esxi1']['nodepool']['interface_ip'] }}"
-      when: "'esxi1' in hostvars"
+        - name: Prepare the NFS datastore
+          import_role:
+            name: vmware-ci-nfs-share
+          vars:
+            vmware_ci_nfs_share_allow_ips: "{{ groups['esxis'] | map('extract', hostvars, ['nodepool'])|map(attribute='interface_ip')|list }}"
 
     - name: Write the configuration for ansible-test
       import_role:

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -72,9 +72,13 @@
         nodes:
           - vcenter
           - esxi1
+      - name: esxis
+        nodes:
+          - esxi1
       - name: controller
         nodes:
           - centos-8
+
 
 # Ansible network appliance nodesets
 - nodeset:


### PR DESCRIPTION
Use the new `esxis` group to find the IP address of the ESXi host. We
pass the list when we configure the NFS share.
Only enable the NFS share when hosts exist.

Signed-off-by: Gonéri Le Bouder <goneri@lebouder.net>