### PR TITLE
Switch sanity-base to ansible 2.9

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -100,6 +100,7 @@
     run: playbooks/ansible-test-base/run.yaml
     required-projects:
       - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
     timeout: 3600
     vars:
       ansible_test_collections: true

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -840,14 +840,14 @@
     name: ansible-collections-openvswitch-openvswitch-units
     check:
       jobs:
-        - ansible-test-sanity-openvswitch:
-            voting: false
+        - ansible-test-sanity-openvswitch
         - ansible-test-units-openvswitch:
             vars:
               ansible_test_collections: true
     gate:
       queue: integrated
       jobs:
+        - ansible-test-sanity-openvswitch
         - ansible-test-units-openvswitch:
             vars:
               ansible_test_collections: true


### PR DESCRIPTION
This is because automation hub defaults to that.

Make openvswitch sanity job voting.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>