### PR TITLE
ansible-galaxy-importer: don't taint the output with Python warnings

### DIFF
--- a/playbooks/ansible-galaxy-importer/run.yaml
+++ b/playbooks/ansible-galaxy-importer/run.yaml
@@ -12,7 +12,7 @@
     - name: Generate version number for ansible collection
       args:
         chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
-      shell: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv/bin/generate-ansible-collection"
+      shell: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv/bin/python -W ignore {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv/bin/generate-ansible-collection"
       register: _version
 
     - name: Fetch and install the artifacts


### PR DESCRIPTION
Call Python with the `-W ignore` flag ensure we don't get any unexpected information in the `_version` variable.