### PR TITLE
Restore ansible-test-netcommon-units targets

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -977,6 +977,7 @@
     timeout: 3600
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
+      ansible_test_integration_targets: "tests/unit/modules/network/cli/test_cli_.*"
 
 - job:
     name: ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python27


### PR DESCRIPTION
This is because of a bug in ansible-test, which needs to fix. This
allows us to release 1.0.0 in the mean time.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>