### PR TITLE
ansible-test: dep on community.general for ini_file

### DIFF
--- a/roles/ansible-test/meta/main.yaml
+++ b/roles/ansible-test/meta/main.yaml
@@ -1,0 +1,3 @@
+---
+collections:
+    - community.general  # ini_file


### PR DESCRIPTION
`ansible-test` role actually depends on `community.general` because of the use of `ini_file` module.