### PR TITLE
Rename nxos  jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1680,25 +1680,25 @@
       ansible_test_split_in: 4
 
 - job:
-    name: ansible-test-network-integration-nxos-cli-python36_1_of_4
+    name: ansible-test-network-integration-nxos-cli-python36_11
     parent: ansible-test-network-integration-nxos-cli-python36
     vars:
       ansible_test_do_number: 1
 
 - job:
-    name: ansible-test-network-integration-nxos-cli-python36_2_of_4
+    name: ansible-test-network-integration-nxos-cli-python36_22
     parent: ansible-test-network-integration-nxos-cli-python36
     vars:
       ansible_test_do_number: 2
 
 - job:
-    name: ansible-test-network-integration-nxos-cli-python36_3_of_4
+    name: ansible-test-network-integration-nxos-cli-python36_33
     parent: ansible-test-network-integration-nxos-cli-python36
     vars:
       ansible_test_do_number: 3
 
 - job:
-    name: ansible-test-network-integration-nxos-cli-python36_4_of_4
+    name: ansible-test-network-integration-nxos-cli-python36_44
     parent: ansible-test-network-integration-nxos-cli-python36
     vars:
       ansible_test_do_number: 4
@@ -1716,25 +1716,25 @@
       ansible_test_split_in: 4
 
 - job:
-    name: ansible-test-network-integration-nxos-cli-python36-stable29_1_of_4
+    name: ansible-test-network-integration-nxos-cli-python36-stable29_11
     parent: ansible-test-network-integration-nxos-cli-python36-stable29
     vars:
       ansible_test_do_number: 1
 
 - job:
-    name: ansible-test-network-integration-nxos-cli-python36-stable29_2_of_4
+    name: ansible-test-network-integration-nxos-cli-python36-stable29_22
     parent: ansible-test-network-integration-nxos-cli-python36-stable29
     vars:
       ansible_test_do_number: 2
 
 - job:
-    name: ansible-test-network-integration-nxos-cli-python36-stable29_3_of_4
+    name: ansible-test-network-integration-nxos-cli-python36-stable29_33
     parent: ansible-test-network-integration-nxos-cli-python36-stable29
     vars:
       ansible_test_do_number: 3
 
 - job:
-    name: ansible-test-network-integration-nxos-cli-python36-stable29_4_of_4
+    name: ansible-test-network-integration-nxos-cli-python36-stable29_44
     parent: ansible-test-network-integration-nxos-cli-python36-stable29
     vars:
       ansible_test_do_number: 4

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1680,25 +1680,25 @@
       ansible_test_split_in: 4
 
 - job:
-    name: ansible-test-network-integration-nxos-cli-python36_11
+    name: ansible-test-network-integration-nxos-cli-python36-scenario01
     parent: ansible-test-network-integration-nxos-cli-python36
     vars:
       ansible_test_do_number: 1
 
 - job:
-    name: ansible-test-network-integration-nxos-cli-python36_22
+    name: ansible-test-network-integration-nxos-cli-python36-scenario02
     parent: ansible-test-network-integration-nxos-cli-python36
     vars:
       ansible_test_do_number: 2
 
 - job:
-    name: ansible-test-network-integration-nxos-cli-python36_33
+    name: ansible-test-network-integration-nxos-cli-python36-scenario03
     parent: ansible-test-network-integration-nxos-cli-python36
     vars:
       ansible_test_do_number: 3
 
 - job:
-    name: ansible-test-network-integration-nxos-cli-python36_44
+    name: ansible-test-network-integration-nxos-cli-python36-scenario04
     parent: ansible-test-network-integration-nxos-cli-python36
     vars:
       ansible_test_do_number: 4
@@ -1716,25 +1716,25 @@
       ansible_test_split_in: 4
 
 - job:
-    name: ansible-test-network-integration-nxos-cli-python36-stable29_11
+    name: ansible-test-network-integration-nxos-cli-python36-stable29-scenario01
     parent: ansible-test-network-integration-nxos-cli-python36-stable29
     vars:
       ansible_test_do_number: 1
 
 - job:
-    name: ansible-test-network-integration-nxos-cli-python36-stable29_22
+    name: ansible-test-network-integration-nxos-cli-python36-stable29-scenario02
     parent: ansible-test-network-integration-nxos-cli-python36-stable29
     vars:
       ansible_test_do_number: 2
 
 - job:
