### PR TITLE
Revert "aws: ensure tox is present"

### DIFF
--- a/playbooks/ansible-test-network-integration-base/pre.yaml
+++ b/playbooks/ansible-test-network-integration-base/pre.yaml
@@ -9,11 +9,6 @@
         _network_os: "{{ hostvars[groups[_network_appliance_groups|first][0]]['ansible_network_os'] }}"
       when: _network_appliance_groups|length > 0
 
-    - name: Ensure tox
-      include_role:
-        name: ensure-tox
-      when: '"aws" in groups'
-
     - name: Setup tox role
       include_role:
         name: tox


### PR DESCRIPTION
This reverts commit c31aca44bb815f11c9b923dd36046503cfc46582.

This package is now installed by cloud-init during the instance provisioning.