### PR TITLE
Install ARA into it's own venv

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -624,28 +624,24 @@
         - ansible-test-network-integration-vyos-python27-stable29:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-vyos-python35:
             vars:
               ansible_test_collections: true
         - ansible-test-network-integration-vyos-python35-stable29:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-vyos-python36:
             vars:
               ansible_test_collections: true
         - ansible-test-network-integration-vyos-python36-stable29:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-vyos-python37:
             vars:
               ansible_test_collections: true
         - ansible-test-network-integration-vyos-python37-stable29:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-vyos-python38:
             vars:
               ansible_test_collections: true
@@ -661,13 +657,25 @@
         - ansible-test-network-integration-vyos-python27:
             vars:
               ansible_test_collections: true
+        - ansible-test-network-integration-vyos-python27-stable29:
+            vars:
+              ansible_test_collections: true
         - ansible-test-network-integration-vyos-python35:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-vyos-python35-stable29:
             vars:
               ansible_test_collections: true
         - ansible-test-network-integration-vyos-python36:
             vars:
               ansible_test_collections: true
+        - ansible-test-network-integration-vyos-python36-stable29:
+            vars:
+              ansible_test_collections: true
         - ansible-test-network-integration-vyos-python37:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-vyos-python37-stable29:
             vars:
               ansible_test_collections: true
         - ansible-test-network-integration-vyos-python38:


### PR DESCRIPTION
This allows use to remove the ARA dependencies from ansible-test
environment.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>