### PR TITLE
network: move py{35,37,38} jobs in periodical pipeline

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -78,29 +78,38 @@
         - ansible-test-network-integration-eos-httpapi-python27
         - ansible-test-network-integration-eos-httpapi-python27-stable210
         - ansible-test-network-integration-eos-httpapi-python27-stable29
-        - ansible-test-network-integration-eos-httpapi-python35
-        - ansible-test-network-integration-eos-httpapi-python35-stable210
-        - ansible-test-network-integration-eos-httpapi-python35-stable29
         - ansible-test-network-integration-eos-httpapi-python36
         - ansible-test-network-integration-eos-httpapi-python36-stable210
         - ansible-test-network-integration-eos-httpapi-python36-stable29
+        - ansible-test-network-integration-eos-network_cli-python27
+        - ansible-test-network-integration-eos-network_cli-python27-stable210-scenario01
+        - ansible-test-network-integration-eos-network_cli-python27-stable210-scenario02
+        - ansible-test-network-integration-eos-network_cli-python27-stable29
+        - ansible-test-network-integration-eos-network_cli-python36
+        - ansible-test-network-integration-eos-network_cli-python36-stable210-scenario01
+        - ansible-test-network-integration-eos-network_cli-python36-stable210-scenario02
+        - ansible-test-network-integration-eos-network_cli-python36-stable29
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-collections/ansible.netcommon
+    gate:
+      queue: integrated
+      jobs: *ansible-collections-arista-eos-jobs
+
+    periodic-weekly:
+      jobs:
+        - ansible-test-network-integration-eos-httpapi-python35
+        - ansible-test-network-integration-eos-httpapi-python35-stable210
+        - ansible-test-network-integration-eos-httpapi-python35-stable29
         - ansible-test-network-integration-eos-httpapi-python37
         - ansible-test-network-integration-eos-httpapi-python37-stable210
         - ansible-test-network-integration-eos-httpapi-python37-stable29
         - ansible-test-network-integration-eos-httpapi-python38
         - ansible-test-network-integration-eos-httpapi-python38-stable210
-        - ansible-test-network-integration-eos-network_cli-python27
-        - ansible-test-network-integration-eos-network_cli-python27-stable210-scenario01
-        - ansible-test-network-integration-eos-network_cli-python27-stable210-scenario02
-        - ansible-test-network-integration-eos-network_cli-python27-stable29
         - ansible-test-network-integration-eos-network_cli-python35
         - ansible-test-network-integration-eos-network_cli-python35-stable210-scenario01
         - ansible-test-network-integration-eos-network_cli-python35-stable210-scenario02
         - ansible-test-network-integration-eos-network_cli-python35-stable29
-        - ansible-test-network-integration-eos-network_cli-python36
-        - ansible-test-network-integration-eos-network_cli-python36-stable210-scenario01
-        - ansible-test-network-integration-eos-network_cli-python36-stable210-scenario02
-        - ansible-test-network-integration-eos-network_cli-python36-stable29
         - ansible-test-network-integration-eos-network_cli-python37
         - ansible-test-network-integration-eos-network_cli-python37-stable210-scenario01
         - ansible-test-network-integration-eos-network_cli-python37-stable210-scenario02
@@ -108,12 +117,7 @@
         - ansible-test-network-integration-eos-network_cli-python38
         - ansible-test-network-integration-eos-network_cli-python38-stable210-scenario01
         - ansible-test-network-integration-eos-network_cli-python38-stable210-scenario02
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/ansible.netcommon
-    gate:
-      queue: integrated
-      jobs: *ansible-collections-arista-eos-jobs
+
 
 - project-template:
     name: ansible-collections-cisco-asa-units
@@ -137,27 +141,10 @@
         - ansible-test-network-integration-asa-python27-stable29:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-asa-python35:
