### PR TITLE
Add retries option to download-artifact-fork

### DIFF
--- a/roles/download-artifact-fork/tasks/main.yaml
+++ b/roles/download-artifact-fork/tasks/main.yaml
@@ -30,4 +30,6 @@
   loop: "{{ _artifacts }}"
   loop_control:
     loop_var: artifact
+  retries: 5
+  delay: 5
   when: "'metadata' in artifact and 'type' in artifact.metadata and (artifact.metadata.type == download_artifact_type or ((download_artifact_type | type_debug) == 'list' and artifact.metadata.type in download_artifact_type))"


### PR DESCRIPTION
This should help when we get network blips when trying to download an
artifact.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>