### PR TITLE
Rename ansible.netcommon jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -659,28 +659,28 @@
       ansible_test_integration_targets: "tests/unit/modules/network/cli/test_cli_.*"
 
 - job:
-    name: ansible-test-network-integration-iosxr-netconf-python27
+    name: ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python27
     parent: ansible-test-network-integration-iosxr-python27
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
-    name: ansible-test-network-integration-iosxr-netconf-python35
+    name: ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python35
     parent: ansible-test-network-integration-iosxr-python35
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
-    name: ansible-test-network-integration-iosxr-netconf-python36
+    name: ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python36
     parent: ansible-test-network-integration-iosxr-python36
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
-    name: ansible-test-network-integration-iosxr-netconf-python37
+    name: ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python37
     parent: ansible-test-network-integration-iosxr-python37
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
@@ -795,35 +795,35 @@
       ansible_test_python: 3.8
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-netconf-python27
+    name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python27
     parent: ansible-test-network-integration-junos-vsrx-python27
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-netconf-python35
+    name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python35
     parent: ansible-test-network-integration-junos-vsrx-python35
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-netconf-python36
+    name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python36
     parent: ansible-test-network-integration-junos-vsrx-python36
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-netconf-python37
+    name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python37
     parent: ansible-test-network-integration-junos-vsrx-python37
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-netconf-python38
+    name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python38
     parent: ansible-test-network-integration-junos-vsrx-python38
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -396,19 +396,19 @@
     name: ansible-collections-cisco-iosxr-netconf
     check:
       jobs:
-        - ansible-test-network-integration-iosxr-netconf-python27:
+        - ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python27:
             vars:
               ansible_test_collections: true
             voting: false
-        - ansible-test-network-integration-iosxr-netconf-python35:
+        - ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python35:
             vars:
               ansible_test_collections: true
             voting: false
-        - ansible-test-network-integration-iosxr-netconf-python36:
+        - ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python36:
             vars:
               ansible_test_collections: true
             voting: false
-        - ansible-test-network-integration-iosxr-netconf-python37:
+        - ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python37:
             vars:
               ansible_test_collections: true
             voting: false
@@ -601,19 +601,19 @@
     name: ansible-collections-juniper-junos-netconf
     check:
       jobs:
-        - ansible-test-network-integration-junos-vsrx-netconf-python27:
+        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python27:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-junos-vsrx-netconf-python35:
+        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python35:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-junos-vsrx-netconf-python36:
+        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python36:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-junos-vsrx-netconf-python37:
+        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python37:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-junos-vsrx-netconf-python38:
+        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python38:
             vars:
               ansible_test_collections: true
         - build-ansible-collection:
@@ -624,19 +624,19 @@
     gate:
       queue: integrated
       jobs:
-        - ansible-test-network-integration-junos-vsrx-netconf-python27:
+        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python27:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-junos-vsrx-netconf-python35:
+        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python35:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-junos-vsrx-netconf-python36:
+        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python36:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-junos-vsrx-netconf-python37:
+        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python37:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-junos-vsrx-netconf-python38:
+        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python38:
             vars:
               ansible_test_collections: true
         - build-ansible-collection:


### PR DESCRIPTION
This helps avoid name conflicts when we create per connection jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>