### PR TITLE
Fix publish-to-galaxy-master-only project-template

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1596,12 +1596,10 @@
             branches: master
     pre-release:
       jobs:
-        - release-ansible-collection-galaxy:
-            branches: master
+        - release-ansible-collection-galaxy
     release:
       jobs:
-        - release-ansible-collection-galaxy:
-            branches: master
+        - release-ansible-collection-galaxy
 
 - project-template:
     name: publish-to-automation-hub


### PR DESCRIPTION
release / pre-release pipelines do not have branches.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>