### PR TITLE
Pull request for split_netconf_jobs_into_two

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -725,6 +725,20 @@
     nodeset: vsrx3-18.4R1-python27
     vars:
       ansible_test_python: 2.7
+      ansible_test_skip_tags: cli
+      ansible_test_split_in: 2
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python27_1_of_2
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python27
+    vars:
+      ansible_test_do_number: 1
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python27_2_of_2
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python27
+    vars:
+      ansible_test_do_number: 2
 
 - job:
     name: ansible-test-network-integration-junos-vsrx-cli-python27
@@ -743,6 +757,20 @@
         override-checkout: stable-2.9
     vars:
       ansible_test_python: 2.7
+      ansible_test_skip_tags: cli
+      ansible_test_split_in: 2
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python27-stable29_1_of_2
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python27-stable29
+    vars:
+      ansible_test_do_number: 1
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python27-stable29_2_of_2
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python27-stable29
+    vars:
+      ansible_test_do_number: 2
 
 - job:
     name: ansible-test-network-integration-junos-vsrx-cli-python27-stable29
@@ -761,6 +789,20 @@
     nodeset: vsrx3-18.4R1-python35
     vars:
       ansible_test_python: 3.5
+      ansible_test_skip_tags: cli
+      ansible_test_split_in: 2
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python35_1_of_2
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python35
+    vars:
+      ansible_test_do_number: 1
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python35_2_of_2
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python35
+    vars:
+      ansible_test_do_number: 2
 
 - job:
     name: ansible-test-network-integration-junos-vsrx-cli-python35
@@ -779,6 +821,28 @@
         override-checkout: stable-2.9
     vars:
       ansible_test_python: 3.5
+      ansible_test_skip_tags: cli
+      ansible_test_split_in: 2
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python35-stable29_1_of_2
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python35-stable29
+    vars:
+      ansible_test_do_number: 1
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python35-stable29_2_of_2
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python35-stable29
+    vars:
+      ansible_test_do_number: 2
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-cli-python35
+    parent: ansible-test-network-integration-junos-vsrx
+    nodeset: vsrx3-18.4R1-python35
+    vars:
+      ansible_test_python: 3.5
+      ansible_test_skip_tags: netconf
 
 - job:
     name: ansible-test-network-integration-junos-vsrx-cli-python35-stable29
@@ -797,6 +861,20 @@
     nodeset: vsrx3-18.4R1-python36
     vars:
       ansible_test_python: 3.6
+      ansible_test_skip_tags: cli
+      ansible_test_split_in: 2
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python36_1_of_2
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python36
+    vars:
+      ansible_test_do_number: 1
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python36_2_of_2
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python36
+    vars:
+      ansible_test_do_number: 2
 
 - job:
     name: ansible-test-network-integration-junos-vsrx-cli-python36
@@ -815,6 +893,20 @@
         override-checkout: stable-2.9
     vars:
       ansible_test_python: 3.6
+      ansible_test_skip_tags: cli
+      ansible_test_split_in: 2
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python36-stable29_1_of_2
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python36-stable29
+    vars:
+      ansible_test_do_number: 1
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python36-stable29_2_of_2
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python36-stable29
+    vars:
+      ansible_test_do_number: 2
 
 - job:
     name: ansible-test-network-integration-junos-vsrx-cli-python36-stable29
@@ -833,6 +925,20 @@
     nodeset: vsrx3-18.4R1-python37
     vars:
       ansible_test_python: 3.7
+      ansible_test_skip_tags: cli
+      ansible_test_split_in: 2
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python37_1_of_2
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python37
+    vars:
+      ansible_test_do_number: 1
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python37_2_of_2
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python37
+    vars:
+      ansible_test_do_number: 2
 
 - job:
     name: ansible-test-network-integration-junos-vsrx-cli-python37
@@ -851,6 +957,20 @@
         override-checkout: stable-2.9
     vars:
       ansible_test_python: 3.7
+      ansible_test_skip_tags: cli
+      ansible_test_split_in: 2
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python37-stable29_1_of_2
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python37-stable29
+    vars:
+      ansible_test_do_number: 1
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python37-stable29_2_of_2
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python37-stable29
+    vars:
+      ansible_test_do_number: 2
 
 - job:
     name: ansible-test-network-integration-junos-vsrx-cli-python37-stable29
