### PR TITLE
Increase junos vsrx job timeout

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -663,7 +663,7 @@
     required-projects:
       - name: github.com/ansible/ansible
       - name: github.com/ansible-collections/junipernetworks.junos
-    timeout: 9000
+    timeout: 10800
     vars:
       ansible_collections_repo: github.com/ansible-collections/junipernetworks.junos
       ansible_test_command: network-integration


### PR DESCRIPTION
This commit bumps the job timeout for vsrx to 3h.