-            vars:
-              ansible_test_collections: true
-            voting: false
-        - ansible-test-network-integration-asa-python35-stable29:
-            vars:
-              ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-asa-python36:
             vars:
               ansible_test_collections: true
         - ansible-test-network-integration-asa-python36-stable29:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-asa-python37:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-asa-python37-stable29:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-asa-python38:
             vars:
               ansible_test_collections: true
         - build-ansible-collection:
@@ -178,6 +165,20 @@
         - ansible-test-network-integration-asa-python36-stable29:
             vars:
               ansible_test_collections: true
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-collections/ansible.netcommon
+
+    periodic-weekly:
+      jobs:
+        - ansible-test-network-integration-asa-python35:
+            vars:
+              ansible_test_collections: true
+            voting: false
+        - ansible-test-network-integration-asa-python35-stable29:
+            vars:
+              ansible_test_collections: true
+            voting: false
         - ansible-test-network-integration-asa-python37:
             vars:
               ansible_test_collections: true
@@ -187,9 +188,7 @@
         - ansible-test-network-integration-asa-python38:
             vars:
               ansible_test_collections: true
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/ansible.netcommon
+
 
 - project-template:
     name: ansible-collections-cisco-nxos-units
@@ -284,37 +283,41 @@
         - ansible-test-network-integration-ios-local-python27
         - ansible-test-network-integration-ios-local-python27-stable210
         - ansible-test-network-integration-ios-local-python27-stable29
-        - ansible-test-network-integration-ios-local-python35
-        - ansible-test-network-integration-ios-local-python35-stable210
-        - ansible-test-network-integration-ios-local-python35-stable29
         - ansible-test-network-integration-ios-local-python36
         - ansible-test-network-integration-ios-local-python36-stable210
         - ansible-test-network-integration-ios-local-python36-stable29
-        - ansible-test-network-integration-ios-local-python37
-        - ansible-test-network-integration-ios-local-python37-stable210
-        - ansible-test-network-integration-ios-local-python37-stable29
-        - ansible-test-network-integration-ios-local-python38
-        - ansible-test-network-integration-ios-local-python38-stable210
         - ansible-test-network-integration-ios-network_cli-python27
         - ansible-test-network-integration-ios-network_cli-python27-stable210
         - ansible-test-network-integration-ios-network_cli-python27-stable29
-        - ansible-test-network-integration-ios-network_cli-python35
-        - ansible-test-network-integration-ios-network_cli-python35-stable210
-        - ansible-test-network-integration-ios-network_cli-python35-stable29
         - ansible-test-network-integration-ios-network_cli-python36
         - ansible-test-network-integration-ios-network_cli-python36-stable210
         - ansible-test-network-integration-ios-network_cli-python36-stable29
-        - ansible-test-network-integration-ios-network_cli-python37
-        - ansible-test-network-integration-ios-network_cli-python37-stable210
-        - ansible-test-network-integration-ios-network_cli-python37-stable29
-        - ansible-test-network-integration-ios-network_cli-python38
-        - ansible-test-network-integration-ios-network_cli-python38-stable210
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
     gate:
       queue: integrated
       jobs: *ansible-collections-cisco-ios-jobs
+
+    periodic-weekly:
+      jobs:
+        - ansible-test-network-integration-ios-local-python35
+        - ansible-test-network-integration-ios-local-python35-stable210
+        - ansible-test-network-integration-ios-local-python35-stable29
+        - ansible-test-network-integration-ios-local-python37
+        - ansible-test-network-integration-ios-local-python37-stable210
+        - ansible-test-network-integration-ios-local-python37-stable29
+        - ansible-test-network-integration-ios-local-python38
+        - ansible-test-network-integration-ios-local-python38-stable210
+        - ansible-test-network-integration-ios-network_cli-python35
+        - ansible-test-network-integration-ios-network_cli-python35-stable210
+        - ansible-test-network-integration-ios-network_cli-python35-stable29
+        - ansible-test-network-integration-ios-network_cli-python37
+        - ansible-test-network-integration-ios-network_cli-python37-stable210
+        - ansible-test-network-integration-ios-network_cli-python37-stable29
+        - ansible-test-network-integration-ios-network_cli-python38
+        - ansible-test-network-integration-ios-network_cli-python38-stable210
+
 
 - project-template:
     name: ansible-collections-cisco-iosxr-units
