### PR TITLE
Add required-projects for network collection jobs

### DIFF
--- a/playbooks/ansible-test-base/run.yaml
+++ b/playbooks/ansible-test-base/run.yaml
@@ -10,7 +10,7 @@
         name: ansible-test
       vars:
         ansible_test_test_command: "{{ ansible_test_command }}"
-        ansible_test_location: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
+        ansible_test_location: "{{ ansible_user_dir }}/{{ zuul.projects[ansible_collections_repo].src_dir }}"
         ansible_test_git_branch: "{{ zuul.projects['github.com/ansible/ansible'].checkout }}"
         ansible_test_enable_ara: true
         ansible_test_ansible_path: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -32,7 +32,9 @@
     required-projects:
       - name: github.com/ansible/ansible
       - name: github.com/ansible/ansible-zuul-jobs
+      - name: github.com/ansible-collections/vmware
     vars:
+      ansible_collections_repo: github.com/ansible-collections/vmware
       ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/govcsim/
       ansible_test_command: integration
@@ -80,8 +82,10 @@
     post-run: playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible-collections/vmware
     timeout: 3600
     vars:
+      ansible_collections_repo: github.com/ansible-collections/vmware
       ansible_test_command: integration
       ansible_test_environment:
         VMWARE_TEST_PLATFORM: static

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -232,8 +232,10 @@
       - playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible-collections/cisco.asa
     timeout: 9000
     vars:
+      ansible_collections_repo: github.com/ansible-collections/cisco.asa
       ansible_test_command: network-integration
       ansible_test_integration_targets: "asa_.*"
 
@@ -288,8 +290,10 @@
       - playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible-collections/arista.eos
     timeout: 9000
     vars:
+      ansible_collections_repo: github.com/ansible-collections/arista.eos
       ansible_test_command: network-integration
       ansible_test_integration_targets: "eos_.*"
 
@@ -384,8 +388,10 @@
       - playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible-collections/cisco.ios
     timeout: 9000
     vars:
+      ansible_collections_repo: github.com/ansible-collections/cisco.ios
       ansible_test_command: network-integration
       ansible_test_integration_targets: "ios_.*"
 
@@ -480,8 +486,10 @@
       - playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible-collections/cisco.iosxr
     timeout: 9000
     vars:
+      ansible_collections_repo: github.com/ansible-collections/cisco.iosxr
       ansible_test_command: network-integration
       ansible_test_integration_targets: "iosxr_.* netconf_.*"
 
@@ -564,24 +572,28 @@
     name: ansible-test-network-integration-iosxr-netconf-python27
     parent: ansible-test-network-integration-iosxr-python27
     vars:
+      ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-iosxr-netconf-python35
     parent: ansible-test-network-integration-iosxr-python35
     vars:
+      ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-iosxr-netconf-python36
     parent: ansible-test-network-integration-iosxr-python36
     vars:
+      ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-iosxr-netconf-python37
     parent: ansible-test-network-integration-iosxr-python37
     vars:
+      ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
@@ -600,8 +612,10 @@
       - playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible-collections/junipernetworks.junos
     timeout: 9000
     vars:
+      ansible_collections_repo: github.com/ansible-collections/junipernetworks.junos
       ansible_test_command: network-integration
       ansible_test_integration_targets: "junos_.* netconf_.*"
 
@@ -684,30 +698,35 @@
     name: ansible-test-network-integration-junos-vsrx-netconf-python27
     parent: ansible-test-network-integration-junos-vsrx-python27
     vars:
+      ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-junos-vsrx-netconf-python35
     parent: ansible-test-network-integration-junos-vsrx-python35
     vars:
+      ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-junos-vsrx-netconf-python36
     parent: ansible-test-network-integration-junos-vsrx-python36
     vars:
+      ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-junos-vsrx-netconf-python37
     parent: ansible-test-network-integration-junos-vsrx-python37
     vars:
+      ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-junos-vsrx-netconf-python38
     parent: ansible-test-network-integration-junos-vsrx-python38
     vars:
+      ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
@@ -726,8 +745,10 @@
       - playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible-collections/cisco.nxos
     timeout: 10800
     vars:
+      ansible_collections_repo: github.com/ansible-collections/cisco.nxos
       ansible_test_command: network-integration
       ansible_test_integration_targets: "nxos_.*"
 
@@ -755,8 +776,10 @@
       - playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible-collections/openvswitch.openvswitch
     timeout: 3600
     vars:
+      ansible_collections_repo: github.com/ansible-collections/openvswitch.openvswitch
       ansible_test_command: network-integration
       ansible_test_integration_targets: "openvswitch_.*"
 
@@ -851,8 +874,10 @@
       - playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible-collections/vyos.vyos
     timeout: 7200
     vars:
+      ansible_collections_repo: github.com/ansible-collections/vyos.vyos
       ansible_test_command: network-integration
       ansible_test_integration_targets: "vyos_.*"
 

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -275,16 +275,26 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
+              - name: github.com/ansible-collections/arista.eos
+              - name: github.com/ansible-collections/cisco.ios
               - name: github.com/ansible-collections/cisco.iosxr
+              - name: github.com/ansible-collections/cisco.nxos
               - name: github.com/ansible-collections/junipernetworks.junos
+              - name: github.com/ansible-collections/openvswitch.openvswitch
+              - name: github.com/ansible-collections/vyos.vyos
     gate:
       queue: integrated
       jobs:
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
+              - name: github.com/ansible-collections/arista.eos
+              - name: github.com/ansible-collections/cisco.ios
               - name: github.com/ansible-collections/cisco.iosxr
+              - name: github.com/ansible-collections/cisco.nxos
               - name: github.com/ansible-collections/junipernetworks.junos
+              - name: github.com/ansible-collections/openvswitch.openvswitch
+              - name: github.com/ansible-collections/vyos.vyos
 
 - project-template:
     name: ansible-collections-community-vmware


### PR DESCRIPTION
This is because for ansible.netcommon, we need to do cross
project-testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>