### PR TITLE
Remove qradar / vmware / splunk from integrated queue

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -575,7 +575,6 @@
         - ansible-tox-linters
         - build-ansible-collection
     gate:
-      queue: integrated
       jobs:
         - ansible-test-cloud-integration-govcsim-python36_1_of_3:
             vars:
@@ -1010,7 +1009,6 @@
         - build-ansible-collection
         - ansible-test-security-integration-qradar-python38
     gate:
-      queue: integrated
       jobs:
         - build-ansible-collection
         - ansible-test-security-integration-qradar-python38
@@ -1022,7 +1020,6 @@
         - build-ansible-collection
         - ansible-security-integration-splunk-es-python36
     gate:
-      queue: integrated
       jobs:
         - build-ansible-collection
         - ansible-security-integration-splunk-es-python36


### PR DESCRIPTION
These jobs do not use ansible.netcommon, so we can remove them from the
shared queue. It maybe possible that each will want to form new queues
themself in the future.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>