-    name: ansible-test-network-integration-nxos-cli-python36-stable29_33
+    name: ansible-test-network-integration-nxos-cli-python36-stable29-scenario03
     parent: ansible-test-network-integration-nxos-cli-python36-stable29
     vars:
       ansible_test_do_number: 3
 
 - job:
-    name: ansible-test-network-integration-nxos-cli-python36-stable29_44
+    name: ansible-test-network-integration-nxos-cli-python36-stable29-scenario04
     parent: ansible-test-network-integration-nxos-cli-python36-stable29
     vars:
       ansible_test_do_number: 4

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -202,28 +202,28 @@
     name: ansible-collections-cisco-nxos
     check:
       jobs:
-        - ansible-test-network-integration-nxos-cli-python36_1_of_4:
+        - ansible-test-network-integration-nxos-cli-python36_11:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36_2_of_4:
+        - ansible-test-network-integration-nxos-cli-python36_22:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36_3_of_4:
+        - ansible-test-network-integration-nxos-cli-python36_33:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36_4_of_4:
+        - ansible-test-network-integration-nxos-cli-python36_44:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29_1_of_4:
+        - ansible-test-network-integration-nxos-cli-python36-stable29_11:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29_2_of_4:
+        - ansible-test-network-integration-nxos-cli-python36-stable29_22:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29_3_of_4:
+        - ansible-test-network-integration-nxos-cli-python36-stable29_33:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29_4_of_4:
+        - ansible-test-network-integration-nxos-cli-python36-stable29_44:
             vars:
               ansible_test_collections: true
         - build-ansible-collection:
@@ -232,28 +232,28 @@
     gate:
       queue: integrated
       jobs:
-        - ansible-test-network-integration-nxos-cli-python36_1_of_4:
+        - ansible-test-network-integration-nxos-cli-python36_11:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36_2_of_4:
+        - ansible-test-network-integration-nxos-cli-python36_22:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36_3_of_4:
+        - ansible-test-network-integration-nxos-cli-python36_33:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36_4_of_4:
+        - ansible-test-network-integration-nxos-cli-python36_44:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29_1_of_4:
+        - ansible-test-network-integration-nxos-cli-python36-stable29_11:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29_2_of_4:
+        - ansible-test-network-integration-nxos-cli-python36-stable29_22:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29_3_of_4:
+        - ansible-test-network-integration-nxos-cli-python36-stable29_33:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29_4_of_4:
+        - ansible-test-network-integration-nxos-cli-python36-stable29_44:
             vars:
               ansible_test_collections: true
         - build-ansible-collection:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -202,28 +202,28 @@
     name: ansible-collections-cisco-nxos
     check:
       jobs:
-        - ansible-test-network-integration-nxos-cli-python36_11:
+        - ansible-test-network-integration-nxos-cli-python36-scenario01:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36_22:
+        - ansible-test-network-integration-nxos-cli-python36-scenario02:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36_33:
+        - ansible-test-network-integration-nxos-cli-python36-scenario03:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36_44:
+        - ansible-test-network-integration-nxos-cli-python36-scenario04:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29_11:
+        - ansible-test-network-integration-nxos-cli-python36-stable29-scenario01:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29_22:
+        - ansible-test-network-integration-nxos-cli-python36-stable29-scenario02:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29_33:
+        - ansible-test-network-integration-nxos-cli-python36-stable29-scenario03:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29_44:
+        - ansible-test-network-integration-nxos-cli-python36-stable29-scenario04:
             vars:
               ansible_test_collections: true
         - build-ansible-collection:
@@ -232,28 +232,28 @@
     gate:
       queue: integrated
       jobs:
-        - ansible-test-network-integration-nxos-cli-python36_11:
+        - ansible-test-network-integration-nxos-cli-python36-scenario01:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36_22:
+        - ansible-test-network-integration-nxos-cli-python36-scenario02:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36_33:
+        - ansible-test-network-integration-nxos-cli-python36-scenario03:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36_44:
+        - ansible-test-network-integration-nxos-cli-python36-scenario04:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29_11:
+        - ansible-test-network-integration-nxos-cli-python36-stable29-scenario01:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29_22:
+        - ansible-test-network-integration-nxos-cli-python36-stable29-scenario02:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29_33:
+        - ansible-test-network-integration-nxos-cli-python36-stable29-scenario03:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29_44:
+        - ansible-test-network-integration-nxos-cli-python36-stable29-scenario04:
             vars:
               ansible_test_collections: true
         - build-ansible-collection:


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gosriniv@redhat.com>

Changing the nxos split jobs name from X_of_Y to XX