### PR TITLE
ansible-lint: correct docs html location

### DIFF
--- a/zuul.d/jobs-ansible-lint.yaml
+++ b/zuul.d/jobs-ansible-lint.yaml
@@ -5,7 +5,8 @@
     name: ansible-lint-tox-docs
     parent: ansible-tox-docs
     vars:
-      sphinx_build_dir: .tox/docs_html
+      # zuul expects a `html` folder to be created under this
+      sphinx_build_dir: .tox/docs
 
 - job:
     name: ansible-lint-tox-linters


### PR DESCRIPTION
Change sphinx_build_dir to a folder that will contain the expected html subdirectory.

Needed-By: https://github.com/ansible/ansible-lint/pull/865