### PR TITLE
move vmware checks in 'integrated' queue

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -557,6 +557,7 @@
 - project-template:
     name: ansible-collections-community-vmware
     check:
+      queue: integrated
       jobs:
         - ansible-test-cloud-integration-govcsim-python36_1_of_3
         - ansible-test-cloud-integration-govcsim-python36_2_of_3


### PR DESCRIPTION
Zuul's scheduler is configured with `relative_priority` on. However
the option only impact the jobs for a given queue.
By moving the vmware check jobs in the `integrated` queue with the
network jobs, Zuul will be able to prioritize the resources.

See: https://zuul-ci.org/docs/zuul/discussion/components.html#attr-scheduler.relative_priority