### PR TITLE
ansible-test-units-base: properly init test_location var

### DIFF
--- a/playbooks/ansible-test-units-base/post.yaml
+++ b/playbooks/ansible-test-units-base/post.yaml
@@ -18,7 +18,7 @@
 
     - name: Setup location of project for tests
       set_fact:
-        test_location: "{{ ansible_test_collection_dir }}/{{ galaxy_info.namespace }}/{{ galaxy_info.namespace }}"
+        test_location: "{{ ansible_test_collection_dir }}/{{ galaxy_info.namespace }}/{{ galaxy_info.name }}"
 
     - name: Coverage report for unit tests
       args:


### PR DESCRIPTION
Ensure we correctly initialize `test_location` path. This commit address
a regression introdued in 6efd51d6954ef1e9daf9cc2afcde3e2678c2786a.