### PR TITLE
Split junipernetworks.junos jobs

### DIFF
--- a/roles/ansible-test/tasks/init_test_options.yaml
+++ b/roles/ansible-test/tasks/init_test_options.yaml
@@ -4,6 +4,11 @@
     ansible_test_options: "{{ ansible_test_options }} --skip-tags {{ ansible_test_skip_tags }}"
   when: ansible_test_skip_tags is defined
 
+- name: Setup --tags for test_options
+  set_fact:
+    ansible_test_options: "{{ ansible_test_options }} --tags {{ ansible_test_tags }}"
+  when: ansible_test_tags is defined
+
 - name: Enable --inventory for network-integration
   set_fact:
     ansible_test_options: "{{ ansible_test_options }} --inventory {{ ansible_test_inventory_path }}"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -720,14 +720,23 @@
       ansible_test_integration_targets: "tests/unit/modules/network/junos/test_junos.*"
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-python27
+    name: ansible-test-network-integration-junos-vsrx-netconf-python27
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python27
     vars:
       ansible_test_python: 2.7
+      ansible_test_tags: netconf
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-python27-stable29
+    name: ansible-test-network-integration-junos-vsrx-cli-python27
+    parent: ansible-test-network-integration-junos-vsrx
+    nodeset: vsrx3-18.4R1-python27
+    vars:
+      ansible_test_python: 2.7
+      ansible_test_skip_tags: netconf
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python27-stable29
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python27
     required-projects:
@@ -735,16 +744,37 @@
         override-checkout: stable-2.9
     vars:
       ansible_test_python: 2.7
+      ansible_test_tags: netconf
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-python35
+    name: ansible-test-network-integration-junos-vsrx-cli-python27-stable29
+    parent: ansible-test-network-integration-junos-vsrx
+    nodeset: vsrx3-18.4R1-python27
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
+    vars:
+      ansible_test_python: 2.7
+      ansible_test_skip_tags: netconf
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python35
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python35
     vars:
       ansible_test_python: 3.5
+      ansible_test_tags: netconf
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-python35-stable29
+    name: ansible-test-network-integration-junos-vsrx-cli-python35
+    parent: ansible-test-network-integration-junos-vsrx
+    nodeset: vsrx3-18.4R1-python35
+    vars:
+      ansible_test_python: 3.5
+      ansible_test_skip_tags: netconf
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python35-stable29
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python35
     required-projects:
@@ -752,16 +782,37 @@
         override-checkout: stable-2.9
     vars:
       ansible_test_python: 3.5
+      ansible_test_tags: netconf
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-python36
+    name: ansible-test-network-integration-junos-vsrx-cli-python35-stable29
+    parent: ansible-test-network-integration-junos-vsrx
+    nodeset: vsrx3-18.4R1-python35
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
+    vars:
+      ansible_test_python: 3.5
+      ansible_test_skip_tags: netconf
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python36
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python36
     vars:
       ansible_test_python: 3.6
+      ansible_test_tags: netconf
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-python36-stable29
+    name: ansible-test-network-integration-junos-vsrx-cli-python36
+    parent: ansible-test-network-integration-junos-vsrx
+    nodeset: vsrx3-18.4R1-python36
+    vars:
+      ansible_test_python: 3.6
+      ansible_test_skip_tags: netconf
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python36-stable29
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python36
     required-projects:
@@ -769,16 +820,37 @@
         override-checkout: stable-2.9
     vars:
       ansible_test_python: 3.6
+      ansible_test_tags: netconf
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-python37
+    name: ansible-test-network-integration-junos-vsrx-cli-python36-stable29
+    parent: ansible-test-network-integration-junos-vsrx
+    nodeset: vsrx3-18.4R1-python36
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
+    vars:
+      ansible_test_python: 3.6
+      ansible_test_skip_tags: netconf
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python37
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python37
     vars:
       ansible_test_python: 3.7
+      ansible_test_tags: netconf
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-python37-stable29
+    name: ansible-test-network-integration-junos-vsrx-cli-python37
+    parent: ansible-test-network-integration-junos-vsrx
+    nodeset: vsrx3-18.4R1-python37
+    vars:
+      ansible_test_python: 3.7
+      ansible_test_skip_tags: netconf
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python37-stable29
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python37
     required-projects:
@@ -786,45 +858,66 @@
         override-checkout: stable-2.9
     vars:
       ansible_test_python: 3.7
+      ansible_test_tags: netconf
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-python38
+    name: ansible-test-network-integration-junos-vsrx-cli-python37-stable29
+    parent: ansible-test-network-integration-junos-vsrx
+    nodeset: vsrx3-18.4R1-python37
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
+    vars:
+      ansible_test_python: 3.7
+      ansible_test_skip_tags: netconf
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python38
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python38
     vars:
       ansible_test_python: 3.8
