### PR TITLE
Remove ansible-base tarball install

### DIFF
--- a/playbooks/ansible-test-integration-base/pre.yaml
+++ b/playbooks/ansible-test-integration-base/pre.yaml
@@ -28,4 +28,3 @@
 
     - name: Install ansible into virtualenv
       shell: "~/venv/bin/pip install {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
-      when: ansible_test_collections is not defined

--- a/roles/deploy-artifacts/tasks/main.yaml
+++ b/roles/deploy-artifacts/tasks/main.yaml
@@ -6,13 +6,6 @@
     download_artifact_directory: ~/downloads
     download_artifact_type: "{{ deploy_artifacts_type }}"
 
-- name: Install the sdist artifacts
-  args:
-    chdir: "{{ ansible_user_dir }}/downloads"
-  shell: "{{ deploy_artifacts_venv_path }}/bin/pip install {{ item.url | basename }}"
-  with_items: "{{ zuul.artifacts }}"
-  when: "'metadata' in item and 'type' in item.metadata and (item.metadata.type == 'python_sdist')"
-
 - name: define __collections
   set_fact:
     __collections: ""

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -23,8 +23,6 @@
     dependencies:
       - name: build-ansible-collection
         soft: true
-      - name: build-ansible-base
-        soft: true
     pre-run:
       - playbooks/ansible-test-integration-base/pre.yaml
       - playbooks/ansible-test-cloud-integration-base/pre.yaml

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -222,8 +222,6 @@
     dependencies:
       - name: build-ansible-collection
         soft: true
-      - name: build-ansible-base
-        soft: true
     parent: ansible-network-asa-appliance
     pre-run:
       - playbooks/ansible-test-integration-base/pre.yaml
@@ -279,8 +277,6 @@
     abstract: true
     dependencies:
       - name: build-ansible-collection
-        soft: true
-      - name: build-ansible-base
         soft: true
     parent: ansible-network-eos-appliance
     pre-run:
@@ -338,8 +334,6 @@
     dependencies:
       - name: build-ansible-collection
         soft: true
-      - name: build-ansible-base
-        soft: true
     parent: ansible-network-ios-appliance
     pre-run:
       - playbooks/ansible-test-integration-base/pre.yaml
@@ -395,8 +389,6 @@
     abstract: true
     dependencies:
       - name: build-ansible-collection
-        soft: true
-      - name: build-ansible-base
         soft: true
     parent: ansible-network-iosxr-appliance
     pre-run:
@@ -477,8 +469,6 @@
     abstract: true
     dependencies:
       - name: build-ansible-collection
-        soft: true
-      - name: build-ansible-base
         soft: true
     parent: ansible-network-junos-vsrx-appliance
     pre-run:
@@ -566,8 +556,6 @@
     dependencies:
       - name: build-ansible-collection
         soft: true
-      - name: build-ansible-base
-        soft: true
     parent: ansible-network-nxos-appliance
     pre-run:
       - playbooks/ansible-test-integration-base/pre.yaml
@@ -596,8 +584,6 @@
     abstract: true
     dependencies:
       - name: build-ansible-collection
-        soft: true
-      - name: build-ansible-base
         soft: true
     parent: ansible-network-openvswitch-appliance
     pre-run:
@@ -654,8 +640,6 @@
     abstract: true
     dependencies:
       - name: build-ansible-collection
-        soft: true
-      - name: build-ansible-base
         soft: true
     parent: ansible-network-vyos-appliance
     pre-run:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -53,7 +53,6 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
-        - build-ansible-base
     gate:
       queue: integrated
       jobs:
@@ -75,7 +74,6 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
-        - build-ansible-base
 
 - project-template:
     name: ansible-collections-cisco-asa
@@ -100,7 +98,6 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
-        - build-ansible-base
     gate:
       queue: integrated
       jobs:
@@ -119,7 +116,6 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
-        - build-ansible-base
 
 - project-template:
     name: ansible-collections-cisco-ios
@@ -143,7 +139,6 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
-        - build-ansible-base
     gate:
       queue: integrated
       jobs:
@@ -165,7 +160,6 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
-        - build-ansible-base
 
 - project-template:
     name: ansible-collections-cisco-iosxr
@@ -199,14 +193,12 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
-        - build-ansible-base
     gate:
       queue: integrated
       jobs:
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
-        - build-ansible-base
 
 - project-template:
     name: ansible-collections-cisco-iosxr-netconf
@@ -233,7 +225,6 @@
               - name: github.com/ansible-collections/netcommon
               - name: github.com/ansible-collections/iosxr
               - name: github.com/ansible-collections/junos
-        - build-ansible-base
     gate:
       queue: integrated
       jobs:
@@ -242,7 +233,6 @@
               - name: github.com/ansible-collections/netcommon
               - name: github.com/ansible-collections/iosxr
               - name: github.com/ansible-collections/junos
-        - build-ansible-base
 
 - project-template:
     name: ansible-collections-community-vmware
@@ -258,7 +248,6 @@
             vars:
               ansible_test_collections: true
         - build-ansible-collection
-        - build-ansible-base
     gate:
       queue: integrated
       jobs:
@@ -272,7 +261,6 @@
             vars:
               ansible_test_collections: true
         - build-ansible-collection
-        - build-ansible-base
 
 - project-template:
     name: ansible-collections-juniper-junos
@@ -301,7 +289,6 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
-        - build-ansible-base
     gate:
       queue: integrated
       jobs:
@@ -328,7 +315,6 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
-        - build-ansible-base
 
 - project-template:
     name: ansible-collections-juniper-junos-netconf
@@ -354,7 +340,6 @@
               - name: github.com/ansible-collections/netcommon
               - name: github.com/ansible-collections/iosxr
               - name: github.com/ansible-collections/junos
-        - build-ansible-base
     gate:
       queue: integrated
       jobs:
@@ -378,7 +363,6 @@
               - name: github.com/ansible-collections/netcommon
               - name: github.com/ansible-collections/iosxr
               - name: github.com/ansible-collections/junos
-        - build-ansible-base
 
 - project-template:
     name: ansible-collections-openvswitch-openvswitch
@@ -402,7 +386,6 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
-        - build-ansible-base
     gate:
       queue: integrated
       jobs:
@@ -424,7 +407,6 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
-        - build-ansible-base
 
 - project-template:
     name: ansible-collections-vyos-vyos
@@ -448,7 +430,6 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
-        - build-ansible-base
     gate:
       queue: integrated
       jobs:
@@ -470,7 +451,6 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/netcommon
-        - build-ansible-base
 
 - project-template:
     name: ansible-test-network-integration


### PR DESCRIPTION
Now that ansible/ansible devel collection has been deleted, we can stop
building out own tarball.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>