### PR TITLE
Remove universal from ansible-build-python-tarball

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -86,7 +86,6 @@
     nodeset: centos-8-1vcpu
     vars:
       release_python: python3
-      bdist_wheel_xargs: "--universal"
 
 - job:
     name: ansible-network-appliance-base


### PR DESCRIPTION
It is possible for some projects to not support universal wheels, this
can be configured per each project as needed.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>