### PR TITLE
Revert "Update centos mirrors to limestonenetwork"

### DIFF
--- a/roles/configure-mirrors-fork/vars/CentOS.yaml
+++ b/roles/configure-mirrors-fork/vars/CentOS.yaml
@@ -1,3 +1,3 @@
 ---
-epel_mirror: http://fedora-epel.mirror.lstn.net
-package_mirror: http://centos.mirror.lstn.net
+epel_mirror: https://mirror.csclub.uwaterloo.ca/fedora/epel
+package_mirror: https://mirror.csclub.uwaterloo.ca/centos


### PR DESCRIPTION
It looks like limestone is having an outage.

This reverts commit 94aa4c6fb7a49bf16a3be7869ba05b941c50df2b.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>