### PR TITLE
Use ensure-docker and ensure-podman to match upstream

### DIFF
--- a/playbooks/ansible-tox-molecule/pre.yaml
+++ b/playbooks/ansible-tox-molecule/pre.yaml
@@ -17,7 +17,7 @@
 
     - name: Install docker
       include_role:
-        name: install-docker
+        name: ensure-docker
 
     - name: Validate docker engine
       # on purpose to verify that non-root user can call docker/podman
@@ -33,7 +33,7 @@
       when:
         - ansible_os_family != "RedHat"
       include_role:
-        name: install-podman
+        name: ensure-podman
 
     # TODO(ssbarnea): Migrate logic to install-podman (zuul-roles)
     - name: Install podman (RedHat)


### PR DESCRIPTION
The install-* roles are now deprecated:
http://lists.zuul-ci.org/pipermail/zuul-announce/2020-April/000071.html

Example job where this causes a failure: https://dashboard.zuul.ansible.com/t/ansible/build/70af1c984bde40f38eb6e4e5bd1740a3