@@ -869,6 +989,20 @@
     nodeset: vsrx3-18.4R1-python38
     vars:
       ansible_test_python: 3.8
+      ansible_test_skip_tags: cli
+      ansible_test_split_in: 2
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python38_1_of_2
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python38
+    vars:
+      ansible_test_do_number: 1
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-netconf-python38_2_of_2
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python38
+    vars:
+      ansible_test_do_number: 2
 
 - job:
     name: ansible-test-network-integration-junos-vsrx-cli-python38

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -720,7 +720,7 @@
       ansible_test_integration_targets: "tests/unit/modules/network/junos/test_junos.*"
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-python27
+    name: ansible-test-network-integration-junos-vsrx-netconf-python27
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python27
     vars:
@@ -735,7 +735,7 @@
       ansible_test_skip_tags: netconf
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-python27-stable29
+    name: ansible-test-network-integration-junos-vsrx-netconf-python27-stable29
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python27
     required-projects:
@@ -756,7 +756,7 @@
       ansible_test_skip_tags: netconf
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-python35
+    name: ansible-test-network-integration-junos-vsrx-netconf-python35
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python35
     vars:
@@ -771,7 +771,7 @@
       ansible_test_skip_tags: netconf
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-python35-stable29
+    name: ansible-test-network-integration-junos-vsrx-netconf-python35-stable29
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python35
     required-projects:
@@ -792,7 +792,7 @@
       ansible_test_skip_tags: netconf
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-python36
+    name: ansible-test-network-integration-junos-vsrx-netconf-python36
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python36
     vars:
@@ -807,7 +807,7 @@
       ansible_test_skip_tags: netconf
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-python36-stable29
+    name: ansible-test-network-integration-junos-vsrx-netconf-python36-stable29
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python36
     required-projects:
@@ -828,7 +828,7 @@
       ansible_test_skip_tags: netconf
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-python37
+    name: ansible-test-network-integration-junos-vsrx-netconf-python37
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python37
     vars:
@@ -843,7 +843,7 @@
       ansible_test_skip_tags: netconf
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-python37-stable29
+    name: ansible-test-network-integration-junos-vsrx-netconf-python37-stable29
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python37
     required-projects:
@@ -864,7 +864,7 @@
       ansible_test_skip_tags: netconf
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-python38
+    name: ansible-test-network-integration-junos-vsrx-netconf-python38
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python38
     vars:
@@ -880,35 +880,35 @@
 
 - job:
     name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python27
-    parent: ansible-test-network-integration-junos-vsrx-python27
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python27
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python35
-    parent: ansible-test-network-integration-junos-vsrx-python35
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python35
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python36
-    parent: ansible-test-network-integration-junos-vsrx-python36
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python36
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python37
-    parent: ansible-test-network-integration-junos-vsrx-python37
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python37
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
     name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python38
-    parent: ansible-test-network-integration-junos-vsrx-python38
+    parent: ansible-test-network-integration-junos-vsrx-netconf-python38
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -727,6 +727,14 @@
       ansible_test_python: 2.7
 
 - job:
+    name: ansible-test-network-integration-junos-vsrx-cli-python27
+    parent: ansible-test-network-integration-junos-vsrx
+    nodeset: vsrx3-18.4R1-python27
+    vars:
+      ansible_test_python: 2.7
+      ansible_test_skip_tags: netconf
+
+- job:
     name: ansible-test-network-integration-junos-vsrx-python27-stable29
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python27
@@ -737,11 +745,30 @@
       ansible_test_python: 2.7
 
 - job:
+    name: ansible-test-network-integration-junos-vsrx-cli-python27-stable29
+    parent: ansible-test-network-integration-junos-vsrx
+    nodeset: vsrx3-18.4R1-python27
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
+    vars:
+      ansible_test_python: 2.7
+      ansible_test_skip_tags: netconf
+
+- job:
     name: ansible-test-network-integration-junos-vsrx-python35
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python35
     vars:
       ansible_test_python: 3.5
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-cli-python35
+    parent: ansible-test-network-integration-junos-vsrx
+    nodeset: vsrx3-18.4R1-python35
+    vars:
+      ansible_test_python: 3.5
+      ansible_test_skip_tags: netconf
 
 - job:
     name: ansible-test-network-integration-junos-vsrx-python35-stable29
