### PR TITLE
vmware: dissociate nested/regular roles

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -99,51 +99,43 @@
       ansible_test_integration_targets: zuul/vmware/vcenter_only/
 
 - job:
-    name: ansible-test-cloud-integration-vcenter_1esxi-python36
+    name: ansible-test-cloud-integration-vcenter_1esxi_with_nested-python36
     parent: ansible-test-cloud-integration-vcenter
-    nodeset: vmware-vcsa_1esxi-6.7.0-python36
+    nodeset: vmware-vcsa_1esxi-6.7.0-python36-without-nested
     vars:
       ansible_test_python: 3.6
-      ansible_test_integration_targets: zuul/vmware/vcenter_1esxi/
-      ansible_test_split_in: 3
+      ansible_test_integration_targets: zuul/vmware/vcenter_1esxi_with_nested/
     timeout: 10800
 
 - job:
-    name: ansible-test-cloud-integration-vcenter_1esxi-python36_1_of_3
+    name: ansible-test-cloud-integration-vcenter_1esxi-python36
+    parent: ansible-test-cloud-integration-vcenter
+    nodeset: vmware-vcsa_1esxi-6.7.0-python36-without-nested
+    vars:
+      ansible_test_python: 3.6
+      ansible_test_integration_targets: zuul/vmware/vcenter_1esxi/
+      ansible_test_split_in: 2
+    timeout: 10800
+
+- job:
+    name: ansible-test-cloud-integration-vcenter_1esxi_without_nested-python36_1_of_2
     parent: ansible-test-cloud-integration-vcenter_1esxi-python36
     vars:
       ansible_test_do_number: 1
 
 - job:
-    name: ansible-test-cloud-integration-vcenter_1esxi-python36_2_of_3
+    name: ansible-test-cloud-integration-vcenter_1esxi_without_nested-python36_2_of_2
     parent: ansible-test-cloud-integration-vcenter_1esxi-python36
     vars:
       ansible_test_do_number: 2
 
 - job:
-    name: ansible-test-cloud-integration-vcenter_1esxi-python36_3_of_3
-    parent: ansible-test-cloud-integration-vcenter_1esxi-python36
-    vars:
-      ansible_test_do_number: 3
-
-- job:
-    name: ansible-test-cloud-integration-vcenter_2esxi-python36
+    name: ansible-test-cloud-integration-vcenter_2esxi_without_nested-python36
     parent: ansible-test-cloud-integration-vcenter
-    nodeset: vmware-vcsa_2esxi-6.7.0-python36
+    nodeset: vmware-vcsa_2esxi-6.7.0-python36-without-nested
     vars:
       ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_2esxi/
-
-# vcenter 6.7.0 on Vexxhost
-- job:
-    name: ansible-test-cloud-integration-vcenter_1esxi-python36_vexxhost_experimental
-    parent: ansible-test-cloud-integration-vcenter
-    nodeset: vmware-vcsa_1esxi-6.7.0-python36_vexxhost_experimental
-    vars:
-      ansible_test_python: 3.6
-      ansible_test_integration_targets: zuul/vmware/vcenter_1esxi/
-    # 5h
-    timeout: 10800
 
 # vcenter 7.0.0
 - job:
@@ -155,9 +147,19 @@
       ansible_test_integration_targets: zuul/vmware/vcenter_only/
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-python36
+    name: ansible-test-cloud-integration-vcenter7_1esxi_with_nested-python36
     parent: ansible-test-cloud-integration-vcenter
-    nodeset: vmware-vcsa_1esxi-7.0.0-python36
+    nodeset: vmware-vcsa_1esxi-7.0.0-python36-with-nested
+    vars:
+      ansible_test_python: 3.6
+      ansible_test_integration_targets: zuul/vmware/vcenter_1esxi_with_nested/
+    # 5h
+    timeout: 10800
+
+- job:
+    name: ansible-test-cloud-integration-vcenter7_1esxi_without_nested-python36
+    parent: ansible-test-cloud-integration-vcenter
+    nodeset: vmware-vcsa_1esxi-7.0.0-python36-without-nested
     vars:
       ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_1esxi/
@@ -165,9 +167,9 @@
     timeout: 10800
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_2esxi-python36
+    name: ansible-test-cloud-integration-vcenter7_2esxi_without_nested-python36
     parent: ansible-test-cloud-integration-vcenter
-    nodeset: vmware-vcsa_2esxi-7.0.0-python36
+    nodeset: vmware-vcsa_2esxi-7.0.0-python36-without-nested
     vars:
       ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_2esxi/

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -68,14 +68,14 @@
           - centos-8
 
 - nodeset:
-    name: vmware-vcsa_1esxi-6.7.0-python36
+    name: vmware-vcsa_1esxi-6.7.0-python36-with-nested
     nodes:
       - name: centos-8
         label: centos-8-1vcpu
       - name: vcenter
         label: vmware-vcsa-6.7.0
       - name: esxi1
-        label: esxi-6.7.0
+        label: esxi-6.7.0-with-nested
     groups:
       - name: appliance
         nodes:
@@ -89,16 +89,37 @@
           - centos-8
 
 - nodeset:
