### PR TITLE
remove vmware test from ansible/ansible

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1295,27 +1295,6 @@
               - ^lib/ansible/plugins/terminal/vyos.py
               - ^test/integration/targets/vyos_.*
               - ^test/integration/targets/prepare_vyos_tests/.*
-        - ansible-test-cloud-integration-vcenter_only-python36:
-            branches:
-              - devel
-            files:
-              - ^lib/ansible/modules/cloud/vmware/.*
-              - ^test/integration/targets/vcenter_.*
-              - ^test/integration/targets/.*vmware_.*
-        - ansible-test-cloud-integration-vcenter_1esxi-python36:
-            branches:
-              - devel
-            files:
-              - ^lib/ansible/modules/cloud/vmware/.*
-              - ^test/integration/targets/vcenter_.*
-              - ^test/integration/targets/.*vmware_.*
-        - ansible-test-cloud-integration-vcenter_2esxi-python36:
-            branches:
-              - devel
-            files:
-              - ^lib/ansible/modules/cloud/vmware/.*
-              - ^test/integration/targets/vcenter_.*
-              - ^test/integration/targets/.*vmware_.*
 
 - project-template:
     name: noop-jobs


### PR DESCRIPTION
Do not run ansible-test-cloud-integration-vcenter_only-python36 jobs
on ansible/ansible anymore.