### PR TITLE
fetch artifacts when ansible_test_collections is True

### DIFF
--- a/playbooks/ansible-test-integration-base/run.yaml
+++ b/playbooks/ansible-test-integration-base/run.yaml
@@ -4,6 +4,7 @@
     - name: Fetch and install the artifacts
       import_role:
         name: deploy-artifacts
+      when: ansible_test_collections | default(False)
     - name: Run ansible-test
       import_role:
         name: ansible-test

--- a/roles/ansible-test/tasks/main.yaml
+++ b/roles/ansible-test/tasks/main.yaml
@@ -7,14 +7,14 @@
 
 - name: Enable --requirements
   set_fact:
-    _test_options: "{{ _test_options }} --requirements"
+    ansible_test_options: "{{ ansible_test_options }} --requirements"
   when: not ansible_test_collections
 
 - name: Prepare ansible-test parameters
   import_tasks: init_test_options.yaml
 
 - name: Single ansible mode
-  import_tasks: init_collection.yaml
+  import_tasks: init_single_mode.yaml
   when: not ansible_test_collections
 
 - name: Ansible with collections


### PR DESCRIPTION
- Only download the artifacts when `ansible_test_collections` is `True`. This
  was the behaviour before d2322e4729ffb8e362d2dca2b0ce981c88f4994d.
- ansible-test: Use `ansible_test_options` instead of `_test_options`
- Finally, correctly calls `init_single_mode.yaml` when `ansible_test_collections` is `False`
