### PR TITLE
Remove post job for automation hub

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1717,9 +1717,6 @@
     gate:
       jobs:
         - build-ansible-collection
-    post:
-      jobs:
-        - release-ansible-collection-automation-hub
     pre-release:
       jobs:
         - release-ansible-collection-automation-hub


### PR DESCRIPTION
Only upload collections if we git tag a release.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>