### PR TITLE
vmware: use appliance-ssh group

### DIFF
--- a/playbooks/ansible-cloud/appliance-base/pre.yaml
+++ b/playbooks/ansible-cloud/appliance-base/pre.yaml
@@ -14,7 +14,7 @@
     - name: Set SSH interface IP for appliance
       set_fact:
         __ssh_ip: "{{ hostvars[item].ansible_host }}"
-      with_inventory_hostnames: appliance
+      with_inventory_hostnames: appliance:appliance-ssh
 
     - name: Wait 300 seconds for port tcp/22 on appliance
       wait_for:
@@ -24,7 +24,7 @@
 
     - name: Ensure remote SSH host keys are known
       shell: "ssh-keyscan -v {{hostvars[item].ansible_host }} >> ~/.ssh/known_hosts"
-      with_inventory_hostnames: appliance
+      with_inventory_hostnames: appliance:appliance-ssh
 
     - name: Create /etc/ansible folder
       become: true

--- a/playbooks/ansible-cloud/vcenter-appliance/files/bootstrap.yaml
+++ b/playbooks/ansible-cloud/vcenter-appliance/files/bootstrap.yaml
@@ -7,7 +7,6 @@
     authorized_keys_file:
       esxi1: /etc/ssh/keys-zuul/authorized_keys
       esxi2: /etc/ssh/keys-zuul/authorized_keys
-      vcenter: /home/zuul/.ssh/authorized_keys
   tasks:
 
     - name: lookup SSH public key

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -60,7 +60,7 @@
       - name: vcenter
         label: vmware-vcsa-6.7.0
     groups:
-      - name: appliance
+      - name: appliance-ssh
         nodes:
           - vcenter
       - name: controller
@@ -77,9 +77,11 @@
       - name: esxi1
         label: esxi-6.7.0-with-nested
     groups:
-      - name: appliance
+      - name: appliance-ssh
         nodes:
           - vcenter
+      - name: appliance
+        nodes:
           - esxi1
       - name: esxis
         nodes:
@@ -98,9 +100,11 @@
       - name: esxi1
         label: esxi-6.7.0-without-nested
     groups:
-      - name: appliance
+      - name: appliance-ssh
         nodes:
           - vcenter
+      - name: appliance
+        nodes:
           - esxi1
       - name: esxis
         nodes:
@@ -121,9 +125,11 @@
       - name: esxi2
         label: esxi-6.7.0-without-nested
     groups:
-      - name: appliance
+      - name: appliance-ssh
         nodes:
           - vcenter
+      - name: appliance
+        nodes:
           - esxi1
           - esxi2
       - name: esxis
@@ -143,7 +149,7 @@
       - name: vcenter
         label: vmware-vcsa-7.0.0
     groups:
-      - name: appliance
+      - name: appliance-ssh
         nodes:
           - vcenter
       - name: controller
@@ -160,9 +166,11 @@
       - name: esxi1
         label: esxi-6.7.0-with-nested
     groups:
-      - name: appliance
+      - name: appliance-ssh
         nodes:
           - vcenter
+      - name: appliance
+        nodes:
           - esxi1
       - name: esxis
         nodes:
@@ -181,9 +189,11 @@
       - name: esxi1
         label: esxi-6.7.0-without-nested
     groups:
-      - name: appliance
+      - name: appliance-ssh
         nodes:
           - vcenter
+      - name: appliance
+        nodes:
           - esxi1
       - name: esxis
         nodes:
@@ -204,9 +214,11 @@
       - name: esxi2
         label: esxi-6.7.0-without-nested
     groups:
-      - name: appliance
+      - name: appliance-ssh
         nodes:
           - vcenter
+      - name: appliance
+        nodes:
           - esxi1
           - esxi2
       - name: esxis


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/507

Use the `appliance-ssh` for the vcenter host. It's a regular Linux VM
and we can update the authorized_keys with `prepare-workspace-git`.