@@ -754,11 +781,30 @@
       ansible_test_python: 3.5
 
 - job:
+    name: ansible-test-network-integration-junos-vsrx-cli-python35-stable29
+    parent: ansible-test-network-integration-junos-vsrx
+    nodeset: vsrx3-18.4R1-python35
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
+    vars:
+      ansible_test_python: 3.5
+      ansible_test_skip_tags: netconf
+
+- job:
     name: ansible-test-network-integration-junos-vsrx-python36
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python36
     vars:
       ansible_test_python: 3.6
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-cli-python36
+    parent: ansible-test-network-integration-junos-vsrx
+    nodeset: vsrx3-18.4R1-python36
+    vars:
+      ansible_test_python: 3.6
+      ansible_test_skip_tags: netconf
 
 - job:
     name: ansible-test-network-integration-junos-vsrx-python36-stable29
@@ -771,11 +817,30 @@
       ansible_test_python: 3.6
 
 - job:
+    name: ansible-test-network-integration-junos-vsrx-cli-python36-stable29
+    parent: ansible-test-network-integration-junos-vsrx
+    nodeset: vsrx3-18.4R1-python36
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
+    vars:
+      ansible_test_python: 3.6
+      ansible_test_skip_tags: netconf
+
+- job:
     name: ansible-test-network-integration-junos-vsrx-python37
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python37
     vars:
       ansible_test_python: 3.7
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-cli-python37
+    parent: ansible-test-network-integration-junos-vsrx
+    nodeset: vsrx3-18.4R1-python37
+    vars:
+      ansible_test_python: 3.7
+      ansible_test_skip_tags: netconf
 
 - job:
     name: ansible-test-network-integration-junos-vsrx-python37-stable29
@@ -788,11 +853,30 @@
       ansible_test_python: 3.7
 
 - job:
+    name: ansible-test-network-integration-junos-vsrx-cli-python37-stable29
+    parent: ansible-test-network-integration-junos-vsrx
+    nodeset: vsrx3-18.4R1-python37
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
+    vars:
+      ansible_test_python: 3.7
+      ansible_test_skip_tags: netconf
+
+- job:
     name: ansible-test-network-integration-junos-vsrx-python38
     parent: ansible-test-network-integration-junos-vsrx
     nodeset: vsrx3-18.4R1-python38
     vars:
       ansible_test_python: 3.8
+
+- job:
+    name: ansible-test-network-integration-junos-vsrx-cli-python38
+    parent: ansible-test-network-integration-junos-vsrx
+    nodeset: vsrx3-18.4R1-python38
+    vars:
+      ansible_test_python: 3.8
+      ansible_test_skip_tags: netconf
 
 - job:
     name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python27

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -515,7 +515,7 @@
     name: ansible-collections-juniper-junos
     check:
       jobs:
-        - ansible-test-network-integration-junos-vsrx-python27:
+        - ansible-test-network-integration-junos-vsrx-netconf-python27:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -523,7 +523,7 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python27-stable29:
+        - ansible-test-network-integration-junos-vsrx-netconf-python27-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -531,7 +531,7 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python35:
+        - ansible-test-network-integration-junos-vsrx-netconf-python35:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -539,7 +539,7 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python35-stable29:
+        - ansible-test-network-integration-junos-vsrx-netconf-python35-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -547,7 +547,7 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python36:
+        - ansible-test-network-integration-junos-vsrx-netconf-python36:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -555,7 +555,7 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python36-stable29:
+        - ansible-test-network-integration-junos-vsrx-netconf-python36-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -563,7 +563,7 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python37:
+        - ansible-test-network-integration-junos-vsrx-netconf-python37:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -571,7 +571,7 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python37-stable29:
+        - ansible-test-network-integration-junos-vsrx-netconf-python37-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -579,7 +579,7 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python38:
+        - ansible-test-network-integration-junos-vsrx-netconf-python38:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -593,7 +593,7 @@
     gate:
       queue: integrated
       jobs:
