### PR TITLE
Revert "ensure virtualenv is installed before bindep run"

### DIFF
--- a/playbooks/ansible-network-appliance-base/pre.yaml
+++ b/playbooks/ansible-network-appliance-base/pre.yaml
@@ -1,13 +1,6 @@
 ---
 - hosts: controller
   tasks:
-    - name: Ensure virtualenv package is installed -- See https://review.opendev.org/#/c/727413/
-      package:
-        name: virtualenv
-        state: present
-      become: true
-      when: "'aws' in group_names"
-
     - name: Install binary dependencies
       include_role:
         name: bindep


### PR DESCRIPTION
This reverts commit 7cf35c77d61a812e4e4cb5c9bca091b79093243c.

This package is now installed by cloud-init during the instance provisioning.