### PR TITLE
vmware: govcsim with podman

### DIFF
--- a/playbooks/ansible-cloud/govcsim-base/pre.yaml
+++ b/playbooks/ansible-cloud/govcsim-base/pre.yaml
@@ -1,0 +1,13 @@
+---
+- hosts: controller
+  tasks:
+    - name: Install podman
+      package:
+        name: podman
+      become: true
+    - name: Add the /usr/bin/docker symlink
+      file:
+        src: /usr/bin/podman
+        dest: /usr/bin/docker
+        state: link
+      become: true

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -26,7 +26,7 @@
         soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
-      - playbooks/ansible-tox-molecule/pre.yaml
+      - playbooks/ansible-cloud/govcsim-base/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
     post-run: playbooks/ansible-test-base/post.yaml
     required-projects:


### PR DESCRIPTION
Use govcsim with podman. This to avoid docker which is not supported on EL8. But also break the dep with molecule job.