### PR TITLE
Don't use ansible 2.9.7 for bootstrapping

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ansible>=2.4.0
+ansible>=2.4.0,!=2.9.7
 paramiko


### PR DESCRIPTION
This contains a regression that breaks netconf.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>