### PR TITLE
Revert "deploy-artifacts: ensure runme.sh scripts are executable"

### DIFF
--- a/roles/deploy-artifacts/tasks/main.yaml
+++ b/roles/deploy-artifacts/tasks/main.yaml
@@ -21,6 +21,3 @@
     chdir: "{{ ansible_user_dir }}/downloads"
     executable: /bin/bash
   shell: "source {{ deploy_artifacts_venv_path }}/bin/activate; ansible-galaxy collection install {{ __collections }}"
-
-- name: Ensure the runme.sh scripts can be run -- https://github.com/ansible/ansible/issues/68564
-  command: find ~/.ansible/collections/ansible_collections -type f -name 'runme.sh' -exec chmod 0755 {} \;


### PR DESCRIPTION
This reverts commit 495d0b08c56fcf7edebee1b4a79cd06ad540ed33.

The can reverse the workaround since the fix has been release in Ansible 2.9.7.
See: https://github.com/ansible/ansible/commit/d6a82e68658d7ec59cbac49e761a51f6ebe86a62