### PR TITLE
Make ansible-collections-cisco-asa Python35 jobs Non-Voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -86,7 +86,7 @@
               ansible_test_collections: true
         - ansible-test-network-integration-asa-python35:
             vars:
-              ansible_test_collections: true
+              ansible_test_collections: false
         - ansible-test-network-integration-asa-python36:
             vars:
               ansible_test_collections: true
@@ -104,9 +104,6 @@
       queue: integrated
       jobs:
         - ansible-test-network-integration-asa-python27:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-asa-python35:
             vars:
               ansible_test_collections: true
         - ansible-test-network-integration-asa-python36:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -86,7 +86,8 @@
               ansible_test_collections: true
         - ansible-test-network-integration-asa-python35:
             vars:
-              ansible_test_collections: false
+              ansible_test_collections: true
+            voting: false
         - ansible-test-network-integration-asa-python36:
             vars:
               ansible_test_collections: true


### PR DESCRIPTION
Make ansible-collections-cisco-asa Python35 jobs Non-Voting as it's getting to Retry_Limit state every-time, which is happening coz Cisco ASA comes with `diffie-hellman-group14-sha256` and that isn't supported on Ubuntu Xenial where currently python35 setup is configured. So making py35 non-voting for the PR to be allowed to merged.