### PR TITLE
Remove fail fast for vyos.vyos

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -889,7 +889,6 @@
 - project-template:
     name: ansible-collections-vyos-vyos
     check:
-      fail-fast: true
       jobs: &ansible-collections-vyos-vyos-jobs
         - ansible-test-network-integration-vyos-local-python27
         - ansible-test-network-integration-vyos-local-python27-stable210


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gosriniv@redhat.com>

Removing fail fast for vyos jobs, so that, other job runs are available for debugging, in case of multiple job failures.