-        - ansible-test-network-integration-junos-vsrx-python27:
+        - ansible-test-network-integration-junos-vsrx-netconf-python27:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -601,7 +601,7 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python27-stable29:
+        - ansible-test-network-integration-junos-vsrx-netconf-python27-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -609,7 +609,7 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python35:
+        - ansible-test-network-integration-junos-vsrx-netconf-python35:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -617,7 +617,7 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python35-stable29:
+        - ansible-test-network-integration-junos-vsrx-netconf-python35-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -625,7 +625,7 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python36:
+        - ansible-test-network-integration-junos-vsrx-netconf-python36:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -633,7 +633,7 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python36-stable29:
+        - ansible-test-network-integration-junos-vsrx-netconf-python36-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -641,7 +641,7 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python37:
+        - ansible-test-network-integration-junos-vsrx-netconf-python37:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -649,7 +649,7 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python37-stable29:
+        - ansible-test-network-integration-junos-vsrx-netconf-python37-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -657,7 +657,7 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-python38:
+        - ansible-test-network-integration-junos-vsrx-netconf-python38:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -969,7 +969,7 @@
             branches:
               - stable-2.9
               - stable-2.8
-        - ansible-test-network-integration-junos-vsrx-python27:
+        - ansible-test-network-integration-junos-vsrx-netconf-python27:
             branches:
               - stable-2.9
               - stable-2.8
@@ -977,7 +977,7 @@
             branches:
               - stable-2.9
               - stable-2.8
-        - ansible-test-network-integration-junos-vsrx-python35:
+        - ansible-test-network-integration-junos-vsrx-netconf-python35:
             branches:
               - stable-2.9
               - stable-2.8
@@ -985,7 +985,7 @@
             branches:
               - stable-2.9
               - stable-2.8
-        - ansible-test-network-integration-junos-vsrx-python36:
+        - ansible-test-network-integration-junos-vsrx-netconf-python36:
             branches:
               - stable-2.9
               - stable-2.8
@@ -993,7 +993,7 @@
             branches:
               - stable-2.9
               - stable-2.8
-        - ansible-test-network-integration-junos-vsrx-python37:
+        - ansible-test-network-integration-junos-vsrx-netconf-python37:
             branches:
               - stable-2.9
               - stable-2.8
@@ -1295,7 +1295,7 @@
               - ^test/integration/targets/netconf_.*
               - ^test/integration/targets/prepare_iosxr_tests/.*
             voting: false
-        - ansible-test-network-integration-junos-vsrx-python27:
+        - ansible-test-network-integration-junos-vsrx-netconf-python27:
             branches:
               - stable-2.9
               - stable-2.8
@@ -1343,7 +1343,7 @@
               - ^test/integration/targets/junos_.*
               - ^test/integration/targets/netconf_.*
               - ^test/integration/targets/prepare_junos_tests/.*
-        - ansible-test-network-integration-junos-vsrx-python35:
+        - ansible-test-network-integration-junos-vsrx-netconf-python35:
             branches:
               - stable-2.9
               - stable-2.8
@@ -1391,7 +1391,7 @@
               - ^test/integration/targets/junos_.*
               - ^test/integration/targets/netconf_.*
               - ^test/integration/targets/prepare_junos_tests/.*
-        - ansible-test-network-integration-junos-vsrx-python36:
+        - ansible-test-network-integration-junos-vsrx-netconf-python36:
             branches:
               - stable-2.9
               - stable-2.8
@@ -1439,7 +1439,7 @@
               - ^test/integration/targets/junos_.*
               - ^test/integration/targets/netconf_.*
               - ^test/integration/targets/prepare_junos_tests/.*
-        - ansible-test-network-integration-junos-vsrx-python37:
+        - ansible-test-network-integration-junos-vsrx-netconf-python37:
             branches:
               - stable-2.9
               - stable-2.8

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -515,7 +515,11 @@
     name: ansible-collections-juniper-junos
     check:
       jobs:
