### PR TITLE
Create publish-to-galaxy-3pci project-template

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1767,6 +1767,21 @@
         - release-ansible-collection-galaxy
 
 - project-template:
+    name: publish-to-galaxy-3pci
+    description: |
+      Publish an Ansible collection to Ansible Galaxy
+    third-party-check:
+      jobs:
+        - ansible-galaxy-importer
+        - build-ansible-collection
+    pre-release:
+      jobs:
+        - release-ansible-collection-galaxy
+    release:
+      jobs:
+        - release-ansible-collection-galaxy
+
+- project-template:
     name: publish-to-galaxy-dev
     description: |
       Publish an Ansible collection to Ansible Galaxy Dev


### PR DESCRIPTION
This is helpful for 3pci collections, to run all required jobs before
uploading to galaxy.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>