### PR TITLE
esxi: retry to set hostname on failure

### DIFF
--- a/roles/vmware-ci-write-etc-hosts/tasks/main.yaml
+++ b/roles/vmware-ci-write-etc-hosts/tasks/main.yaml
@@ -22,6 +22,11 @@
     - name: set the correct ESXi hostname
       command: "esxcli system hostname set --fqdn={{ inventory_hostname }}.test"
       when: inventory_hostname.startswith("esxi")
+      # See: https://github.com/ansible-collections/vmware/issues/144
+      retries: 3
+      delay: 3
+      register: _esxcli_system_hostname_set
+      until: _esxcli_system_hostname_set is not failed
 
     - name: set the vCenter hostname
       command: "hostnamectl set-hostname {{ inventory_hostname }}.test"


### PR DESCRIPTION
Time to time, we get the following error:
`IO error: [Errno 97] Address family not supported by protocol`

This seems to be a sporadic issue, lets see if a `retry` is enough
to deal with it.

See: https://github.com/ansible-collections/vmware/issues/144