### PR TITLE
aws: ensure tox is present

### DIFF
--- a/playbooks/ansible-test-network-integration-base/pre.yaml
+++ b/playbooks/ansible-test-network-integration-base/pre.yaml
@@ -11,6 +11,11 @@
         _network_os: "{{ hostvars[groups['openvswitch'][0]]['ansible_network_os'] }}"
       when: '"openvswitch" in groups'
 
+    - name: Ensure tox
+      include_role:
+        name: ensure-tox
+      when: '"aws" in groups'
+
     - name: Setup tox role
       include_role:
         name: tox


### PR DESCRIPTION
We don't use DIB image they with AWS, and `tox` is not part of the generic images yet.