### PR TITLE
Remove periodic devel jobs for network

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -567,142 +567,100 @@
       jobs:
         - ansible-test-network-integration-eos-python27:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
         - ansible-test-network-integration-eos-python35:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
         - ansible-test-network-integration-eos-python36:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
         - ansible-test-network-integration-eos-python37:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
-        - ansible-test-network-integration-eos-python38:
-            branches:
-              - devel
         - ansible-test-network-integration-ios-python27:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
         - ansible-test-network-integration-ios-python35:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
         - ansible-test-network-integration-ios-python36:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
         - ansible-test-network-integration-ios-python37:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
-        - ansible-test-network-integration-ios-python38:
-            branches:
-              - devel
         - ansible-test-network-integration-iosxr-python27:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
         - ansible-test-network-integration-iosxr-python35:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
         - ansible-test-network-integration-iosxr-python36:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
         - ansible-test-network-integration-iosxr-python37:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
-        - ansible-test-network-integration-iosxr-python38:
-            branches:
-              - devel
         - ansible-test-network-integration-junos-vsrx-python27:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
         - ansible-test-network-integration-junos-vsrx-python35:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
         - ansible-test-network-integration-junos-vsrx-python36:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
         - ansible-test-network-integration-junos-vsrx-python37:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
-        - ansible-test-network-integration-junos-vsrx-python38:
-            branches:
-              - devel
         - ansible-test-network-integration-openvswitch-python27:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
         - ansible-test-network-integration-openvswitch-python35:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
         - ansible-test-network-integration-openvswitch-python36:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
         - ansible-test-network-integration-openvswitch-python37:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
-        - ansible-test-network-integration-openvswitch-python38:
-            branches:
-              - devel
         - ansible-test-network-integration-vyos-python27:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
         - ansible-test-network-integration-vyos-python35:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
         - ansible-test-network-integration-vyos-python36:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
         - ansible-test-network-integration-vyos-python37:
             branches:
-              - devel
               - stable-2.9
               - stable-2.8
-        - ansible-test-network-integration-vyos-python38:
-            branches:
-              - devel
     third-party-check:
       jobs:
         - ansible-test-network-integration-eos-python27:


### PR DESCRIPTION
Now that we have moved to collections, we no longer need to run these
jobs on devel.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>