### PR TITLE
vcenter: #3 should not run load of worker #2

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -73,7 +73,7 @@
     parent: ansible-test-cloud-integration-vcenter_1esxi-python36
     vars:
       ansible_test_split_in: 3
-      ansible_test_do_number: 2
+      ansible_test_do_number: 3
 
 - job:
     name: ansible-test-cloud-integration-vcenter_2esxi-python36


### PR DESCRIPTION
Ensure `ansible-test-cloud-integration-vcenter_1esxi-python36_3_of_3`'s
`ansible_test_do_number` value is correctly set.