### PR TITLE
vmware-ci-set-passwords: blacklist % and \

### DIFF
--- a/roles/vmware-ci-set-passwords/files/vcenter_set_password
+++ b/roles/vmware-ci-set-passwords/files/vcenter_set_password
@@ -18,7 +18,7 @@ import subprocess
 
 import time
 
-CHARACTER_BLACKLIST = ["\\", "'", '"', '%']
+CHARACTER_BLACKLIST = ["\\", "'", '"', '%', '{', '}']
 
 
 def set_new_pw():

--- a/roles/vmware-ci-set-passwords/files/vcenter_set_password
+++ b/roles/vmware-ci-set-passwords/files/vcenter_set_password
@@ -18,10 +18,16 @@ import subprocess
 
 import time
 
+CHARACTER_BLACKLIST = ["\\", "'", '"', '%']
+
 
 def set_new_pw():
-    p = subprocess.Popen(['/usr/lib/vmware-vmdir/bin/vdcadmintool'], bufsize=1024,
-                    stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(
+            ['/usr/lib/vmware-vmdir/bin/vdcadmintool'],
+            bufsize=1024,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
     (child_stdin, child_stdout, child_stderr) = (p.stdin, p.stdout, p.stderr)
 
     buff = ''
@@ -45,7 +51,9 @@ def set_new_pw():
 
 while True:
     new_pw = set_new_pw()
-    if '"' not in new_pw and "'" not in new_pw:
-        print(new_pw)
-        exit(0)
-    time.sleep(1)
+    found = [c for c in CHARACTER_BLACKLIST if c in new_pw]
+    if found:
+        time.sleep(0.1)
+        continue
+    print(new_pw)
+    exit(0)


### PR DESCRIPTION
Blacklist \ to avoid any problem later during the test execution. Also
remove % to any interpolation syntax error with ConfigParser. This being
said, the interpolation issue should not happen anymore since
https://github.com/ansible/ansible/commit/c4bb38d2b1b69c8bdafd8df1e03889ec0c85b555.

Example of a job with a problematic password: https://object-storage-ca-ymq-1.vexxhost.net/v1/a0b4156a37f9453eb4ec7db5422272df/ansible_66/66366/fcb73a4e35b8e6fdff259925581b976dfda238f8/third-party-check/ansible-test-cloud-integration-vcenter_only-python36/ed1fce5/controller/ara-report/