### PR TITLE
Create playbooks/ansible-test-units-base/post.yaml

### DIFF
--- a/playbooks/ansible-test-base/pre.yaml
+++ b/playbooks/ansible-test-base/pre.yaml
@@ -1,6 +1,11 @@
 ---
 - hosts: controller
   tasks:
+    - name: Ensure controller directory exists
+      file:
+        path: "{{ ansible_user_dir }}/zuul-output/logs/controller"
+        state: directory
+
     - name: Add python38 support if needed
       block:
         - name: Ensure python3.8 is present

--- a/playbooks/ansible-test-units-base/post.yaml
+++ b/playbooks/ansible-test-units-base/post.yaml
@@ -1,0 +1,12 @@
+---
+- hosts: controller
+  tasks:
+    # TODO: Migrate to fetch-zuul-logs when
+    # https://review.openstack.org/#/c/583346/ is merged.
+    - name: Collect log output
+      no_log: true
+      synchronize:
+        dest: "{{ zuul.executor.log_root }}/"
+        mode: pull
+        src: "{{ ansible_user_dir }}/zuul-output/logs/"
+        verify_host: true

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -928,6 +928,7 @@
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
+    post-run: playbooks/ansible-test-units-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
     timeout: 3600


### PR DESCRIPTION
to allow unit tests to sync back logs from ansible-test.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>