### PR TITLE
ensure virtualenv is installed before bindep run

### DIFF
--- a/playbooks/ansible-network-appliance-base/pre.yaml
+++ b/playbooks/ansible-network-appliance-base/pre.yaml
@@ -1,6 +1,13 @@
 ---
 - hosts: controller
   tasks:
+    - name: Ensure virtualenv package is installed -- See https://review.opendev.org/#/c/727413/
+      package:
+        name: virtualenv
+        state: present
+      become: true
+      when: "'aws' in group_names"
+
     - name: Install binary dependencies
       include_role:
         name: bindep


### PR DESCRIPTION
Bindep uses the `virtualenv` command.