### PR TITLE
nodesets: add appliance_no_ssh group

### DIFF
--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -81,6 +81,9 @@
         nodes:
           - vcenter
           - esxi1
+      - name: appliance_no_ssh
+        nodes:
+          - esxi1
       - name: esxis
         nodes:
           - esxi1
@@ -101,6 +104,9 @@
       - name: appliance
         nodes:
           - vcenter
+          - esxi1
+      - name: appliance_no_ssh
+        nodes:
           - esxi1
       - name: esxis
         nodes:
@@ -124,6 +130,10 @@
       - name: appliance
         nodes:
           - vcenter
+          - esxi1
+          - esxi2
+      - name: appliance_no_ssh
+        nodes:
           - esxi1
           - esxi2
       - name: esxis
@@ -164,6 +174,9 @@
         nodes:
           - vcenter
           - esxi1
+      - name: appliance_no_ssh
+        nodes:
+          - esxi1
       - name: esxis
         nodes:
           - esxi1
@@ -184,6 +197,9 @@
       - name: appliance
         nodes:
           - vcenter
+          - esxi1
+      - name: appliance_no_ssh
+        nodes:
           - esxi1
       - name: esxis
         nodes:
@@ -209,6 +225,10 @@
           - vcenter
           - esxi1
           - esxi2
+      - name: appliance_no_ssh
+        nodes:
+          - esxi1
+          - esxi2
       - name: esxis
         nodes:
           - esxi1
@@ -230,6 +250,9 @@
       - name: appliance
         nodes:
           - asav9-12-3
+      - name: appliance_no_ssh
+        nodes:
+          - asav9-12-3
       - name: controller
         nodes:
           - ubuntu-bionic
@@ -243,6 +266,9 @@
         label: asav9-12-3
     groups:
       - name: appliance
+        nodes:
+          - asav9-12-3
+      - name: appliance_no_ssh
         nodes:
           - asav9-12-3
       - name: controller
@@ -260,6 +286,9 @@
       - name: appliance
         nodes:
           - asav9-12-3
+      - name: appliance_no_ssh
+        nodes:
+          - asav9-12-3
       - name: controller
         nodes:
           - centos-8
@@ -273,6 +302,9 @@
         label: asav9-12-3
     groups:
       - name: appliance
+        nodes:
+          - asav9-12-3
+      - name: appliance_no_ssh
         nodes:
           - asav9-12-3
       - name: controller
@@ -290,6 +322,9 @@
       - name: appliance
         nodes:
           - asav9-12-3
+      - name: appliance_no_ssh
+        nodes:
+          - asav9-12-3
       - name: controller
         nodes:
           - ubuntu-bionic
@@ -303,6 +338,9 @@
         label: eos-4.20.10
     groups:
       - name: appliance
+        nodes:
+          - eos-4.20.10
+      - name: appliance_no_ssh
         nodes:
           - eos-4.20.10
       - name: controller
@@ -320,6 +358,9 @@
       - name: appliance
         nodes:
           - eos-4.20.10
+      - name: appliance_no_ssh
+        nodes:
+          - eos-4.20.10
       - name: controller
         nodes:
           - ubuntu-xenial
@@ -333,6 +374,9 @@
         label: eos-4.20.10
     groups:
       - name: appliance
+        nodes:
+          - eos-4.20.10
+      - name: appliance_no_ssh
         nodes:
           - eos-4.20.10
       - name: controller
@@ -350,6 +394,9 @@
       - name: appliance
         nodes:
           - eos-4.20.10
+      - name: appliance_no_ssh
+        nodes:
+          - eos-4.20.10
       - name: controller
         nodes:
           - fedora-31
@@ -363,6 +410,9 @@
         label: eos-4.20.10
     groups:
       - name: appliance
+        nodes:
+          - eos-4.20.10
+      - name: appliance_no_ssh
         nodes:
           - eos-4.20.10
       - name: controller
@@ -380,6 +430,9 @@
       - name: appliance
         nodes:
           - ios-15.6-2T
+      - name: appliance_no_ssh
+        nodes:
+          - ios-15.6-2T
       - name: controller
         nodes:
           - ubuntu-bionic
@@ -393,6 +446,9 @@
         label: ios-15.6-2T
     groups:
       - name: appliance
+        nodes:
+          - ios-15.6-2T
+      - name: appliance_no_ssh
         nodes:
           - ios-15.6-2T
       - name: controller
@@ -410,6 +466,9 @@
       - name: appliance
         nodes:
           - ios-15.6-2T
+      - name: appliance_no_ssh
+        nodes:
+          - ios-15.6-2T
       - name: controller
         nodes:
           - centos-8
@@ -423,6 +482,9 @@
         label: ios-15.6-2T
     groups:
       - name: appliance
+        nodes:
+          - ios-15.6-2T
+      - name: appliance_no_ssh
         nodes:
           - ios-15.6-2T
       - name: controller
@@ -440,6 +502,9 @@
       - name: appliance
         nodes:
           - ios-15.6-2T
+      - name: appliance_no_ssh
+        nodes:
+          - ios-15.6-2T
       - name: controller
         nodes:
           - ubuntu-bionic
@@ -453,6 +518,9 @@
         label: iosxrv-6.1.3
     groups:
       - name: appliance
+        nodes:
+          - iosxr-6.1.3
+      - name: appliance_no_ssh
         nodes:
           - iosxr-6.1.3
       - name: controller