+      ansible_test_tags: netconf
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-cli-python38
+    parent: ansible-test-network-integration-junos-vsrx
+    nodeset: vsrx3-18.4R1-python38
+    vars:
+      ansible_test_python: 3.8
+      ansible_test_skip_tags: netconf
 
 - job:
     name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python27
-    parent: ansible-test-network-integration-junos-vsrx-python27
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python27
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python35
-    parent: ansible-test-network-integration-junos-vsrx-python35
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python35
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python36
-    parent: ansible-test-network-integration-junos-vsrx-python36
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python36
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python37
-    parent: ansible-test-network-integration-junos-vsrx-python37
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python37
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python38
-    parent: ansible-test-network-integration-junos-vsrx-python38
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python38
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -515,39 +515,75 @@
     name: ansible-collections-juniper-junos
     check:
       jobs:
-        - ansible-test-network-integration-junos-vsrx-python27:
+        - ansible-test-network-integration-junos-vsrx-netconf-python27:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python27-stable29:
+        - ansible-test-network-integration-junos-vsrx-cli-python27:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python35:
+        - ansible-test-network-integration-junos-vsrx-netconf-python27-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python35-stable29:
+        - ansible-test-network-integration-junos-vsrx-cli-python27-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python36:
+        - ansible-test-network-integration-junos-vsrx-netconf-python35:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python36-stable29:
+        - ansible-test-network-integration-junos-vsrx-cli-python35:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python37:
+        - ansible-test-network-integration-junos-vsrx-netconf-python35-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python37-stable29:
+        - ansible-test-network-integration-junos-vsrx-cli-python35-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python38:
+        - ansible-test-network-integration-junos-vsrx-netconf-python36:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python36:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python36-stable29:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python36-stable29:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python37:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python37:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python37-stable29:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python37-stable29:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python38:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python38:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -557,39 +593,75 @@
     gate:
       queue: integrated
       jobs:
-        - ansible-test-network-integration-junos-vsrx-python27:
+        - ansible-test-network-integration-junos-vsrx-netconf-python27:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python27-stable29:
+        - ansible-test-network-integration-junos-vsrx-cli-python27:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python35:
+        - ansible-test-network-integration-junos-vsrx-netconf-python27-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python35-stable29:
+        - ansible-test-network-integration-junos-vsrx-cli-python27-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python36:
+        - ansible-test-network-integration-junos-vsrx-netconf-python35:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python36-stable29:
+        - ansible-test-network-integration-junos-vsrx-cli-python35:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python37:
+        - ansible-test-network-integration-junos-vsrx-netconf-python35-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python37-stable29:
+        - ansible-test-network-integration-junos-vsrx-cli-python35-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python38:
+        - ansible-test-network-integration-junos-vsrx-netconf-python36:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python36:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python36-stable29:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python36-stable29:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python37:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python37:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python37-stable29:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python37-stable29:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python38:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python38:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -897,19 +969,35 @@
             branches:
               - stable-2.9
               - stable-2.8
-        - ansible-test-network-integration-junos-vsrx-python27:
+        - ansible-test-network-integration-junos-vsrx-netconf-python27:
             branches:
               - stable-2.9
               - stable-2.8
-        - ansible-test-network-integration-junos-vsrx-python35:
+        - ansible-test-network-integration-junos-vsrx-cli-python27:
             branches:
               - stable-2.9
               - stable-2.8
-        - ansible-test-network-integration-junos-vsrx-python36:
+        - ansible-test-network-integration-junos-vsrx-netconf-python35:
             branches:
               - stable-2.9
               - stable-2.8
-        - ansible-test-network-integration-junos-vsrx-python37:
+        - ansible-test-network-integration-junos-vsrx-cli-python35:
+            branches:
+              - stable-2.9
+              - stable-2.8
+        - ansible-test-network-integration-junos-vsrx-netconf-python36:
+            branches:
+              - stable-2.9
+              - stable-2.8
+        - ansible-test-network-integration-junos-vsrx-cli-python36:
+            branches:
+              - stable-2.9
+              - stable-2.8
+        - ansible-test-network-integration-junos-vsrx-netconf-python37:
+            branches:
+              - stable-2.9
+              - stable-2.8
+        - ansible-test-network-integration-junos-vsrx-cli-python37:
             branches:
               - stable-2.9
               - stable-2.8
@@ -1207,7 +1295,7 @@
               - ^test/integration/targets/netconf_.*
               - ^test/integration/targets/prepare_iosxr_tests/.*
             voting: false
