### PR TITLE
govcsim: increase the timeout.

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -33,6 +33,7 @@
       - name: github.com/ansible/ansible
       - name: github.com/ansible/ansible-zuul-jobs
       - name: github.com/ansible-collections/vmware
+    timeout: 3600
     vars:
       ansible_collections_repo: github.com/ansible-collections/vmware
       ansible_test_python: 3.6


### PR DESCRIPTION
Time to time we go slightly above 30 minutes, the goal is to avoid a
timeout.