### PR TITLE
Set junos unit test job to non-voting

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -960,6 +960,7 @@
 - job:
     name: ansible-test-units-junos
     parent: ansible-test-units-base
+    voting: false
     required-projects:
       - name: github.com/ansible-collections/junipernetworks.junos
     timeout: 3600


### PR DESCRIPTION
Before the dependencies on the job [1] are merged, triggering unit test
will just fail. It seems that until recently ansible-test was providing
such dependencies, so we were able to merge jobs, but that's no longer
the case.

Once [1] is merged, we'll reenable the voting

[1] https://github.com/ansible-collections/junipernetworks.junos/pull/52