### PR TITLE
unbound: ensure the package is installed

### DIFF
--- a/roles/configure-unbound/tasks/main.yaml
+++ b/roles/configure-unbound/tasks/main.yaml
@@ -11,6 +11,22 @@
     - "{{ ansible_os_family }}.yaml"
     - "default.yaml"
 
+- name: Ensure /etc/resolv.conf works before pulling packages
+  become: true
+  template:
+    dest: /etc/resolv.conf
+    owner: root
+    group: root
+    mode: 0644
+    src: resolv.conf.j2
+
+- name: Install the packages
+  become: true
+  package:
+    name: "{{ unbound_packages }}"
+    update_cache: true
+    state: present
+
 - name: Ensure Unbound conf.d directory exists
   become: true
   file:

--- a/roles/configure-unbound/templates/resolv.conf.j2
+++ b/roles/configure-unbound/templates/resolv.conf.j2
@@ -1,0 +1,4 @@
+# {{ ansible_managed }}
+
+nameserver {{ unbound_primary_nameserver }}
+nameserver {{ unbound_secondary_nameserver }}

--- a/roles/configure-unbound/vars/Debian.yaml
+++ b/roles/configure-unbound/vars/Debian.yaml
@@ -1,2 +1,4 @@
 ---
 unbound_confd: /etc/unbound/unbound.conf.d
+unbound_packages:
+    - unbound

--- a/roles/configure-unbound/vars/default.yaml
+++ b/roles/configure-unbound/vars/default.yaml
@@ -1,2 +1,4 @@
 ---
 unbound_confd: /etc/unbound/conf.d
+unbound_packages:
+    - unbound


### PR DESCRIPTION
In the case of AWS, we reuse existing generic images. They are not
generated by DIB (yet!). So, some assumption regarding the state
of the image may be wrong.