### PR TITLE
Update Cisco ASA stable-29 to voting from its current non-voting state

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -198,7 +198,6 @@
         - ansible-test-network-integration-asa-python27-stable29:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-asa-python35:
             vars:
               ansible_test_collections: true
@@ -213,14 +212,12 @@
         - ansible-test-network-integration-asa-python36-stable29:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-asa-python37:
             vars:
               ansible_test_collections: true
         - ansible-test-network-integration-asa-python37-stable29:
             vars:
               ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-asa-python38:
             vars:
               ansible_test_collections: true
@@ -234,10 +231,19 @@
         - ansible-test-network-integration-asa-python27:
             vars:
               ansible_test_collections: true
+        - ansible-test-network-integration-asa-python27-stable29:
+            vars:
+              ansible_test_collections: true
         - ansible-test-network-integration-asa-python36:
             vars:
               ansible_test_collections: true
+        - ansible-test-network-integration-asa-python36-stable29:
+            vars:
+              ansible_test_collections: true
         - ansible-test-network-integration-asa-python37:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-asa-python37-stable29:
             vars:
               ansible_test_collections: true
         - ansible-test-network-integration-asa-python38:


### PR DESCRIPTION
Update Cisco ASA stable-29 to voting from its current non-voting state.

Also, updated the same for gate pipeline as well.