@@ -470,6 +538,9 @@
       - name: appliance
         nodes:
           - iosxr-6.1.3
+      - name: appliance_no_ssh
+        nodes:
+          - iosxr-6.1.3
       - name: controller
         nodes:
           - ubuntu-xenial
@@ -483,6 +554,9 @@
         label: iosxrv-6.1.3
     groups:
       - name: appliance
+        nodes:
+          - iosxr-6.1.3
+      - name: appliance_no_ssh
         nodes:
           - iosxr-6.1.3
       - name: controller
@@ -500,6 +574,9 @@
       - name: appliance
         nodes:
           - iosxr-6.1.3
+      - name: appliance_no_ssh
+        nodes:
+          - iosxr-6.1.3
       - name: controller
         nodes:
           - fedora-31
@@ -515,6 +592,9 @@
       - name: appliance
         nodes:
           - iosxr-6.1.3
+      - name: appliance_no_ssh
+        nodes:
+          - iosxr-6.1.3
       - name: controller
         nodes:
           - ubuntu-bionic
@@ -528,6 +608,9 @@
         label: nxos-7.0.3
     groups:
       - name: appliance
+        nodes:
+          - nxos-7.0.3
+      - name: appliance_no_ssh
         nodes:
           - nxos-7.0.3
       - name: controller
@@ -620,6 +703,9 @@
       - name: appliance
         nodes:
           - vqfx-18.1R3
+      - name: appliance_no_ssh
+        nodes:
+          - vqfx-18.1R3
       - name: controller
         nodes:
           - ubuntu-bionic
@@ -633,6 +719,9 @@
         label: vqfx-18.1R3
     groups:
       - name: appliance
+        nodes:
+          - vqfx-18.1R3
+      - name: appliance_no_ssh
         nodes:
           - vqfx-18.1R3
       - name: controller
@@ -650,6 +739,9 @@
       - name: appliance
         nodes:
           - vqfx-18.1R3
+      - name: appliance_no_ssh
+        nodes:
+          - vqfx-18.1R3
       - name: controller
         nodes:
           - centos-8
@@ -663,6 +755,9 @@
         label: vqfx-18.1R3
     groups:
       - name: appliance
+        nodes:
+          - vqfx-18.1R3
+      - name: appliance_no_ssh
         nodes:
           - vqfx-18.1R3
       - name: controller
@@ -695,6 +790,9 @@
       - name: appliance
         nodes:
           - vsrx3-18.4R1
+      - name: appliance_no_ssh
+        nodes:
+          - vsrx3-18.4R1
       - name: controller
         nodes:
           - ubuntu-bionic
@@ -708,6 +806,9 @@
         label: vsrx3-18.4R1
     groups:
       - name: appliance
+        nodes:
+          - vsrx3-18.4R1
+      - name: appliance_no_ssh
         nodes:
           - vsrx3-18.4R1
       - name: controller
@@ -725,6 +826,9 @@
       - name: appliance
         nodes:
           - vsrx3-18.4R1
+      - name: appliance_no_ssh
+        nodes:
+          - vsrx3-18.4R1
       - name: controller
         nodes:
           - centos-8
@@ -738,6 +842,9 @@
         label: vsrx3-18.4R1
     groups:
       - name: appliance
+        nodes:
+          - vsrx3-18.4R1
+      - name: appliance_no_ssh
         nodes:
           - vsrx3-18.4R1
       - name: controller
@@ -755,6 +862,9 @@
       - name: appliance
         nodes:
           - vsrx3-18.4R1
+      - name: appliance_no_ssh
+        nodes:
+          - vsrx3-18.4R1
       - name: controller
         nodes:
           - ubuntu-bionic
@@ -768,6 +878,9 @@
         label: vyos-1.1.8-1vcpu
     groups:
       - name: appliance
+        nodes:
+          - vyos-1.1.8
+      - name: appliance_no_ssh
         nodes:
           - vyos-1.1.8
       - name: controller
@@ -785,6 +898,9 @@
       - name: appliance
         nodes:
           - vyos-1.1.8
+      - name: appliance_no_ssh
+        nodes:
+          - vyos-1.1.8
       - name: controller
         nodes:
           - ubuntu-xenial
@@ -798,6 +914,9 @@
         label: vyos-1.1.8-1vcpu
     groups:
       - name: appliance
+        nodes:
+          - vyos-1.1.8
+      - name: appliance_no_ssh
         nodes:
           - vyos-1.1.8
       - name: controller
@@ -815,6 +934,9 @@
       - name: appliance
         nodes:
           - vyos-1.1.8
+      - name: appliance_no_ssh
+        nodes:
+          - vyos-1.1.8
       - name: controller
         nodes:
           - fedora-31
@@ -828,6 +950,9 @@
         label: vyos-1.1.8-1vcpu
     groups:
       - name: appliance
+        nodes:
+          - vyos-1.1.8
+      - name: appliance_no_ssh
         nodes:
           - vyos-1.1.8
       - name: controller


### PR DESCRIPTION
`add-build-sshkey` from `base-minimal` will regenerate a new set
of SSH key and push them on the nodes. However it ignores the
hosts from the `appliance` group. As a result, there is no way to
access the appliances over SSH after this step.

The `appliance` group is too broad. This new group resolves the
problem. It clearly identifies the hosts that should not be targeted
by this operation.

We currently face the problem with the vcenter and splunk hosts. So
far the workaround was to hardcode a known password to the zuul users.