-        - ansible-test-network-integration-junos-vsrx-python27:
+        - ansible-test-network-integration-junos-vsrx-netconf-python27:
             branches:
               - stable-2.9
               - stable-2.8
@@ -1231,7 +1319,7 @@
               - ^test/integration/targets/junos_.*
               - ^test/integration/targets/netconf_.*
               - ^test/integration/targets/prepare_junos_tests/.*
-        - ansible-test-network-integration-junos-vsrx-python35:
+        - ansible-test-network-integration-junos-vsrx-cli-python27:
             branches:
               - stable-2.9
               - stable-2.8
@@ -1255,7 +1343,7 @@
               - ^test/integration/targets/junos_.*
               - ^test/integration/targets/netconf_.*
               - ^test/integration/targets/prepare_junos_tests/.*
-        - ansible-test-network-integration-junos-vsrx-python36:
+        - ansible-test-network-integration-junos-vsrx-netconf-python35:
             branches:
               - stable-2.9
               - stable-2.8
@@ -1279,7 +1367,103 @@
               - ^test/integration/targets/junos_.*
               - ^test/integration/targets/netconf_.*
               - ^test/integration/targets/prepare_junos_tests/.*
-        - ansible-test-network-integration-junos-vsrx-python37:
+        - ansible-test-network-integration-junos-vsrx-cli-python35:
+            branches:
+              - stable-2.9
+              - stable-2.8
+            files:
+              - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+              - ^lib/ansible/modules/network/cli/.*
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/modules/network/netconf/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/module_utils/network/netconf/.*
+              - ^lib/ansible/plugins/action/junos.py
+              - ^lib/ansible/plugins/action/net_.*
+              - ^lib/ansible/plugins/cliconf/junos.py
+              - ^lib/ansible/plugins/connection/local.py
+              - ^lib/ansible/plugins/connection/netconf.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/netconf/.*
+              - ^lib/ansible/plugins/terminal/__init__.py
+              - ^lib/ansible/plugins/terminal/junos.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
+              - ^test/integration/targets/prepare_junos_tests/.*
+        - ansible-test-network-integration-junos-vsrx-netconf-python36:
+            branches:
+              - stable-2.9
+              - stable-2.8
+            files:
+              - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+              - ^lib/ansible/modules/network/cli/.*
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/modules/network/netconf/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/module_utils/network/netconf/.*
+              - ^lib/ansible/plugins/action/junos.py
+              - ^lib/ansible/plugins/action/net_.*
+              - ^lib/ansible/plugins/cliconf/junos.py
+              - ^lib/ansible/plugins/connection/local.py
+              - ^lib/ansible/plugins/connection/netconf.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/netconf/.*
+              - ^lib/ansible/plugins/terminal/__init__.py
+              - ^lib/ansible/plugins/terminal/junos.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
+              - ^test/integration/targets/prepare_junos_tests/.*
+        - ansible-test-network-integration-junos-vsrx-cli-python36:
+            branches:
+              - stable-2.9
+              - stable-2.8
+            files:
+              - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+              - ^lib/ansible/modules/network/cli/.*
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/modules/network/netconf/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/module_utils/network/netconf/.*
+              - ^lib/ansible/plugins/action/junos.py
+              - ^lib/ansible/plugins/action/net_.*
+              - ^lib/ansible/plugins/cliconf/junos.py
+              - ^lib/ansible/plugins/connection/local.py
+              - ^lib/ansible/plugins/connection/netconf.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/netconf/.*
+              - ^lib/ansible/plugins/terminal/__init__.py
+              - ^lib/ansible/plugins/terminal/junos.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
+              - ^test/integration/targets/prepare_junos_tests/.*
+        - ansible-test-network-integration-junos-vsrx-netconf-python37:
+            branches:
+              - stable-2.9
+              - stable-2.8
+            files:
+              - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+              - ^lib/ansible/modules/network/cli/.*
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/modules/network/netconf/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/module_utils/network/netconf/.*
+              - ^lib/ansible/plugins/action/junos.py
+              - ^lib/ansible/plugins/action/net_.*
+              - ^lib/ansible/plugins/cliconf/junos.py
+              - ^lib/ansible/plugins/connection/local.py
+              - ^lib/ansible/plugins/connection/netconf.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/netconf/.*
+              - ^lib/ansible/plugins/terminal/__init__.py
+              - ^lib/ansible/plugins/terminal/junos.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
+              - ^test/integration/targets/prepare_junos_tests/.*
+        - ansible-test-network-integration-junos-vsrx-cli-python37:
             branches:
               - stable-2.9
               - stable-2.8


### PR DESCRIPTION
This PR splits the junos zuul jobs into two, skipping tags when
necessary as per cli and netconf.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>