### PR TITLE
Revert "openvswitch: use appliance-ssh to target appliance"

### DIFF
--- a/playbooks/ansible-network-appliance-base/pre.yaml
+++ b/playbooks/ansible-network-appliance-base/pre.yaml
@@ -14,24 +14,24 @@
     - name: Set SSH interface IP for appliance
       set_fact:
         __ssh_ip: "{{ hostvars[item].ansible_host }}"
-      with_inventory_hostnames: appliance:appliance-ssh
+      with_inventory_hostnames: appliance:appliance-ssh:openvswitch
 
     - name: Set SSH interface IP for IOSXR
       set_fact:
         __ssh_ip: "{{ hostvars[item].nodepool.private_ipv4 }}"
       when: hostvars[item].ansible_network_os in ['iosxr']
-      with_inventory_hostnames: appliance:appliance-ssh
+      with_inventory_hostnames: appliance:appliance-ssh:openvswitch
 
     - name: Set SSH interface port for appliance
       set_fact:
         __ssh_port: 22
-      with_inventory_hostnames: appliance:appliance-ssh
+      with_inventory_hostnames: appliance:appliance-ssh:openvswitch
 
     - name: Set SSH interface port for NXOS
       set_fact:
         __ssh_port: 8022
       when: hostvars[item].ansible_network_os in ['nxos']
-      with_inventory_hostnames: appliance:appliance-ssh
+      with_inventory_hostnames: appliance:appliance-ssh:openvswitch
 
     - name: Wait 300 seconds for SSH port on appliance
       wait_for:
@@ -63,7 +63,7 @@
       set_fact:
         __inventory_hostvars: "{{ hostvars | replace(hostvars[item]['ansible_host'], hostvars[item]['nodepool']['private_ipv4']) }}"
       when: hostvars[item].ansible_network_os in ['iosxr']
-      with_inventory_hostnames: appliance:appliance-ssh
+      with_inventory_hostnames: appliance:appliance-ssh:openvswitch
 
     - name: Run write-inventory-fork role
       include_role:

--- a/playbooks/ansible-test-network-integration-base/files/bootstrap-openvswitch.yaml
+++ b/playbooks/ansible-test-network-integration-base/files/bootstrap-openvswitch.yaml
@@ -1,3 +1,3 @@
 ---
-- hosts: appliance*
+- hosts: openvswitch
   tasks: []

--- a/playbooks/ansible-test-network-integration-base/pre.yaml
+++ b/playbooks/ansible-test-network-integration-base/pre.yaml
@@ -2,7 +2,7 @@
 - hosts: controller
   tasks:
     - set_fact:
-        _network_appliance_groups: "{{ groups.keys()|select('match', '^appliance')|list }}"
+        _network_appliance_groups: "{{ groups.keys()|select('match', '^(appliance|openvswitch)')|list }}"
 
     - name: Select proper ansible_network_os
       set_fact:

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -554,7 +554,7 @@
       - name: openvswitch-2.9.0
         label: ubuntu-bionic-1vcpu
     groups:
-      - name: appliance-ssh
+      - name: openvswitch
         nodes:
           - openvswitch-2.9.0
       - name: controller
@@ -569,7 +569,7 @@
       - name: openvswitch-2.9.0
         label: ubuntu-bionic-1vcpu
     groups:
-      - name: appliance-ssh
+      - name: openvswitch
         nodes:
           - openvswitch-2.9.0
       - name: controller
@@ -584,7 +584,7 @@
       - name: openvswitch-2.9.0
         label: ubuntu-bionic-1vcpu
     groups:
-      - name: appliance-ssh
+      - name: openvswitch
         nodes:
           - openvswitch-2.9.0
       - name: controller
@@ -599,7 +599,7 @@
       - name: openvswitch-2.9.0
         label: ubuntu-bionic-1vcpu
     groups:
-      - name: appliance-ssh
+      - name: openvswitch
         nodes:
           - openvswitch-2.9.0
       - name: controller
@@ -614,7 +614,7 @@
       - name: openvswitch-2.9.0
         label: ubuntu-bionic-1vcpu
     groups:
-      - name: appliance-ssh
+      - name: openvswitch
         nodes:
           - openvswitch-2.9.0
       - name: controller


### PR DESCRIPTION
This seems to have broken OVS jobs.

This reverts commit f58e161e195b64606b68fb4e9e1ccf73a73c0139.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>