### PR TITLE
vmware: turn voting on for stable jobs

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1177,7 +1177,6 @@
               - ^lib/ansible/modules/cloud/vmware/.*
               - ^test/integration/targets/vcenter_.*
               - ^test/integration/targets/.*vmware_.*
-            voting: false
         - ansible-test-cloud-integration-vcenter_1esxi-python36:
             branches:
               - devel
@@ -1193,7 +1192,6 @@
               - ^lib/ansible/modules/cloud/vmware/.*
               - ^test/integration/targets/vcenter_.*
               - ^test/integration/targets/.*vmware_.*
-            voting: false
 
 - project-template:
     name: noop-jobs


### PR DESCRIPTION
Turn on the "voting mode" on for the following jobs, they are stable enough:

- ansible-test-cloud-integration-vcenter_only-python36
- ansible-test-cloud-integration-vcenter_2esxi-python36