### PR TITLE
Enable unit tests in CI for cisco.asa

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -240,6 +240,16 @@
       ansible_test_integration_targets: "asa_.*"
 
 - job:
+    name: ansible-test-units-asa
+    parent: ansible-test-units-base
+    required-projects:
+      - name: github.com/ansible-collections/cisco.asa
+    timeout: 3600
+    vars:
+      ansible_collections_repo: github.com/ansible-collections/cisco.asa
+      ansible_test_integration_targets: "tests/unit/modules/network/asa/test_asa.*"
+
+- job:
     name: ansible-test-network-integration-asa-python27
     parent: ansible-test-network-integration-asa
     nodeset: asav9-12-3-python27

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -117,6 +117,9 @@
         - ansible-test-network-integration-asa-python38:
             vars:
               ansible_test_collections: true
+        - ansible-test-units-asa:
+            vars:
+              ansible_test_collections: true
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
@@ -133,6 +136,9 @@
             vars:
               ansible_test_collections: true
         - ansible-test-network-integration-asa-python38:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-units-asa:
             vars:
               ansible_test_collections: true
         - build-ansible-collection:


### PR DESCRIPTION
This runs the unit testcases for cisco.asa platform in zuul.