### PR TITLE
Add ansible-galaxy-importer job

### DIFF
--- a/playbooks/ansible-galaxy-importer/run.yaml
+++ b/playbooks/ansible-galaxy-importer/run.yaml
@@ -1,0 +1,27 @@
+---
+- hosts: all
+  tasks:
+    - name: Setup tox role
+      include_role:
+        name: tox
+      vars:
+        tox_extra_args: -vv --notest
+        tox_install_siblings: false
+        zuul_work_dir: "{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"
+
+    - name: Generate version number for ansible collection
+      args:
+        chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
+      shell: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv/bin/generate-ansible-collection"
+      register: _version
+
+    - name: Fetch and install the artifacts
+      import_role:
+        name: deploy-artifacts
+      vars:
+        deploy_artifacts_venv_path: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv"
+
+    - name: Confirm collection can be imported into galaxy
+      args:
+        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"
+      shell: "source .tox/venv/bin/activate; ./tools/validate-collection.sh {{ ansible_user_dir }}/downloads/{{ _version.stdout }}"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -88,6 +88,17 @@
       release_python: python3
 
 - job:
+    name: ansible-galaxy-importer
+    description: |
+      Build ansible collections and return artifacts to zuul
+    dependencies:
+      - name: build-ansible-collection
+    run: playbooks/ansible-galaxy-importer/run.yaml
+    required-projects:
+      - github.com/ansible-network/releases
+    nodeset: centos-8-1vcpu
+
+- job:
     name: ansible-test-sanity-base
     parent: unittests
     nodeset: controller-python36

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -51,6 +51,7 @@
     name: ansible-collections-arista-eos
     check:
       jobs:
+        - ansible-galaxy-importer
         - ansible-test-network-integration-eos-httpapi-python27:
             vars:
               ansible_test_collections: true
@@ -111,6 +112,7 @@
     gate:
       queue: integrated
       jobs:
+        - ansible-galaxy-importer
         - ansible-test-network-integration-eos-httpapi-python27:
             vars:
               ansible_test_collections: true
@@ -189,6 +191,7 @@
     name: ansible-collections-cisco-asa
     check:
       jobs:
+        - ansible-galaxy-importer
         - ansible-test-network-integration-asa-python27:
             vars:
               ansible_test_collections: true
@@ -227,6 +230,7 @@
     gate:
       queue: integrated
       jobs:
+        - ansible-galaxy-importer
         - ansible-test-network-integration-asa-python27:
             vars:
               ansible_test_collections: true
@@ -263,6 +267,7 @@
     name: ansible-collections-cisco-nxos
     check:
       jobs:
+        - ansible-galaxy-importer
         - ansible-test-network-integration-nxos-cli-python36_1_of_4:
             vars:
               ansible_test_collections: true
@@ -281,6 +286,7 @@
     gate:
       queue: integrated
       jobs:
+        - ansible-galaxy-importer
         - ansible-test-network-integration-nxos-cli-python36_1_of_4:
             vars:
               ansible_test_collections: true
@@ -317,6 +323,7 @@
     name: ansible-collections-cisco-ios
     check:
       jobs:
+        - ansible-galaxy-importer
         - ansible-test-network-integration-ios-local-python27:
             vars:
               ansible_test_collections: true
@@ -377,6 +384,7 @@
     gate:
       queue: integrated
       jobs:
+        - ansible-galaxy-importer
         - ansible-test-network-integration-ios-local-python27:
             vars:
               ansible_test_collections: true
@@ -455,6 +463,7 @@
     name: ansible-collections-cisco-iosxr
     check:
       jobs:
+        - ansible-galaxy-importer
         - ansible-test-network-integration-iosxr-python27:
             vars:
               ansible_test_collections: true
@@ -506,6 +515,7 @@
     gate:
       queue: integrated
       jobs:
+        - ansible-galaxy-importer
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
@@ -558,6 +568,7 @@
     name: ansible-collections-community-vmware
     check:
       jobs:
+        - ansible-galaxy-importer
         - ansible-test-cloud-integration-govcsim-python36_1_of_3:
             vars:
               ansible_test_collections: true
@@ -586,6 +597,7 @@
         - build-ansible-collection
     gate:
       jobs:
+        - ansible-galaxy-importer
         - ansible-test-cloud-integration-govcsim-python36_1_of_3:
             vars:
               ansible_test_collections: true
@@ -634,6 +646,7 @@
     name: ansible-collections-juniper-junos
     check:
       jobs:
+        - ansible-galaxy-importer
         - ansible-test-network-integration-junos-vsrx-netconf-python27:
             vars:
               ansible_test_collections: true
@@ -712,6 +725,7 @@
     gate:
       queue: integrated
       jobs:
+        - ansible-galaxy-importer
         - ansible-test-network-integration-junos-vsrx-netconf-python27:
             vars:
               ansible_test_collections: true
@@ -856,6 +870,7 @@
     name: ansible-collections-openvswitch-openvswitch
     check:
       jobs:
+        - ansible-galaxy-importer
         - ansible-test-network-integration-openvswitch-python27:
             vars:
               ansible_test_collections: true
@@ -889,6 +904,7 @@
     gate:
       queue: integrated
       jobs:
+        - ansible-galaxy-importer
         - ansible-test-network-integration-openvswitch-python27:
             vars:
               ansible_test_collections: true
@@ -940,6 +956,7 @@
     name: ansible-collections-vyos-vyos
     check:
       jobs:
+        - ansible-galaxy-importer
         - ansible-test-network-integration-vyos-python27:
             vars:
               ansible_test_collections: true
@@ -973,6 +990,7 @@
     gate:
       queue: integrated
       jobs:
+        - ansible-galaxy-importer
         - ansible-test-network-integration-vyos-python27:
             vars:
               ansible_test_collections: true
@@ -1040,10 +1058,12 @@
     name: ansible-collections-security-ibm-qradar
     check:
       jobs:
+        - ansible-galaxy-importer
         - build-ansible-collection
         - ansible-test-security-integration-qradar-python38
     gate:
       jobs:
+        - ansible-galaxy-importer
         - build-ansible-collection
         - ansible-test-security-integration-qradar-python38
 
@@ -1051,10 +1071,12 @@
     name: ansible-collections-security-splunk-es
     check:
       jobs:
+        - ansible-galaxy-importer
         - build-ansible-collection
         - ansible-security-integration-splunk-es-python36
     gate:
       jobs:
+        - ansible-galaxy-importer
         - build-ansible-collection
         - ansible-security-integration-splunk-es-python36
 


### PR DESCRIPTION
A new job to confirm we can import collections into galaxy.

Depends-On: https://github.com/ansible-network/releases/pull/6
Signed-off-by: Paul Belanger <pabelanger@redhat.com>