### PR TITLE
vcenter_1esxi-python36: bump timeout to 10800s

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -48,7 +48,8 @@
     vars:
       ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_1esxi/
-    timeout: 10000
+    # 5h
+    timeout: 10800
 
 - job:
     name: ansible-test-cloud-integration-vcenter_2esxi-python36


### PR DESCRIPTION
The last run with the previous timeout has failed during
`vmware_vm_info` test.