### PR TITLE
security: fix the name of splunk run.yanl

### DIFF
--- a/zuul.d/ansible-security-jobs.yaml
+++ b/zuul.d/ansible-security-jobs.yaml
@@ -4,7 +4,7 @@
     name: ansible-security-splunk-appliance
     parent: ansible-network-appliance-base
     pre-run: playbooks/ansible-security-splunk-appliance/pre.yaml
-    run: playbooks/ansible-security-qradar-appliance/run.yaml
+    run: playbooks/ansible-security-splunk-appliance/run.yaml
     host-vars:
       SplunkEnterprise-SES-8.0.0:
         ansible_connection: network_cli


### PR DESCRIPTION
Ensure the `run` key point on the correct file.