### PR TITLE
vmware: govcsim integration

### DIFF
--- a/roles/ansible-test/tasks/init_collection.yaml
+++ b/roles/ansible-test/tasks/init_collection.yaml
@@ -24,4 +24,5 @@
 
 - name: Copy potential cloud provider configuration for ansible-test in the collection
   shell: "cp -v {{ ansible_test_ansible_path }}/test/integration/cloud-config-*.ini {{ _test_location }}/tests/integration/"
+  ignore_errors: true
   when: ansible_test_test_command == 'integration'

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -16,12 +16,62 @@
       - name: github.com/ansible/ansible-zuul-jobs
     nodeset: vmware-vcsa-6.7.0-python36
 
+# govcsim
+
+- job:
+    name: ansible-test-cloud-integration-govcsim-python36
+    nodeset: vmware-govcsim-python36
+    dependencies:
+      - name: build-ansible-collection
+        soft: true
+    pre-run:
+      - playbooks/ansible-test-integration-base/pre.yaml
+      - playbooks/ansible-tox-molecule/pre.yaml
+    run: playbooks/ansible-test-integration-base/run.yaml
+    post-run: playbooks/ansible-test-integration-base/post.yaml
+    required-projects:
+      - name: github.com/ansible/ansible
+      - name: github.com/ansible/ansible-zuul-jobs
+    vars:
+      ansible_test_python: 3.6
+      ansible_test_integration_targets: zuul/vmware/govcsim/
+      ansible_test_command: integration
+      ansible_test_environment:
+        VMWARE_TEST_PLATFORM: govcsim
+      ansible_test_split_in: 3
+
+- job:
+    name: ansible-test-cloud-integration-govcsim-python36_1_of_3
+    parent: ansible-test-cloud-integration-govcsim-python36
+    vars:
+      ansible_test_do_number: 1
+
+- job:
+    name: ansible-test-cloud-integration-govcsim-python36_2_of_3
+    parent: ansible-test-cloud-integration-govcsim-python36
+    vars:
+      ansible_test_do_number: 2
+
+- job:
+    name: ansible-test-cloud-integration-govcsim-python36_3_of_3
+    parent: ansible-test-cloud-integration-govcsim-python36
+    vars:
+      ansible_test_do_number: 3
+
+# master
+
 - job:
     name: ansible-test-cloud-integration-vcenter
     abstract: true
     parent: ansible-cloud-vcenter-appliance
     dependencies:
       - name: build-ansible-collection
+        soft: true
+      - name: ansible-test-cloud-integration-govcsim-python36_1_of_3
+        soft: true
+      - name: ansible-test-cloud-integration-govcsim-python36_2_of_3
+        soft: true
+      - name: ansible-test-cloud-integration-govcsim-python36_3_of_3
         soft: true
     pre-run:
       - playbooks/ansible-test-integration-base/pre.yaml
@@ -39,6 +89,7 @@
       ansible_test_retry_on_error: true
 
 # vcenter 6.7.0
+
 - job:
     name: ansible-test-cloud-integration-vcenter_only-python36
     parent: ansible-test-cloud-integration-vcenter
@@ -67,14 +118,12 @@
     name: ansible-test-cloud-integration-vcenter_1esxi-python36_2_of_3
     parent: ansible-test-cloud-integration-vcenter_1esxi-python36
     vars:
-      ansible_test_split_in: 3
       ansible_test_do_number: 2
 
 - job:
     name: ansible-test-cloud-integration-vcenter_1esxi-python36_3_of_3
     parent: ansible-test-cloud-integration-vcenter_1esxi-python36
     vars:
-      ansible_test_split_in: 3
       ansible_test_do_number: 3
 
 - job:

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -43,6 +43,16 @@
 
 # Ansible cloud appliance nodesets
 - nodeset:
+    name: vmware-govcsim-python36
+    nodes:
+      - name: centos-8
+        label: centos-8-1vcpu
+    groups:
+      - name: controller
+        nodes:
+          - centos-8
+
+- nodeset:
     name: vmware-vcsa-6.7.0-python36
     nodes:
       - name: centos-8

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -290,6 +290,15 @@
     name: ansible-collections-community-vmware
     check:
       jobs:
+        - ansible-test-cloud-integration-govcsim-python36_1_of_3:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-cloud-integration-govcsim-python36_2_of_3:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-cloud-integration-govcsim-python36_3_of_3:
+            vars:
+              ansible_test_collections: true
         - ansible-test-cloud-integration-vcenter_only-python36:
             vars:
               ansible_test_collections: true
@@ -310,6 +319,15 @@
     gate:
       queue: integrated
       jobs:
+        - ansible-test-cloud-integration-govcsim-python36_1_of_3:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-cloud-integration-govcsim-python36_2_of_3:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-cloud-integration-govcsim-python36_3_of_3:
+            vars:
+              ansible_test_collections: true
         - ansible-tox-linters
         - build-ansible-collection
     periodic:


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware/pull/95
    
- starts govcsim on 3 different nodes
- wait for govcsim success before starting the other jobs, on regular lab