### PR TITLE
add vmware-vcsa_1esxi-6.7.0-python36_exp nodeset

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -57,6 +57,17 @@
     timeout: 10800
 
 - job:
+    name: ansible-test-cloud-integration-vcenter_1esxi-python36_exp
+    parent: ansible-test-cloud-integration-vcenter
+    nodeset: vmware-vcsa_1esxi-6.7.0-python36_exp
+    vars:
+      ansible_test_python: 3.6
+      ansible_test_integration_targets: zuul/vmware/vcenter_1esxi/
+    # 5h
+    timeout: 10800
+    voting: false
+
+- job:
     name: ansible-test-cloud-integration-vcenter_2esxi-python36
     parent: ansible-test-cloud-integration-vcenter
     nodeset: vmware-vcsa_2esxi-6.7.0-python36

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -79,6 +79,27 @@
           - centos-8
 
 - nodeset:
+    name: vmware-vcsa_1esxi-6.7.0-python36_exp
+    nodes:
+      - name: centos-8
+        label: centos-8-1vcpu
+      - name: vcenter
+        label: vmware-vcsa-6.7.0
+      - name: esxi1
+        label: esxi-6.7.0_exp
+    groups:
+      - name: appliance
+        nodes:
+          - vcenter
+          - esxi1
+      - name: esxis
+        nodes:
+          - esxi1
+      - name: controller
+        nodes:
+          - centos-8
+
+- nodeset:
     name: vmware-vcsa_2esxi-6.7.0-python36
     nodes:
       - name: centos-8


### PR DESCRIPTION
Depends-On: https://github.com/ansible-network/windmill-config/pull/608

This is an temporary nodeset to test the new v2-standard-N-iops flavor
from Vexxhost.