### PR TITLE
govcsim: don't use the container anymore

### DIFF
--- a/playbooks/ansible-cloud/govcsim-base/pre.yaml
+++ b/playbooks/ansible-cloud/govcsim-base/pre.yaml
@@ -1,13 +1,22 @@
 ---
 - hosts: controller
   tasks:
-    - name: Install podman
+    - name: Install golang
       package:
-        name: podman
+        name: golang
       become: true
-    - name: Add the /usr/bin/docker symlink
-      file:
-        src: /usr/bin/podman
-        dest: /usr/bin/docker
-        state: link
+    - name: Fetch and build govcsim
+      command: go get -u github.com/vmware/govmomi/vcsim
+    - name: Expse vcsim in a directory from PATH
+      copy:
+        src: ~zuul/go/bin/vcsim
+        dest: /usr/local/bin/vcsim
+        remote_src: true
+        mode: '0755'
       become: true
+    - name: Write the configuration for ansible-test
+      import_role:
+        name: vmware-ci-configure-ansible-test
+      vars:
+        vmware_ci_configure_ansible_test_ansible_path: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
+        vmware_ci_configure_ansible_test_with_vcsim: true

--- a/roles/vmware-ci-configure-ansible-test/defaults/main.yaml
+++ b/roles/vmware-ci-configure-ansible-test/defaults/main.yaml
@@ -1,2 +1,3 @@
 ---
+vmware_ci_configure_ansible_test_with_vcsim: false
 vmware_ci_set_passwords_secret_dir: /tmp

--- a/roles/vmware-ci-configure-ansible-test/templates/cloud-config-vcenter.ini.j2
+++ b/roles/vmware-ci-configure-ansible-test/templates/cloud-config-vcenter.ini.j2
@@ -1,4 +1,17 @@
 [DEFAULT]
+{% if vmware_ci_configure_ansible_test_with_vcsim %}
+vcenter_username: user
+vcenter_password: pass
+vcenter_hostname: localhost
+vcenter_port: 443
+vmware_user: user
+vmware_password: pass
+vmware_host: localhost
+vmware_port: 443
+vmware_validate_certs: false
+vcsim: true
+vcsim_with: systemd
+{% else %}
 vcenter_username: administrator@vsphere.local
 vcenter_password: {{ lookup('file', vmware_ci_set_passwords_secret_dir + '/vcenter/tmp/vcenter_password.txt') }}
 vcenter_hostname: vcenter.test
@@ -12,4 +25,5 @@ esxi1_password: {{ lookup('file', vmware_ci_set_passwords_secret_dir + '/vcenter
 esxi2_username: zuul
 esxi2_hostname: esxi2.test
 esxi2_password: {{ lookup('file', vmware_ci_set_passwords_secret_dir + '/vcenter/tmp/esxi_password_zuul.txt') }}
+{% endif %}
 {% endif %}

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -39,9 +39,9 @@
       ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/govcsim/
       ansible_test_command: integration
-      ansible_test_environment:
-        VMWARE_TEST_PLATFORM: govcsim
       ansible_test_split_in: 3
+      ansible_test_environment:
+        VMWARE_TEST_PLATFORM: static
 
 - job:
     name: ansible-test-cloud-integration-govcsim-python36_1_of_3


### PR DESCRIPTION
Use `systemd-run` to start `govcsim` to simplify the process:

- `ansible-test` don't pull container anymore
- no need to configure docker^wpodman
- easier to reproduce the problem locally