### PR TITLE
openvswitch: use appliance-ssh to target appliance

### DIFF
--- a/playbooks/ansible-network-appliance-base/pre.yaml
+++ b/playbooks/ansible-network-appliance-base/pre.yaml
@@ -21,24 +21,24 @@
     - name: Set SSH interface IP for appliance
       set_fact:
         __ssh_ip: "{{ hostvars[item].ansible_host }}"
-      with_inventory_hostnames: appliance:appliance-ssh:openvswitch
+      with_inventory_hostnames: appliance:appliance-ssh
 
     - name: Set SSH interface IP for IOSXR
       set_fact:
         __ssh_ip: "{{ hostvars[item].nodepool.private_ipv4 }}"
       when: hostvars[item].ansible_network_os in ['iosxr']
-      with_inventory_hostnames: appliance:appliance-ssh:openvswitch
+      with_inventory_hostnames: appliance:appliance-ssh
 
     - name: Set SSH interface port for appliance
       set_fact:
         __ssh_port: 22
-      with_inventory_hostnames: appliance:appliance-ssh:openvswitch
+      with_inventory_hostnames: appliance:appliance-ssh
 
     - name: Set SSH interface port for NXOS
       set_fact:
         __ssh_port: 8022
       when: hostvars[item].ansible_network_os in ['nxos']
-      with_inventory_hostnames: appliance:appliance-ssh:openvswitch
+      with_inventory_hostnames: appliance:appliance-ssh
 
     - name: Wait 300 seconds for SSH port on appliance
       wait_for:
@@ -70,7 +70,7 @@
       set_fact:
         __inventory_hostvars: "{{ hostvars | replace(hostvars[item]['ansible_host'], hostvars[item]['nodepool']['private_ipv4']) }}"
       when: hostvars[item].ansible_network_os in ['iosxr']
-      with_inventory_hostnames: appliance:appliance-ssh:openvswitch
+      with_inventory_hostnames: appliance:appliance-ssh
 
     - name: Run write-inventory-fork role
       include_role:

--- a/playbooks/ansible-test-network-integration-base/files/bootstrap-openvswitch.yaml
+++ b/playbooks/ansible-test-network-integration-base/files/bootstrap-openvswitch.yaml
@@ -1,3 +1,3 @@
 ---
-- hosts: openvswitch
+- hosts: appliance*
   tasks: []

--- a/playbooks/ansible-test-network-integration-base/pre.yaml
+++ b/playbooks/ansible-test-network-integration-base/pre.yaml
@@ -2,7 +2,7 @@
 - hosts: controller
   tasks:
     - set_fact:
-        _network_appliance_groups: "{{ groups.keys()|select('match', '^(appliance|openvswitch)')|list }}"
+        _network_appliance_groups: "{{ groups.keys()|select('match', '^appliance')|list }}"
 
     - name: Select proper ansible_network_os
       set_fact:

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -542,7 +542,7 @@
       - name: openvswitch-2.9.0
         label: ubuntu-bionic-1vcpu
     groups:
-      - name: openvswitch
+      - name: appliance-ssh
         nodes:
           - openvswitch-2.9.0
       - name: controller
@@ -557,7 +557,7 @@
       - name: openvswitch-2.9.0
         label: ubuntu-bionic-1vcpu
     groups:
-      - name: openvswitch
+      - name: appliance-ssh
         nodes:
           - openvswitch-2.9.0
       - name: controller
@@ -572,7 +572,7 @@
       - name: openvswitch-2.9.0
         label: ubuntu-bionic-1vcpu
     groups:
-      - name: openvswitch
+      - name: appliance-ssh
         nodes:
           - openvswitch-2.9.0
       - name: controller
@@ -587,7 +587,7 @@
       - name: openvswitch-2.9.0
         label: ubuntu-bionic-1vcpu
     groups:
-      - name: openvswitch
+      - name: appliance-ssh
         nodes:
           - openvswitch-2.9.0
       - name: controller
@@ -602,7 +602,7 @@
       - name: openvswitch-2.9.0
         label: ubuntu-bionic-1vcpu
     groups:
-      - name: openvswitch
+      - name: appliance-ssh
         nodes:
           - openvswitch-2.9.0
       - name: controller


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/507

We apply `prepare-workspace-git` too all host, but the ones from
the `appliance` groups. As a result, all the hosts from the `appliance`
won't have the temporary SSH key, and won't be reachable over SSH.

Until now we were using an `openvswitch` to target the openvswitch
appliance. This way, they were not part of the `appliance` group.
And so, the SSH key was update.

We now have an `appliance-ssh` group for this purpose. This commit
makes us of it.