### PR TITLE
ansible-lint: fix docs location

### DIFF
--- a/zuul.d/jobs-ansible-lint.yaml
+++ b/zuul.d/jobs-ansible-lint.yaml
@@ -4,6 +4,8 @@
 - job:
     name: ansible-lint-tox-docs
     parent: ansible-tox-docs
+    vars:
+      sphinx_build_dir: docs/docsite/_build
 
 - job:
     name: ansible-lint-tox-linters


### PR DESCRIPTION
Ansible-lint does not produce sphinx docs in the standard location expected by Zuul, so we help
him find them.

Needed-By: https://github.com/ansible/ansible-lint/pull/754
