### PR TITLE
vcenter: ensure esxcli can resolve the FQDN

### DIFF
--- a/roles/vmware-ci-write-etc-hosts/tasks/main.yaml
+++ b/roles/vmware-ci-write-etc-hosts/tasks/main.yaml
@@ -4,10 +4,14 @@
 
 - when: ansible_hostname != inventory_hostname
   block:
+    - name: Gather some information to troubleshot the ESXi to troubleshoot issue 144
+      debug: var=hostvars
+      when: inventory_hostname.startswith("esxi")
+
     - name: Ensure esxcli can resolve the hostname
       copy:
         content: |
-          127.0.0.1 localhost {{ ansible_hostname }}
+          127.0.0.1 localhost {{ ansible_facts.fqdn }} {{ ansible_hostname }}
         dest: /etc/hosts
       when: inventory_hostname.startswith("esxi")
 


### PR DESCRIPTION
Ensure the host can resolve the local FQDN befere we try to use the
`esxcli` command.

See: https://github.com/ansible-collections/vmware/issues/144