### PR TITLE
Refactor vyos.vyos jobs

### DIFF
--- a/roles/configure-mirrors-fork/vars/Fedora.yaml
+++ b/roles/configure-mirrors-fork/vars/Fedora.yaml
@@ -1,2 +1,2 @@
 ---
-package_mirror: http://pubmirror2.math.uh.edu/fedora-buffet/fedora/linux
+package_mirror: http://pubmirror1.math.uh.edu/fedora-buffet/fedora/linux


### PR DESCRIPTION
With this change, we are now making it more important to use unit
testing to check for python versions over integration jobs.  This is
mostly to help cut down on the amount of time it takes a PR to run.

The idea is, integration testing hasn't been a good indicator of finding
issues with the different versions of python, and we likely can improve
unitesting to account for that.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>