### PR TITLE
vmware: mv vexxhost_exp job in periodic

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -302,10 +302,6 @@
         - ansible-test-cloud-integration-vcenter_1esxi-python36_3_of_3:
             vars:
               ansible_test_collections: true
-        - ansible-test-cloud-integration-vcenter_1esxi-python36_vexxhost_experimental:
-            vars:
-              ansible_test_collections: true
-            voting: false
         - ansible-test-cloud-integration-vcenter_2esxi-python36:
             vars:
               ansible_test_collections: true
@@ -327,6 +323,10 @@
         - ansible-test-cloud-integration-vcenter7_2esxi-python36:
             vars:
               ansible_test_collections: true
+        - ansible-test-cloud-integration-vcenter_1esxi-python36_vexxhost_experimental:
+            vars:
+              ansible_test_collections: true
+            voting: false
         - ansible-tox-linters
         - build-ansible-collection
 


### PR DESCRIPTION
The job is slow and fails consistently. And the situation is unlikely
to change soon.