-        - ansible-test-network-integration-junos-vsrx-netconf-python27:
+        - ansible-test-network-integration-junos-vsrx-netconf-python27_1_of_2:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python27_2_of_2:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -523,7 +527,11 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python27-stable29:
+        - ansible-test-network-integration-junos-vsrx-netconf-python27-stable29_1_of_2:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python27-stable29_2_of_2:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -531,7 +539,11 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python35:
+        - ansible-test-network-integration-junos-vsrx-netconf-python35_1_of_2:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python35_2_of_2:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -539,7 +551,11 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python35-stable29:
+        - ansible-test-network-integration-junos-vsrx-netconf-python35-stable29_1_of_2:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python35-stable29_2_of_2:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -547,7 +563,11 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python36:
+        - ansible-test-network-integration-junos-vsrx-netconf-python36_1_of_2:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python36_2_of_2:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -555,7 +575,11 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python36-stable29:
+        - ansible-test-network-integration-junos-vsrx-netconf-python36-stable29_1_of_2:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python36-stable29_2_of_2:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -563,7 +587,11 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python37:
+        - ansible-test-network-integration-junos-vsrx-netconf-python37_1_of_2:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python37_2_of_2:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -571,7 +599,11 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python37-stable29:
+        - ansible-test-network-integration-junos-vsrx-netconf-python37-stable29_1_of_2:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python37-stable29_2_of_2:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -579,7 +611,11 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python38:
+        - ansible-test-network-integration-junos-vsrx-netconf-python38_1_of_2:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python38_2_of_2:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -593,7 +629,11 @@
     gate:
       queue: integrated
       jobs:
-        - ansible-test-network-integration-junos-vsrx-netconf-python27:
+        - ansible-test-network-integration-junos-vsrx-netconf-python27_1_of_2:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python27_2_of_2:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -601,7 +641,11 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python27-stable29:
+        - ansible-test-network-integration-junos-vsrx-netconf-python27-stable29_1_of_2:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python27-stable29_2_of_2:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -609,7 +653,11 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python35:
+        - ansible-test-network-integration-junos-vsrx-netconf-python35_1_of_2:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python35_2_of_2:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -617,7 +665,11 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python35-stable29:
+        - ansible-test-network-integration-junos-vsrx-netconf-python35-stable29_1_of_2:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python35-stable29_2_of_2:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -625,7 +677,11 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python36:
+        - ansible-test-network-integration-junos-vsrx-netconf-python36_1_of_2:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python36_2_of_2:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -633,7 +689,11 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python36-stable29:
+        - ansible-test-network-integration-junos-vsrx-netconf-python36-stable29_1_of_2:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python36-stable29_2_of_2:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -641,7 +701,11 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python37:
+        - ansible-test-network-integration-junos-vsrx-netconf-python37_1_of_2:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python37_2_of_2:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -649,7 +713,11 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python37-stable29:
+        - ansible-test-network-integration-junos-vsrx-netconf-python37-stable29_1_of_2:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python37-stable29_2_of_2:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -657,7 +725,11 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python38:
+        - ansible-test-network-integration-junos-vsrx-netconf-python38_1_of_2:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python38_2_of_2:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -969,7 +1041,11 @@
             branches:
               - stable-2.9
               - stable-2.8
-        - ansible-test-network-integration-junos-vsrx-netconf-python27:
+        - ansible-test-network-integration-junos-vsrx-netconf-python27_1_of_2:
+            branches:
+              - stable-2.9
+              - stable-2.8
+        - ansible-test-network-integration-junos-vsrx-netconf-python27_2_of_2:
             branches:
               - stable-2.9
               - stable-2.8
@@ -977,7 +1053,11 @@
             branches:
               - stable-2.9
               - stable-2.8
-        - ansible-test-network-integration-junos-vsrx-netconf-python35:
+        - ansible-test-network-integration-junos-vsrx-netconf-python35_1_of_2:
+            branches:
+              - stable-2.9
+              - stable-2.8
+        - ansible-test-network-integration-junos-vsrx-netconf-python35_2_of_2:
             branches:
               - stable-2.9
               - stable-2.8
@@ -985,7 +1065,11 @@
             branches:
               - stable-2.9
               - stable-2.8
