### PR TITLE
Simplify ansible-test-sanity-base job

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -288,7 +288,6 @@
     timeout: 3600
     vars:
       ansible_collections_repo: github.com/ansible-collections/cisco.asa
-      ansible_test_integration_targets: "tests/unit/modules/network/asa/test_asa.*"
 
 - job:
     name: ansible-test-network-integration-asa-python27
@@ -405,7 +404,6 @@
     timeout: 3600
     vars:
       ansible_collections_repo: github.com/ansible-collections/arista.eos
-      ansible_test_integration_targets: "tests/unit/modules/network/eos/test_eos.*"
 
 - job:
     name: ansible-test-network-integration-eos-httpapi
@@ -646,7 +644,6 @@
     timeout: 3600
     vars:
       ansible_collections_repo: github.com/ansible-collections/cisco.ios
-      ansible_test_integration_targets: "tests/unit/modules/network/ios/test_ios.*"
 
 - job:
     name: ansible-test-network-integration-ios-local
@@ -887,7 +884,6 @@
     timeout: 3600
     vars:
       ansible_collections_repo: github.com/ansible-collections/cisco.iosxr
-      ansible_test_integration_targets: "tests/unit/modules/network/iosxr/test_iosxr_.*"
 
 - job:
     name: ansible-test-network-integration-iosxr-python27
@@ -981,7 +977,6 @@
     timeout: 3600
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
-      ansible_test_integration_targets: "tests/unit/modules/network/cli/test_cli_.*"
 
 - job:
     name: ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python27
@@ -1060,7 +1055,6 @@
     timeout: 3600
     vars:
       ansible_collections_repo: github.com/ansible-collections/junipernetworks.junos
-      ansible_test_integration_targets: "tests/unit/modules/network/junos/test_junos.*"
 
 - job:
     name: ansible-test-network-integration-junos-vsrx-netconf
@@ -1338,7 +1332,6 @@
     timeout: 3600
     vars:
       ansible_collections_repo: github.com/ansible-collections/cisco.nxos
-      ansible_test_integration_targets: "tests/unit/modules/network/nxos/test_nxos_.*"
 
 - job:
     name: ansible-test-network-integration-nxos-cli-python36
@@ -1412,8 +1405,10 @@
       - name: github.com/ansible/ansible
     timeout: 3600
     vars:
-      ansible_test_python: 3.8
+      ansible_test_collections: true
       ansible_test_command: units
+      ansible_test_integration_targets: ""
+      ansible_test_python: 3.8
 
 - job:
     name: ansible-test-sanity-openvswitch
@@ -1432,7 +1427,6 @@
     timeout: 3600
     vars:
       ansible_collections_repo: github.com/ansible-collections/openvswitch.openvswitch
-      ansible_test_integration_targets: "tests/unit/modules/network/ovs/test_openvswitch_.*"
 
 - job:
     name: ansible-test-network-integration-openvswitch-python27
@@ -1549,7 +1543,6 @@
     timeout: 3600
     vars:
       ansible_collections_repo: github.com/ansible-collections/vyos.vyos
-      ansible_test_integration_targets: "tests/unit/modules/network/vyos/test_vyos.*"
 
 - job:
     name: ansible-test-network-integration-vyos-python27
@@ -1643,7 +1636,6 @@
     timeout: 3600
     vars:
       ansible_collections_repo: github.com/ansible-collections/frr.frr
-      ansible_test_integration_targets: "tests/unit/modules/network/frr/test_frr.*"
 
 # molecule- prefixed jobs match ansible- ones but also enable extra
 # virtualization services that are use by molecule, like docker, podman (TBD)

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -65,15 +65,11 @@
       jobs:
         - ansible-test-sanity-eos:
             voting: false
-        - ansible-test-units-eos:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-eos
     gate:
       queue: integrated
       jobs:
-        - ansible-test-units-eos:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-eos
 
 - project-template:
     name: ansible-collections-arista-eos
@@ -203,15 +199,11 @@
       jobs:
         - ansible-test-sanity-asa:
             voting: false
-        - ansible-test-units-asa:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-asa
     gate:
       queue: integrated
       jobs:
-        - ansible-test-units-asa:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-asa
 
 - project-template:
     name: ansible-collections-cisco-asa
@@ -283,15 +275,11 @@
       jobs:
         - ansible-test-sanity-nxos:
             voting: false
-        - ansible-test-units-nxos:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-nxos
     gate:
       queue: integrated
       jobs:
-        - ansible-test-units-nxos:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-nxos
 
 - project-template:
     name: ansible-collections-cisco-nxos
@@ -337,15 +325,11 @@
       jobs:
         - ansible-test-sanity-ios:
             voting: false
-        - ansible-test-units-ios:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-ios
     gate:
       queue: integrated
       jobs:
-        - ansible-test-units-ios:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-ios
 
 - project-template:
     name: ansible-collections-cisco-ios
@@ -475,15 +459,11 @@
       jobs:
         - ansible-test-sanity-iosxr:
             voting: false
-        - ansible-test-units-iosxr:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-iosxr
     gate:
       queue: integrated
       jobs:
-        - ansible-test-units-iosxr:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-iosxr
 
 - project-template:
     name: ansible-collections-cisco-iosxr
@@ -654,15 +634,11 @@
       jobs:
         - ansible-test-sanity-junos:
             voting: false
-        - ansible-test-units-junos:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-junos
     gate:
       queue: integrated
       jobs:
-        - ansible-test-units-junos:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-junos
 
 - project-template:
     name: ansible-collections-juniper-junos
@@ -875,16 +851,12 @@
     check:
       jobs:
         - ansible-test-sanity-openvswitch
-        - ansible-test-units-openvswitch:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-openvswitch
     gate:
       queue: integrated
       jobs:
         - ansible-test-sanity-openvswitch
-        - ansible-test-units-openvswitch:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-openvswitch
 
 - project-template:
     name: ansible-collections-openvswitch-openvswitch
@@ -960,15 +932,11 @@
       jobs:
         - ansible-test-sanity-vyos:
             voting: false
-        - ansible-test-units-vyos:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-vyos
     gate:
       queue: integrated
       jobs:
-        - ansible-test-units-vyos:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-vyos
 
 - project-template:
     name: ansible-collections-vyos-vyos
@@ -1043,32 +1011,24 @@
     check:
       jobs:
         - ansible-test-sanity-frr
-        - ansible-test-units-frr:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-frr
     gate:
       queue: integrated
       jobs:
         - ansible-test-sanity-frr
-        - ansible-test-units-frr:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-frr
 
 - project-template:
     name: ansible-collections-ansible-netcommon-units
     check:
       jobs:
         - ansible-test-sanity-netcommon
-        - ansible-test-units-netcommon:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-netcommon
     gate:
       queue: integrated
       jobs:
         - ansible-test-sanity-netcommon
-        - ansible-test-units-netcommon:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-units-netcommon
 
 - project-template:
     name: ansible-collections-ansible-posix-units


### PR DESCRIPTION
This removes a lot of unneeded code, which we can just setup in base
job.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>