### PR TITLE
Don't install ara for ansible-test unit

### DIFF
--- a/playbooks/ansible-test-base/pre.yaml
+++ b/playbooks/ansible-test-base/pre.yaml
@@ -30,7 +30,7 @@
 
     - name: Install ara into virtualenv
       shell: ~/venv/bin/pip install "ara<1.0.0"
-      when: ansible_test_command != 'sanity'
+      when: ansible_test_command in ['integration', 'network-integration']
 
     - name: Install ansible into virtualenv
       shell: "~/venv/bin/pip install {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1401,7 +1401,7 @@
 - job:
     name: ansible-test-units-base
     parent: unittests
-    nodeset: controller-python38
+    nodeset: controller-python36
     abstract: true
     dependencies:
       - name: build-ansible-collection
@@ -1412,12 +1412,14 @@
     post-run: playbooks/ansible-test-units-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+        override-checkout: stable-2.10
     timeout: 3600
     vars:
       ansible_test_collections: true
       ansible_test_command: units
+      ansible_test_enable_ara: false
       ansible_test_integration_targets: ""
-      ansible_test_python: 3.8
+      ansible_test_python: 3.6
 
 - job:
     name: ansible-test-sanity-openvswitch


### PR DESCRIPTION
There is no need, as we don't use ara to render results.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>