-        - ansible-test-network-integration-junos-vsrx-netconf-python36:
+        - ansible-test-network-integration-junos-vsrx-netconf-python36_1_of_2:
+            branches:
+              - stable-2.9
+              - stable-2.8
+        - ansible-test-network-integration-junos-vsrx-netconf-python36_2_of_2:
             branches:
               - stable-2.9
               - stable-2.8
@@ -993,7 +1077,11 @@
             branches:
               - stable-2.9
               - stable-2.8
-        - ansible-test-network-integration-junos-vsrx-netconf-python37:
+        - ansible-test-network-integration-junos-vsrx-netconf-python37_1_of_2:
+            branches:
+              - stable-2.9
+              - stable-2.8
+        - ansible-test-network-integration-junos-vsrx-netconf-python37_2_of_2:
             branches:
               - stable-2.9
               - stable-2.8
@@ -1295,7 +1383,31 @@
               - ^test/integration/targets/netconf_.*
               - ^test/integration/targets/prepare_iosxr_tests/.*
             voting: false
-        - ansible-test-network-integration-junos-vsrx-netconf-python27:
+        - ansible-test-network-integration-junos-vsrx-netconf-python27_1_of_2:
+            branches:
+              - stable-2.9
+              - stable-2.8
+            files:
+              - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+              - ^lib/ansible/modules/network/cli/.*
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/modules/network/netconf/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/module_utils/network/netconf/.*
+              - ^lib/ansible/plugins/action/junos.py
+              - ^lib/ansible/plugins/action/net_.*
+              - ^lib/ansible/plugins/cliconf/junos.py
+              - ^lib/ansible/plugins/connection/local.py
+              - ^lib/ansible/plugins/connection/netconf.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/netconf/.*
+              - ^lib/ansible/plugins/terminal/__init__.py
+              - ^lib/ansible/plugins/terminal/junos.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
+              - ^test/integration/targets/prepare_junos_tests/.*
+        - ansible-test-network-integration-junos-vsrx-netconf-python27_2_of_2:
             branches:
               - stable-2.9
               - stable-2.8
@@ -1343,7 +1455,7 @@
               - ^test/integration/targets/junos_.*
               - ^test/integration/targets/netconf_.*
               - ^test/integration/targets/prepare_junos_tests/.*
-        - ansible-test-network-integration-junos-vsrx-netconf-python35:
+        - ansible-test-network-integration-junos-vsrx-netconf-python35_1_of_2:
             branches:
               - stable-2.9
               - stable-2.8
@@ -1367,6 +1479,31 @@
               - ^test/integration/targets/junos_.*
               - ^test/integration/targets/netconf_.*
               - ^test/integration/targets/prepare_junos_tests/.*
+        - ansible-test-network-integration-junos-vsrx-netconf-python35_2_of_2:
+            branches:
+              - stable-2.9
+              - stable-2.8
+            files:
+              - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+              - ^lib/ansible/modules/network/cli/.*
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/modules/network/netconf/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/module_utils/network/netconf/.*
+              - ^lib/ansible/plugins/action/junos.py
+              - ^lib/ansible/plugins/action/net_.*
+              - ^lib/ansible/plugins/cliconf/junos.py
+              - ^lib/ansible/plugins/connection/local.py
+              - ^lib/ansible/plugins/connection/netconf.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/netconf/.*
+              - ^lib/ansible/plugins/terminal/__init__.py
+              - ^lib/ansible/plugins/terminal/junos.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
+              - ^test/integration/targets/prepare_junos_tests/.*
+
         - ansible-test-network-integration-junos-vsrx-cli-python35:
             branches:
               - stable-2.9
@@ -1391,7 +1528,31 @@
               - ^test/integration/targets/junos_.*
               - ^test/integration/targets/netconf_.*
               - ^test/integration/targets/prepare_junos_tests/.*
