### PR TITLE
ara: correctly get the location of the callback dir

### DIFF
--- a/roles/ansible-test/tasks/enable_ara.yaml
+++ b/roles/ansible-test/tasks/enable_ara.yaml
@@ -1,10 +1,14 @@
 ---
+- name: Get the Ara callback location
+  command: "{{ ansible_test_venv_path }}/bin/python -m ara.setup.callback_plugins"
+  register: _ara_callback_location
+
 - name: Enable ARA callback plugin
   ini_file:
     path: "{{ _test_cfg_location }}"
     section: defaults
     option: callback_plugins
-    value: "{{ ansible_test_venv_path }}/site-packages/ara/plugins/callbacks"
+    value: "{{ _ara_callback_location.stdout }}"
 
 - name: Enable persistent connection logging
   ini_file:


### PR DESCRIPTION
Use `python -m ara.setup.callback_plugins`, as advised in the doc,
to know the location of the callback directory.