### PR TITLE
deploy-artifacts: ensure runme.sh scripts are executable

### DIFF
--- a/roles/deploy-artifacts/tasks/main.yaml
+++ b/roles/deploy-artifacts/tasks/main.yaml
@@ -21,3 +21,6 @@
     chdir: "{{ ansible_user_dir }}/downloads"
     executable: /bin/bash
   shell: "source {{ deploy_artifacts_venv_path }}/bin/activate; ansible-galaxy collection install {{ __collections }}"
+
+- name: Ensure the runme.sh scripts can be run -- https://github.com/ansible/ansible/issues/68564
+  command: find ~/.ansible/collections/ansible_collections -type f -name 'runme.sh' -exec chmod 0755 {} \;


### PR DESCRIPTION
The +x flag of the files are lost in the tarballs generated by
`ansible-galaxy`. We need to put them back, or the associated
tests will fail.