### PR TITLE
vmware: refactoring

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -107,7 +107,6 @@
     parent: ansible-test-cloud-integration-vcenter
     nodeset: vmware-vcsa_1esxi-6.7.0-python36-with-nested
     vars:
-      ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_1esxi_with_nested/
     timeout: 10800
 
@@ -116,7 +115,6 @@
     parent: ansible-test-cloud-integration-vcenter
     nodeset: vmware-vcsa_1esxi-6.7.0-python36-without-nested
     vars:
-      ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_1esxi/
       ansible_test_split_in: 2
     timeout: 10800
@@ -138,24 +136,19 @@
     parent: ansible-test-cloud-integration-vcenter
     nodeset: vmware-vcsa_2esxi-6.7.0-python36-without-nested
     vars:
-      ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_2esxi/
 
 # vcenter 7.0.0
 - job:
     name: ansible-test-cloud-integration-vcenter7_only-python36
-    parent: ansible-test-cloud-integration-vcenter
+    parent: ansible-test-cloud-integration-vcenter_only-python36
     nodeset: vmware-vcsa-7.0.0-python36
-    vars:
-      ansible_test_python: 3.6
-      ansible_test_integration_targets: zuul/vmware/vcenter_only/
 
 - job:
     name: ansible-test-cloud-integration-vcenter7_1esxi_with_nested-python36
     parent: ansible-test-cloud-integration-vcenter
     nodeset: vmware-vcsa_1esxi-7.0.0-python36-with-nested
     vars:
-      ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_1esxi_with_nested/
     # 5h
     timeout: 10800
@@ -165,7 +158,6 @@
     parent: ansible-test-cloud-integration-vcenter
     nodeset: vmware-vcsa_1esxi-7.0.0-python36-without-nested
     vars:
-      ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_1esxi/
     # 5h
     timeout: 10800
@@ -175,5 +167,4 @@
     parent: ansible-test-cloud-integration-vcenter
     nodeset: vmware-vcsa_2esxi-7.0.0-python36-without-nested
     vars:
-      ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_2esxi/


### PR DESCRIPTION
- do not re-set the `ansible_test_python`, it's already defined in the parent
- `ansible-test-cloud-integration-vcenter7_only-python36` inherites from `ansible-test-cloud-integration-vcenter_only-python36`