### PR TITLE
Set network collections job voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -38,23 +38,18 @@
         - ansible-test-network-integration-eos-python27:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-eos-python35:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-eos-python36:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-eos-python37:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-eos-python38:
             vars:
               ansible_test_collections: true
-            voting: false
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
@@ -62,6 +57,21 @@
     gate:
       queue: integrated
       jobs:
+        - ansible-test-network-integration-eos-python27:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-eos-python35:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-eos-python36:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-eos-python37:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-eos-python38:
+            vars:
+              ansible_test_collections: true
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
@@ -74,23 +84,18 @@
         - ansible-test-network-integration-ios-python27:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-ios-python35:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-ios-python36:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-ios-python37:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-ios-python38:
             vars:
               ansible_test_collections: true
-            voting: false
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
@@ -98,6 +103,21 @@
     gate:
       queue: integrated
       jobs:
+        - ansible-test-network-integration-ios-python27:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-ios-python35:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-ios-python36:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-ios-python37:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-ios-python38:
+            vars:
+              ansible_test_collections: true
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
@@ -212,27 +232,22 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-            voting: false
         - ansible-test-network-integration-junos-vsrx-python35:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-            voting: false
         - ansible-test-network-integration-junos-vsrx-python36:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-            voting: false
         - ansible-test-network-integration-junos-vsrx-python37:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-            voting: false
         - ansible-test-network-integration-junos-vsrx-python38:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-            voting: false
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
@@ -240,6 +255,26 @@
     gate:
       queue: integrated
       jobs:
+        - ansible-test-network-integration-junos-vsrx-python27:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-python35:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-python36:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-python37:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-python38:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
@@ -252,23 +287,18 @@
         - ansible-test-network-integration-junos-vsrx-netconf-python27:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-junos-vsrx-netconf-python35:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-junos-vsrx-netconf-python36:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-junos-vsrx-netconf-python37:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-junos-vsrx-netconf-python38:
             vars:
               ansible_test_collections: true
-            voting: false
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
@@ -278,6 +308,21 @@
     gate:
       queue: integrated
       jobs:
+        - ansible-test-network-integration-junos-vsrx-netconf-python27:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-junos-vsrx-netconf-python35:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-junos-vsrx-netconf-python36:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-junos-vsrx-netconf-python37:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-junos-vsrx-netconf-python38:
+            vars:
+              ansible_test_collections: true
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
@@ -292,23 +337,18 @@
         - ansible-test-network-integration-openvswitch-python27:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-openvswitch-python35:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-openvswitch-python36:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-openvswitch-python37:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-openvswitch-python38:
             vars:
               ansible_test_collections: true
-            voting: false
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
@@ -316,6 +356,21 @@
     gate:
       queue: integrated
       jobs:
+        - ansible-test-network-integration-openvswitch-python27:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-openvswitch-python35:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-openvswitch-python36:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-openvswitch-python37:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-openvswitch-python38:
+            vars:
+              ansible_test_collections: true
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
@@ -328,23 +383,18 @@
         - ansible-test-network-integration-vyos-python27:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-vyos-python35:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-vyos-python36:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-vyos-python37:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-vyos-python38:
             vars:
               ansible_test_collections: true
-            voting: false
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
@@ -352,6 +402,21 @@
     gate:
       queue: integrated
       jobs:
+        - ansible-test-network-integration-vyos-python27:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-vyos-python35:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-vyos-python36:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-vyos-python37:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-vyos-python38:
+            vars:
+              ansible_test_collections: true
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon


### PR DESCRIPTION
Now that we have completed the final sync from ansible/ansible we can
enable all jobs and start to properly gate.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>