-    name: vmware-vcsa_2esxi-6.7.0-python36
+    name: vmware-vcsa_1esxi-6.7.0-python36-without-nested
     nodes:
       - name: centos-8
         label: centos-8-1vcpu
       - name: vcenter
         label: vmware-vcsa-6.7.0
       - name: esxi1
-        label: esxi-6.7.0
+        label: esxi-6.7.0-without-nested
+    groups:
+      - name: appliance
+        nodes:
+          - vcenter
+          - esxi1
+      - name: esxis
+        nodes:
+          - esxi1
+      - name: controller
+        nodes:
+          - centos-8
+
+- nodeset:
+    name: vmware-vcsa_2esxi-6.7.0-python36-without-nested
+    nodes:
+      - name: centos-8
+        label: centos-8-1vcpu
+      - name: vcenter
+        label: vmware-vcsa-6.7.0
+      - name: esxi1
+        label: esxi-6.7.0-without-nested
       - name: esxi2
-        label: esxi-6.7.0
+        label: esxi-6.7.0-without-nested
     groups:
       - name: appliance
         nodes:
@@ -109,28 +130,6 @@
         nodes:
           - esxi1
           - esxi2
-      - name: controller
-        nodes:
-          - centos-8
-
-# Vexxhost, experimental flavor
-- nodeset:
-    name: vmware-vcsa_1esxi-6.7.0-python36_vexxhost_experimental
-    nodes:
-      - name: centos-8
-        label: centos-8-1vcpu
-      - name: vcenter
-        label: vmware-vcsa-6.7.0
-      - name: esxi1
-        label: esxi-6.7.0_exp
-    groups:
-      - name: appliance
-        nodes:
-          - vcenter
-          - esxi1
-      - name: esxis
-        nodes:
-          - esxi1
       - name: controller
         nodes:
           - centos-8
@@ -152,14 +151,14 @@
           - centos-8
 
 - nodeset:
-    name: vmware-vcsa_1esxi-7.0.0-python36
+    name: vmware-vcsa_1esxi-7.0.0-python36-with-nested
     nodes:
       - name: centos-8
         label: centos-8-1vcpu
       - name: vcenter
         label: vmware-vcsa-7.0.0
       - name: esxi1
-        label: esxi-6.7.0
+        label: esxi-6.7.0-with-nested
     groups:
       - name: appliance
         nodes:
@@ -173,16 +172,37 @@
           - centos-8
 
 - nodeset:
-    name: vmware-vcsa_2esxi-7.0.0-python36
+    name: vmware-vcsa_1esxi-7.0.0-python36-without-nested
     nodes:
       - name: centos-8
         label: centos-8-1vcpu
       - name: vcenter
         label: vmware-vcsa-7.0.0
       - name: esxi1
-        label: esxi-6.7.0
+        label: esxi-6.7.0-without-nested
+    groups:
+      - name: appliance
+        nodes:
+          - vcenter
+          - esxi1
+      - name: esxis
+        nodes:
+          - esxi1
+      - name: controller
+        nodes:
+          - centos-8
+
+- nodeset:
+    name: vmware-vcsa_2esxi-7.0.0-python36-without-nested
+    nodes:
+      - name: centos-8
+        label: centos-8-1vcpu
+      - name: vcenter
+        label: vmware-vcsa-7.0.0
+      - name: esxi1
+        label: esxi-6.7.0-without-nested
       - name: esxi2
-        label: esxi-6.7.0
+        label: esxi-6.7.0-without-nested
     groups:
       - name: appliance
         nodes:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -302,6 +302,18 @@
         - ansible-test-cloud-integration-vcenter_only-python36:
             vars:
               ansible_test_collections: true
+        - ansible-test-cloud-integration-vcenter_1esxi_with_nested-python36:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-cloud-integration-vcenter_1esxi_without_nested-python36_1_of_2:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-cloud-integration-vcenter_1esxi_without_nested-python36_2_of_2:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-cloud-integration-vcenter_2esxi_without_nested-python36:
+            vars:
+              ansible_test_collections: true
         - ansible-tox-linters
         - build-ansible-collection
     gate:
@@ -323,16 +335,15 @@
         - ansible-test-cloud-integration-vcenter7_only-python36:
             vars:
               ansible_test_collections: true
-        - ansible-test-cloud-integration-vcenter7_1esxi-python36:
+        - ansible-test-cloud-integration-vcenter7_1esxi_with_nested-python36:
             vars:
               ansible_test_collections: true
-        - ansible-test-cloud-integration-vcenter7_2esxi-python36:
+        - ansible-test-cloud-integration-vcenter7_1esxi_without_nested-python36:
             vars:
               ansible_test_collections: true
-        - ansible-test-cloud-integration-vcenter_1esxi-python36_vexxhost_experimental:
+        - ansible-test-cloud-integration-vcenter7_2esxi_without_nested-python36:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-tox-linters
         - build-ansible-collection
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible-network/windmill-config/pull/636
Depends-On: https://github.com/ansible-collections/vmware/pull/105

Just one of our 4 OpenStack zone is able to run nested ESXi that can run
nested VM.
So the idea is to split workload.