### PR TITLE
configure-swap: depends on ansible.posix

### DIFF
--- a/roles/configure-swap/meta/main.yaml
+++ b/roles/configure-swap/meta/main.yaml
@@ -1,0 +1,3 @@
+---
+collections:
+  - ansible.posix  # for sysctl


### PR DESCRIPTION
`configure-swap` uses `sysctl` which comes from `ansible.posix`. The
dependency will be important the day we will switch to Ansible 2.10.