@@ -344,18 +347,6 @@
             vars:
               ansible_test_integration_targets: "iosxr_.*"
             voting: false
-        - ansible-test-network-integration-iosxr-netconf-python35:
-            vars:
-              ansible_test_integration_targets: "iosxr_.*"
-            voting: false
-        - ansible-test-network-integration-iosxr-netconf-python35-stable210:
-            vars:
-              ansible_test_integration_targets: "iosxr_.*"
-            voting: false
-        - ansible-test-network-integration-iosxr-netconf-python35-stable29:
-            vars:
-              ansible_test_integration_targets: "iosxr_.*"
-            voting: false
         - ansible-test-network-integration-iosxr-netconf-python36:
             vars:
               ansible_test_integration_targets: "iosxr_.*"
@@ -365,26 +356,6 @@
               ansible_test_integration_targets: "iosxr_.*"
             voting: false
         - ansible-test-network-integration-iosxr-netconf-python36-stable29:
-            vars:
-              ansible_test_integration_targets: "iosxr_.*"
-            voting: false
-        - ansible-test-network-integration-iosxr-netconf-python37:
-            vars:
-              ansible_test_integration_targets: "iosxr_.*"
-            voting: false
-        - ansible-test-network-integration-iosxr-netconf-python37-stable210:
-            vars:
-              ansible_test_integration_targets: "iosxr_.*"
-            voting: false
-        - ansible-test-network-integration-iosxr-netconf-python37-stable29:
-            vars:
-              ansible_test_integration_targets: "iosxr_.*"
-            voting: false
-        - ansible-test-network-integration-iosxr-netconf-python38:
-            vars:
-              ansible_test_integration_targets: "iosxr_.*"
-            voting: false
-        - ansible-test-network-integration-iosxr-netconf-python38-stable210:
             vars:
               ansible_test_integration_targets: "iosxr_.*"
             voting: false
@@ -412,30 +383,6 @@
             vars:
               ansible_test_integration_targets: "iosxr_.*"
             voting: false
-        - ansible-test-network-integration-iosxr-network_cli-python35-scenario01:
-            vars:
-              ansible_test_integration_targets: "iosxr_.*"
-            voting: false
-        - ansible-test-network-integration-iosxr-network_cli-python35-scenario02:
-            vars:
-              ansible_test_integration_targets: "iosxr_.*"
-            voting: false
-        - ansible-test-network-integration-iosxr-network_cli-python35-stable210-scenario01:
-            vars:
-              ansible_test_integration_targets: "iosxr_.*"
-            voting: false
-        - ansible-test-network-integration-iosxr-network_cli-python35-stable210-scenario02:
-            vars:
-              ansible_test_integration_targets: "iosxr_.*"
-            voting: false
-        - ansible-test-network-integration-iosxr-network_cli-python35-stable29-scenario01:
-            vars:
-              ansible_test_integration_targets: "iosxr_.*"
-            voting: false
-        - ansible-test-network-integration-iosxr-network_cli-python35-stable29-scenario02:
-            vars:
-              ansible_test_integration_targets: "iosxr_.*"
-            voting: false
         - ansible-test-network-integration-iosxr-network_cli-python36-scenario01:
             vars:
               ansible_test_integration_targets: "iosxr_.*"
@@ -457,6 +404,74 @@
               ansible_test_integration_targets: "iosxr_.*"
             voting: false
         - ansible-test-network-integration-iosxr-network_cli-python36-stable29-scenario02:
+            vars:
+              ansible_test_integration_targets: "iosxr_.*"
+            voting: false
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-collections/ansible.netcommon
+    gate:
+      queue: integrated
+      jobs:
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-collections/ansible.netcommon
+
+    periodic-weekly:
+      jobs:
+        - ansible-test-network-integration-iosxr-netconf-python35:
+            vars:
+              ansible_test_integration_targets: "iosxr_.*"
+            voting: false
+        - ansible-test-network-integration-iosxr-netconf-python35-stable210:
+            vars:
+              ansible_test_integration_targets: "iosxr_.*"
+            voting: false
+        - ansible-test-network-integration-iosxr-netconf-python35-stable29:
+            vars:
+              ansible_test_integration_targets: "iosxr_.*"
+            voting: false
+        - ansible-test-network-integration-iosxr-netconf-python37:
+            vars:
+              ansible_test_integration_targets: "iosxr_.*"
+            voting: false
+        - ansible-test-network-integration-iosxr-netconf-python37-stable210:
+            vars:
+              ansible_test_integration_targets: "iosxr_.*"
+            voting: false
+        - ansible-test-network-integration-iosxr-netconf-python37-stable29:
+            vars:
+              ansible_test_integration_targets: "iosxr_.*"
+            voting: false
+        - ansible-test-network-integration-iosxr-netconf-python38:
+            vars:
+              ansible_test_integration_targets: "iosxr_.*"
+            voting: false
+        - ansible-test-network-integration-iosxr-netconf-python38-stable210:
+            vars:
+              ansible_test_integration_targets: "iosxr_.*"
+            voting: false
+        - ansible-test-network-integration-iosxr-network_cli-python35-scenario01:
+            vars:
+              ansible_test_integration_targets: "iosxr_.*"
+            voting: false
+        - ansible-test-network-integration-iosxr-network_cli-python35-scenario02:
+            vars:
+              ansible_test_integration_targets: "iosxr_.*"
+            voting: false
+        - ansible-test-network-integration-iosxr-network_cli-python35-stable210-scenario01:
+            vars:
+              ansible_test_integration_targets: "iosxr_.*"
+            voting: false
+        - ansible-test-network-integration-iosxr-network_cli-python35-stable210-scenario02:
+            vars:
+              ansible_test_integration_targets: "iosxr_.*"
+            voting: false
+        - ansible-test-network-integration-iosxr-network_cli-python35-stable29-scenario01:
+            vars:
+              ansible_test_integration_targets: "iosxr_.*"
+            voting: false
+        - ansible-test-network-integration-iosxr-network_cli-python35-stable29-scenario02:
             vars:
               ansible_test_integration_targets: "iosxr_.*"
             voting: false
@@ -500,15 +515,7 @@
             vars:
               ansible_test_integration_targets: "iosxr_.*"
             voting: false
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/ansible.netcommon
-    gate:
-      queue: integrated
-      jobs:
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/ansible.netcommon
+
 
 - project-template:
     name: ansible-collections-cisco-iosxr-netconf
@@ -518,15 +525,7 @@
             vars:
               ansible_test_collections: true
             voting: false
-        - ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python35:
-            vars:
-              ansible_test_collections: true
-            voting: false
         - ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python36:
-            vars:
-              ansible_test_collections: true
-            voting: false
-        - ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python37:
             vars:
               ansible_test_collections: true
             voting: false
@@ -553,6 +552,17 @@
               - name: github.com/ansible-collections/junipernetworks.junos
               - name: github.com/ansible-collections/openvswitch.openvswitch
               - name: github.com/ansible-collections/vyos.vyos
+
+    periodic-weekly:
+      jobs:
+        - ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python35:
+            vars:
+              ansible_test_collections: true
+            voting: false
+        - ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python37:
+            vars:
+              ansible_test_collections: true
+            voting: false
 
 - project-template:
     name: ansible-collections-community-vmware
@@ -630,22 +640,6 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python35:
-            vars:
-              ansible_test_collections: true
-              ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python35-stable29:
-            vars:
-              ansible_test_collections: true
-              ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-network_cli-python35:
-            vars:
-              ansible_test_collections: true
-              ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-network_cli-python35-stable29:
-            vars:
-              ansible_test_collections: true
-              ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-netconf-python36:
             vars:
               ansible_test_collections: true