-        - ansible-test-network-integration-junos-vsrx-netconf-python36:
+        - ansible-test-network-integration-junos-vsrx-netconf-python36_1_of_2:
+            branches:
+              - stable-2.9
+              - stable-2.8
+            files:
+              - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+              - ^lib/ansible/modules/network/cli/.*
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/modules/network/netconf/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/module_utils/network/netconf/.*
+              - ^lib/ansible/plugins/action/junos.py
+              - ^lib/ansible/plugins/action/net_.*
+              - ^lib/ansible/plugins/cliconf/junos.py
+              - ^lib/ansible/plugins/connection/local.py
+              - ^lib/ansible/plugins/connection/netconf.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/netconf/.*
+              - ^lib/ansible/plugins/terminal/__init__.py
+              - ^lib/ansible/plugins/terminal/junos.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
+              - ^test/integration/targets/prepare_junos_tests/.*
+        - ansible-test-network-integration-junos-vsrx-netconf-python36_2_of_2:
             branches:
               - stable-2.9
               - stable-2.8
@@ -1439,7 +1600,31 @@
               - ^test/integration/targets/junos_.*
               - ^test/integration/targets/netconf_.*
               - ^test/integration/targets/prepare_junos_tests/.*
-        - ansible-test-network-integration-junos-vsrx-netconf-python37:
+        - ansible-test-network-integration-junos-vsrx-netconf-python37_1_of_2:
+            branches:
+              - stable-2.9
+              - stable-2.8
+            files:
+              - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+              - ^lib/ansible/modules/network/cli/.*
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/modules/network/netconf/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/module_utils/network/netconf/.*
+              - ^lib/ansible/plugins/action/junos.py
+              - ^lib/ansible/plugins/action/net_.*
+              - ^lib/ansible/plugins/cliconf/junos.py
+              - ^lib/ansible/plugins/connection/local.py
+              - ^lib/ansible/plugins/connection/netconf.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/netconf/.*
+              - ^lib/ansible/plugins/terminal/__init__.py
+              - ^lib/ansible/plugins/terminal/junos.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
+              - ^test/integration/targets/prepare_junos_tests/.*
+        - ansible-test-network-integration-junos-vsrx-netconf-python37_2_of_2:
             branches:
               - stable-2.9
               - stable-2.8

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -519,7 +519,15 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python27:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-python27-stable29:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python27-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -527,7 +535,15 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python35:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-python35-stable29:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python35-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -535,7 +551,15 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python36:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-python36-stable29:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python36-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -543,11 +567,23 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python37:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-python37-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python37-stable29:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-python38:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python38:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -561,7 +597,15 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python27:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-python27-stable29:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python27-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -569,7 +613,15 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python35:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-python35-stable29:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python35-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -577,7 +629,15 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python36:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-python36-stable29:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python36-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -585,11 +645,23 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python37:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-python37-stable29:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python37-stable29:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-python38:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-cli-python38:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -901,7 +973,15 @@
             branches:
               - stable-2.9
               - stable-2.8
+        - ansible-test-network-integration-junos-vsrx-cli-python27:
+            branches:
+              - stable-2.9
+              - stable-2.8
         - ansible-test-network-integration-junos-vsrx-python35:
+            branches:
+              - stable-2.9
+              - stable-2.8
+        - ansible-test-network-integration-junos-vsrx-cli-python35:
             branches:
               - stable-2.9
               - stable-2.8
@@ -909,7 +989,15 @@
             branches:
               - stable-2.9
               - stable-2.8
+        - ansible-test-network-integration-junos-vsrx-cli-python36:
+            branches:
+              - stable-2.9
+              - stable-2.8
         - ansible-test-network-integration-junos-vsrx-python37:
+            branches:
+              - stable-2.9
+              - stable-2.8
+        - ansible-test-network-integration-junos-vsrx-cli-python37:
             branches:
               - stable-2.9
               - stable-2.8
@@ -1231,7 +1319,55 @@
               - ^test/integration/targets/junos_.*
               - ^test/integration/targets/netconf_.*
               - ^test/integration/targets/prepare_junos_tests/.*
