### PR TITLE
Add irrelevant-files for network-integration jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -266,6 +266,8 @@
       - name: github.com/ansible/ansible
       - name: github.com/ansible-collections/cisco.asa
     timeout: 9000
+    irrelevant-files:
+      - README.md
     vars:
       ansible_collections_repo: github.com/ansible-collections/cisco.asa
       ansible_test_command: network-integration
@@ -382,6 +384,8 @@
       - name: github.com/ansible/ansible
       - name: github.com/ansible-collections/arista.eos
     timeout: 10800
+    irrelevant-files:
+      - README.md
     vars:
       ansible_collections_repo: github.com/ansible-collections/arista.eos
       ansible_test_command: network-integration
@@ -724,6 +728,8 @@
       - name: github.com/ansible/ansible
       - name: github.com/ansible-collections/cisco.ios
     timeout: 10800
+    irrelevant-files:
+      - README.md
     vars:
       ansible_collections_repo: github.com/ansible-collections/cisco.ios
       ansible_test_command: network-integration
@@ -1066,6 +1072,8 @@
       - name: github.com/ansible/ansible
       - name: github.com/ansible-collections/cisco.iosxr
     timeout: 10800
+    irrelevant-files:
+      - README.md
     vars:
       ansible_collections_repo: github.com/ansible-collections/cisco.iosxr
       ansible_test_command: network-integration
@@ -1656,6 +1664,8 @@
       - name: github.com/ansible/ansible
       - name: github.com/ansible-collections/junipernetworks.junos
     timeout: 10800
+    irrelevant-files:
+      - README.md
     vars:
       ansible_collections_repo: github.com/ansible-collections/junipernetworks.junos
       ansible_test_command: network-integration
@@ -1933,6 +1943,8 @@
       - name: github.com/ansible/ansible
       - name: github.com/ansible-collections/cisco.nxos
     timeout: 10800
+    irrelevant-files:
+      - README.md
     vars:
       ansible_collections_repo: github.com/ansible-collections/cisco.nxos
       ansible_test_command: network-integration
@@ -2043,6 +2055,8 @@
       - name: github.com/ansible/ansible
       - name: github.com/ansible-collections/openvswitch.openvswitch
     timeout: 3600
+    irrelevant-files:
+      - README.md
     vars:
       ansible_collections_repo: github.com/ansible-collections/openvswitch.openvswitch
       ansible_test_command: network-integration
@@ -2239,6 +2253,8 @@
       - name: github.com/ansible/ansible
       - name: github.com/ansible-collections/vyos.vyos
     timeout: 10800
+    irrelevant-files:
+      - README.md
     vars:
       ansible_collections_repo: github.com/ansible-collections/vyos.vyos
       ansible_test_command: network-integration


### PR DESCRIPTION
Lets start to filter integration jobs, based on which files are updated.
If a PR is only making a docs change, there is no need to do integration
testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>