@@ -659,30 +653,6 @@
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-network_cli-python36-stable29:
-            vars:
-              ansible_test_collections: true
-              ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python37:
-            vars:
-              ansible_test_collections: true
-              ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python37-stable29:
-            vars:
-              ansible_test_collections: true
-              ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-network_cli-python37:
-            vars:
-              ansible_test_collections: true
-              ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-network_cli-python37-stable29:
-            vars:
-              ansible_test_collections: true
-              ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python38:
-            vars:
-              ansible_test_collections: true
-              ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-network_cli-python38:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -708,22 +678,6 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python35:
-            vars:
-              ansible_test_collections: true
-              ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python35-stable29:
-            vars:
-              ansible_test_collections: true
-              ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-network_cli-python35:
-            vars:
-              ansible_test_collections: true
-              ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-network_cli-python35-stable29:
-            vars:
-              ansible_test_collections: true
-              ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-netconf-python36:
             vars:
               ansible_test_collections: true
@@ -740,6 +694,29 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-collections/ansible.netcommon
+
+    periodic-weekly:
+      jobs:
+        - ansible-test-network-integration-junos-vsrx-netconf-python35:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-netconf-python35-stable29:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-network_cli-python35:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+        - ansible-test-network-integration-junos-vsrx-network_cli-python35-stable29:
+            vars:
+              ansible_test_collections: true
+              ansible_test_integration_targets: "junos_.*"
+
         - ansible-test-network-integration-junos-vsrx-netconf-python37:
             vars:
               ansible_test_collections: true
@@ -764,9 +741,6 @@
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/ansible.netcommon
 
 - project-template:
     name: ansible-collections-juniper-junos-netconf
@@ -775,16 +749,7 @@
         - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python27:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python35:
-            vars:
-              ansible_test_collections: true
         - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python36:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python37:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python38:
             vars:
               ansible_test_collections: true
         - build-ansible-collection:
@@ -798,10 +763,18 @@
         - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python27:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python35:
+        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python36:
             vars:
               ansible_test_collections: true
-        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python36:
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-collections/ansible.netcommon
+              - name: github.com/ansible-collections/cisco.iosxr
+              - name: github.com/ansible-collections/junipernetworks.junos
+
+    periodic-weekly:
+      jobs:
+        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python35:
             vars:
               ansible_test_collections: true
         - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python37:
@@ -810,11 +783,7 @@
         - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python38:
             vars:
               ansible_test_collections: true
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/ansible.netcommon
-              - name: github.com/ansible-collections/cisco.iosxr
-              - name: github.com/ansible-collections/junipernetworks.junos
+
 
 - project-template:
     name: ansible-collections-openvswitch-openvswitch-units
@@ -837,16 +806,22 @@
               ansible_test_collections: true
         - ansible-test-network-integration-openvswitch-python27-stable210
         - ansible-test-network-integration-openvswitch-python27-stable29
-        - ansible-test-network-integration-openvswitch-python35:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-openvswitch-python35-stable210
-        - ansible-test-network-integration-openvswitch-python35-stable29
         - ansible-test-network-integration-openvswitch-python36:
             vars:
               ansible_test_collections: true
         - ansible-test-network-integration-openvswitch-python36-stable210
         - ansible-test-network-integration-openvswitch-python36-stable29
+    gate:
+      queue: integrated
+      jobs: *ansible-collections-openvswitch-openvswitch-jobs
+
+    periodic-weekly:
+      jobs:
+        - ansible-test-network-integration-openvswitch-python35:
+            vars:
+              ansible_test_collections: true
+        - ansible-test-network-integration-openvswitch-python35-stable210
+        - ansible-test-network-integration-openvswitch-python35-stable29
         - ansible-test-network-integration-openvswitch-python37:
             vars:
               ansible_test_collections: true