+        - ansible-test-network-integration-junos-vsrx-cli-python27:
+            branches:
+              - stable-2.9
+              - stable-2.8
+            files:
+              - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+              - ^lib/ansible/modules/network/cli/.*
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/modules/network/netconf/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/module_utils/network/netconf/.*
+              - ^lib/ansible/plugins/action/junos.py
+              - ^lib/ansible/plugins/action/net_.*
+              - ^lib/ansible/plugins/cliconf/junos.py
+              - ^lib/ansible/plugins/connection/local.py
+              - ^lib/ansible/plugins/connection/netconf.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/netconf/.*
+              - ^lib/ansible/plugins/terminal/__init__.py
+              - ^lib/ansible/plugins/terminal/junos.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
+              - ^test/integration/targets/prepare_junos_tests/.*
         - ansible-test-network-integration-junos-vsrx-python35:
+            branches:
+              - stable-2.9
+              - stable-2.8
+            files:
+              - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+              - ^lib/ansible/modules/network/cli/.*
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/modules/network/netconf/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/module_utils/network/netconf/.*
+              - ^lib/ansible/plugins/action/junos.py
+              - ^lib/ansible/plugins/action/net_.*
+              - ^lib/ansible/plugins/cliconf/junos.py
+              - ^lib/ansible/plugins/connection/local.py
+              - ^lib/ansible/plugins/connection/netconf.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/netconf/.*
+              - ^lib/ansible/plugins/terminal/__init__.py
+              - ^lib/ansible/plugins/terminal/junos.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
+              - ^test/integration/targets/prepare_junos_tests/.*
+        - ansible-test-network-integration-junos-vsrx-cli-python35:
             branches:
               - stable-2.9
               - stable-2.8
@@ -1279,7 +1415,55 @@
               - ^test/integration/targets/junos_.*
               - ^test/integration/targets/netconf_.*
               - ^test/integration/targets/prepare_junos_tests/.*
+        - ansible-test-network-integration-junos-vsrx-cli-python36:
+            branches:
+              - stable-2.9
+              - stable-2.8
+            files:
+              - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+              - ^lib/ansible/modules/network/cli/.*
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/modules/network/netconf/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/module_utils/network/netconf/.*
+              - ^lib/ansible/plugins/action/junos.py
+              - ^lib/ansible/plugins/action/net_.*
+              - ^lib/ansible/plugins/cliconf/junos.py
+              - ^lib/ansible/plugins/connection/local.py
+              - ^lib/ansible/plugins/connection/netconf.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/netconf/.*
+              - ^lib/ansible/plugins/terminal/__init__.py
+              - ^lib/ansible/plugins/terminal/junos.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
+              - ^test/integration/targets/prepare_junos_tests/.*
         - ansible-test-network-integration-junos-vsrx-python37:
+            branches:
+              - stable-2.9
+              - stable-2.8
+            files:
+              - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+              - ^lib/ansible/modules/network/cli/.*
+              - ^lib/ansible/modules/network/junos/.*
+              - ^lib/ansible/modules/network/netconf/.*
+              - ^lib/ansible/module_utils/network/common/.*
+              - ^lib/ansible/module_utils/network/junos/.*
+              - ^lib/ansible/module_utils/network/netconf/.*
+              - ^lib/ansible/plugins/action/junos.py
+              - ^lib/ansible/plugins/action/net_.*
+              - ^lib/ansible/plugins/cliconf/junos.py
+              - ^lib/ansible/plugins/connection/local.py
+              - ^lib/ansible/plugins/connection/netconf.py
+              - ^lib/ansible/plugins/connection/network_cli.py
+              - ^lib/ansible/plugins/netconf/.*
+              - ^lib/ansible/plugins/terminal/__init__.py
+              - ^lib/ansible/plugins/terminal/junos.py
+              - ^test/integration/targets/junos_.*
+              - ^test/integration/targets/netconf_.*
+              - ^test/integration/targets/prepare_junos_tests/.*
+        - ansible-test-network-integration-junos-vsrx-cli-python37:
             branches:
               - stable-2.9
               - stable-2.8


### PR DESCRIPTION
## Add junos cli jobs

This commit adds junos cli transport jobs.

## Rename junos netconf jobs

This PR renames netconf junos jobs, as well as junos netcommon
integration jobs.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>

## Split junos netconf 2 into two

This PR splits current netconf jobs into two, in order to parallellize
them and avoid getting into timeout issues.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>