### PR TITLE
split eos stable-210 jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -465,6 +465,19 @@
         override-checkout: stable-2.10
     vars:
       ansible_test_python: 2.7
+      ansible_test_split_in: 2
+
+- job:
+    name: ansible-test-network-integration-eos-network_cli-python27-stable210-scenario01
+    parent: ansible-test-network-integration-eos-network_cli-python27-stable210
+    vars:
+      ansible_test_do_number: 1
+
+- job:
+    name: ansible-test-network-integration-eos-network_cli-python27-stable210-scenario02
+    parent: ansible-test-network-integration-eos-network_cli-python27-stable210
+    vars:
+      ansible_test_do_number: 2
 
 - job:
     name: ansible-test-network-integration-eos-httpapi-python27-stable29
@@ -526,6 +539,21 @@
         override-checkout: stable-2.10
     vars:
       ansible_test_python: 3.5
+      ansible_test_split_in: 2
+
+
+- job:
+    name: ansible-test-network-integration-eos-network_cli-python35-stable210-scenario01
+    parent: ansible-test-network-integration-eos-network_cli-python35-stable210
+    vars:
+      ansible_test_do_number: 1
+
+- job:
+    name: ansible-test-network-integration-eos-network_cli-python35-stable210-scenario02
+    parent: ansible-test-network-integration-eos-network_cli-python35-stable210
+    vars:
+      ansible_test_do_number: 2
+
 
 - job:
     name: ansible-test-network-integration-eos-httpapi-python35-stable29
@@ -587,6 +615,19 @@
         override-checkout: stable-2.10
     vars:
       ansible_test_python: 3.6
+      ansible_test_split_in: 2
+
+- job:
+    name: ansible-test-network-integration-eos-network_cli-python36-stable210-scenario01
+    parent: ansible-test-network-integration-eos-network_cli-python36-stable210
+    vars:
+      ansible_test_do_number: 1
+
+- job:
+    name: ansible-test-network-integration-eos-network_cli-python36-stable210-scenario02
+    parent: ansible-test-network-integration-eos-network_cli-python36-stable210
+    vars:
+      ansible_test_do_number: 2
 
 - job:
     name: ansible-test-network-integration-eos-httpapi-python36-stable29
@@ -648,6 +689,20 @@
         override-checkout: stable-2.10
     vars:
       ansible_test_python: 3.7
+      ansible_test_split_in: 2
+
+- job:
+    name: ansible-test-network-integration-eos-network_cli-python37-stable210-scenario01
+    parent: ansible-test-network-integration-eos-network_cli-python37-stable210
+    vars:
+      ansible_test_do_number: 1
+
+- job:
+    name: ansible-test-network-integration-eos-network_cli-python37-stable210-scenario02
+    parent: ansible-test-network-integration-eos-network_cli-python37-stable210
+    vars:
+      ansible_test_do_number: 2
+
 
 - job:
     name: ansible-test-network-integration-eos-httpapi-python37-stable29
@@ -709,6 +764,20 @@
         override-checkout: stable-2.10
     vars:
       ansible_test_python: 3.8
+      ansible_test_split_in: 2
+
+- job:
+    name: ansible-test-network-integration-eos-network_cli-python38-stable210-scenario01
+    parent: ansible-test-network-integration-eos-network_cli-python38-stable210
+    vars:
+      ansible_test_do_number: 1
+
+- job:
+    name: ansible-test-network-integration-eos-network_cli-python38-stable210-scenario02
+    parent: ansible-test-network-integration-eos-network_cli-python38-stable210
+    vars:
+      ansible_test_do_number: 2
+
 
 - job:
     name: ansible-test-network-integration-ios

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -90,19 +90,24 @@
         - ansible-test-network-integration-eos-httpapi-python38
         - ansible-test-network-integration-eos-httpapi-python38-stable210
         - ansible-test-network-integration-eos-network_cli-python27
-        - ansible-test-network-integration-eos-network_cli-python27-stable210
+        - ansible-test-network-integration-eos-network_cli-python27-stable210-scenario01
+        - ansible-test-network-integration-eos-network_cli-python27-stable210-scenario02
         - ansible-test-network-integration-eos-network_cli-python27-stable29
         - ansible-test-network-integration-eos-network_cli-python35
-        - ansible-test-network-integration-eos-network_cli-python35-stable210
+        - ansible-test-network-integration-eos-network_cli-python35-stable210-scenario01
+        - ansible-test-network-integration-eos-network_cli-python35-stable210-scenario02
         - ansible-test-network-integration-eos-network_cli-python35-stable29
         - ansible-test-network-integration-eos-network_cli-python36
-        - ansible-test-network-integration-eos-network_cli-python36-stable210
+        - ansible-test-network-integration-eos-network_cli-python36-stable210-scenario01
+        - ansible-test-network-integration-eos-network_cli-python36-stable210-scenario02
         - ansible-test-network-integration-eos-network_cli-python36-stable29
         - ansible-test-network-integration-eos-network_cli-python37
-        - ansible-test-network-integration-eos-network_cli-python37-stable210
+        - ansible-test-network-integration-eos-network_cli-python37-stable210-scenario01
+        - ansible-test-network-integration-eos-network_cli-python37-stable210-scenario02
         - ansible-test-network-integration-eos-network_cli-python37-stable29
         - ansible-test-network-integration-eos-network_cli-python38
-        - ansible-test-network-integration-eos-network_cli-python38-stable210
+        - ansible-test-network-integration-eos-network_cli-python38-stable210-scenario01
+        - ansible-test-network-integration-eos-network_cli-python38-stable210-scenario02
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gosriniv@redhat.com>

eos network_cli stable210 jobs are split in to 2, inorder to avoid the timed_out failure.