### PR TITLE
Have integrated queue for check pipeline too

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -3,6 +3,8 @@
     name: integrated-queue
     description: |
       Group projects together into a shared (integrated) change queue.
+    check:
+      queue: integrated
     gate:
       queue: integrated
 


### PR DESCRIPTION
This means all projects in the 'integrated' queue will now have
relative priority for nodes in check. We do this, so the network content
collections don't starve all the resources from other projects.

Long term, we are moving to move unit test based testing, then
integration tests but that will take some time.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>