### PR TITLE
Add ansible.netcommon to ibm.qradar / splunk.es build dependency

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1045,27 +1045,35 @@
     name: ansible-collections-security-ibm-qradar
     check:
       jobs:
-        - build-ansible-collection
-        - ansible-test-security-integration-qradar-python38
         - ansible-test-sanity-qradar
+        - ansible-test-security-integration-qradar-python38
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-collections/ansible.netcommon
     gate:
       jobs:
-        - build-ansible-collection
-        - ansible-test-security-integration-qradar-python38
         - ansible-test-sanity-qradar
+        - ansible-test-security-integration-qradar-python38
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-collections/ansible.netcommon
 
 - project-template:
     name: ansible-collections-security-splunk-es
     check:
       jobs:
-        - build-ansible-collection
         - ansible-security-integration-splunk-es-python36
         - ansible-test-sanity-splunk
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-collections/ansible.netcommon
     gate:
       jobs:
-        - build-ansible-collection
         - ansible-security-integration-splunk-es-python36
         - ansible-test-sanity-splunk
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-collections/ansible.netcommon
 
 - project-template:
     name: ansible-test-network-integration


### PR DESCRIPTION
This will help with cross-project testing, and avoid the need to
download content from galaxy.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>