### PR TITLE
vmware: centos-8_v2-standard-1-iops for the vexxhost lab

### DIFF
--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -108,7 +108,8 @@
     name: vmware-vcsa_1esxi-6.7.0-python36_vexxhost_experimental
     nodes:
       - name: centos-8
-        label: centos-8-1vcpu
+        # label: centos-8-1vcpu
+        label: centos-8_v2-standard-1-iops
       - name: vcenter
         label: vmware-vcsa-6.7.0
       - name: esxi1


### PR DESCRIPTION
Depends-On: https://github.com/ansible-network/windmill-config/pull/632

Is the new `centos-8_v2-standard-1-iops` label for the `centos-8` node.
This to validate with a regular Linux that the flavor matches our expectation.