@@ -859,9 +834,7 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
-    gate:
-      queue: integrated
-      jobs: *ansible-collections-openvswitch-openvswitch-jobs
+
 
 - project-template:
     name: ansible-collections-vyos-vyos-units
@@ -882,37 +855,41 @@
         - ansible-test-network-integration-vyos-local-python27
         - ansible-test-network-integration-vyos-local-python27-stable210
         - ansible-test-network-integration-vyos-local-python27-stable29
-        - ansible-test-network-integration-vyos-local-python35
-        - ansible-test-network-integration-vyos-local-python35-stable210
-        - ansible-test-network-integration-vyos-local-python35-stable29
         - ansible-test-network-integration-vyos-local-python36
         - ansible-test-network-integration-vyos-local-python36-stable210
         - ansible-test-network-integration-vyos-local-python36-stable29
-        - ansible-test-network-integration-vyos-local-python37
-        - ansible-test-network-integration-vyos-local-python37-stable210
-        - ansible-test-network-integration-vyos-local-python37-stable29
-        - ansible-test-network-integration-vyos-local-python38
-        - ansible-test-network-integration-vyos-local-python38-stable210
         - ansible-test-network-integration-vyos-network_cli-python27
         - ansible-test-network-integration-vyos-network_cli-python27-stable210
         - ansible-test-network-integration-vyos-network_cli-python27-stable29
-        - ansible-test-network-integration-vyos-network_cli-python35
-        - ansible-test-network-integration-vyos-network_cli-python35-stable210
-        - ansible-test-network-integration-vyos-network_cli-python35-stable29
         - ansible-test-network-integration-vyos-network_cli-python36
         - ansible-test-network-integration-vyos-network_cli-python36-stable210
         - ansible-test-network-integration-vyos-network_cli-python36-stable29
-        - ansible-test-network-integration-vyos-network_cli-python37
-        - ansible-test-network-integration-vyos-network_cli-python37-stable210
-        - ansible-test-network-integration-vyos-network_cli-python37-stable29
-        - ansible-test-network-integration-vyos-network_cli-python38
-        - ansible-test-network-integration-vyos-network_cli-python38-stable210
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
     gate:
       queue: integrated
       jobs: *ansible-collections-vyos-vyos-jobs
+
+    periodic-weekly:
+      jobs:
+        - ansible-test-network-integration-vyos-local-python35
+        - ansible-test-network-integration-vyos-local-python35-stable210
+        - ansible-test-network-integration-vyos-local-python35-stable29
+        - ansible-test-network-integration-vyos-local-python37
+        - ansible-test-network-integration-vyos-local-python37-stable210
+        - ansible-test-network-integration-vyos-local-python37-stable29
+        - ansible-test-network-integration-vyos-local-python38
+        - ansible-test-network-integration-vyos-local-python38-stable210
+        - ansible-test-network-integration-vyos-network_cli-python35
+        - ansible-test-network-integration-vyos-network_cli-python35-stable210
+        - ansible-test-network-integration-vyos-network_cli-python35-stable29
+        - ansible-test-network-integration-vyos-network_cli-python37
+        - ansible-test-network-integration-vyos-network_cli-python37-stable210
+        - ansible-test-network-integration-vyos-network_cli-python37-stable29
+        - ansible-test-network-integration-vyos-network_cli-python38
+        - ansible-test-network-integration-vyos-network_cli-python38-stable210
+
 
 - project-template:
     name: ansible-collections-frr-frr-units


### PR DESCRIPTION
There is currently quite a few running jobs but they consume wy too much jobs
and as a result, we are often at capacity. Our resources are not unlimited,
and in this case, jobs just stay pending... for hours.

For instance, we've got currently a vmware job that has been running
for 16h now.

This kind of delay does not benefit anyone, they impact our moral,
the contributors motivations and they certainly don't improve the quality
of the collections.

Python35, Python37 and Python38 are not criticial and consume a lot of
resources. They can definitiely be run in a delayed pipeline. And this would
help use greatly to speed up our CI.