### PR TITLE
vmware: run flake8 with tox

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -299,6 +299,7 @@
         - ansible-test-cloud-integration-vcenter_2esxi-python36:
             vars:
               ansible_test_collections: true
+        - ansible-tox-py37
         - build-ansible-collection
     gate:
       queue: integrated


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware/pull/70

Enable the `ansible-tox-py37` template to run tox.