### PR TITLE
vmware: disable the integration jobs

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -302,18 +302,6 @@
         - ansible-test-cloud-integration-vcenter_only-python36:
             vars:
               ansible_test_collections: true
-        - ansible-test-cloud-integration-vcenter_1esxi-python36_1_of_3:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-cloud-integration-vcenter_1esxi-python36_2_of_3:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-cloud-integration-vcenter_1esxi-python36_3_of_3:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-cloud-integration-vcenter_2esxi-python36:
-            vars:
-              ansible_test_collections: true
         - ansible-tox-linters
         - build-ansible-collection
     gate:


### PR DESCRIPTION
Temporarily disable the VMware integration jobs. This to be able to
land:
- https://github.com/ansible-collections/vmware/pull/105
- https://github.com/ansible/ansible-zuul-jobs/pull/410