### PR TITLE
vmware: set password of vcenter

### DIFF
--- a/playbooks/ansible-cloud/vcenter-appliance/pre.yaml
+++ b/playbooks/ansible-cloud/vcenter-appliance/pre.yaml
@@ -38,7 +38,7 @@
           esxi2: "{{ 'esxi2' in hostvars and hostvars['esxi2']['nodepool']['interface_ip']}}"
           datastore: "{{ hostvars[groups['controller'][0]]['nodepool']['interface_ip']}}"
 
-- hosts: appliance
+- hosts: appliance:appliance-ssh
   gather_facts: false
   tasks:
     - import_role:


### PR DESCRIPTION
Apply `vmware-ci-set-passwords` on the vcenter. This is a regression
introduced by a59edaf696bb51b8dbdac8f293b6d96ca22877ae.