### PR TITLE
Use ansible-galaxy from ansible-base venv

### DIFF
--- a/playbooks/ansible-test-integration-base/run.yaml
+++ b/playbooks/ansible-test-integration-base/run.yaml
@@ -69,7 +69,7 @@
           args:
             chdir: "{{ ansible_user_dir }}/downloads"
             executable: /bin/bash
-          shell: "source ~/venv/bin/activate; {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/bin/ansible-galaxy collection install -p ~/.ansible/collection {{ item.url | basename }}"
+          shell: "source ~/venv/bin/activate; ansible-galaxy collection install -p ~/.ansible/collection {{ item.url | basename }}"
           with_items: "{{ zuul.artifacts }}"
           when: "'metadata' in item and 'type' in item.metadata and (item.metadata.type == 'ansible_collection')"
 


### PR DESCRIPTION
We need to use ansible-galaxy CLI, from ansible-base to install our
collections. Otherwise, we have to pin to say ansible-2.9 version.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>