### PR TITLE
Default all system-required projects to squash-merge

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1654,6 +1654,7 @@
       repository should use this directly.
     # Include a check queue so that initially every repo has a check queue
     # and we can report invalid zuul.yaml files.
+    merge-mode: squash-merge
     check:
       jobs:
         - github-workflows


### PR DESCRIPTION
This should help clean up git commit history.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>