### PR TITLE
Refactor vyos.vyos jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -2329,11 +2329,42 @@
       ansible_collections_repo: github.com/ansible-collections/vyos.vyos
 
 - job:
-    name: ansible-test-units-vyos
-    parent: ansible-test-units-base
+    name: ansible-test-units-vyos-python27
+    parent: ansible-test-units-base-python27
     required-projects:
       - name: github.com/ansible-collections/vyos.vyos
-    timeout: 3600
+    vars:
+      ansible_collections_repo: github.com/ansible-collections/vyos.vyos
+
+- job:
+    name: ansible-test-units-vyos-python35
+    parent: ansible-test-units-base-python35
+    required-projects:
+      - name: github.com/ansible-collections/vyos.vyos
+    vars:
+      ansible_collections_repo: github.com/ansible-collections/vyos.vyos
+
+- job:
+    name: ansible-test-units-vyos-python36
+    parent: ansible-test-units-base-python36
+    required-projects:
+      - name: github.com/ansible-collections/vyos.vyos
+    vars:
+      ansible_collections_repo: github.com/ansible-collections/vyos.vyos
+
+- job:
+    name: ansible-test-units-vyos-python37
+    parent: ansible-test-units-base-python37
+    required-projects:
+      - name: github.com/ansible-collections/vyos.vyos
+    vars:
+      ansible_collections_repo: github.com/ansible-collections/vyos.vyos
+
+- job:
+    name: ansible-test-units-vyos-python38
+    parent: ansible-test-units-base-python38
+    required-projects:
+      - name: github.com/ansible-collections/vyos.vyos
     vars:
       ansible_collections_repo: github.com/ansible-collections/vyos.vyos
 
@@ -2361,117 +2392,9 @@
       ansible_test_python: 2.7
 
 - job:
-    name: ansible-test-network-integration-vyos-local-python27
-    parent: ansible-test-network-integration-vyos-local
-    nodeset: vyos-1.1.8-python27
-    vars:
-      ansible_test_python: 2.7
-
-- job:
-    name: ansible-test-network-integration-vyos-network_cli-python27
-    parent: ansible-test-network-integration-vyos-network_cli
-    nodeset: vyos-1.1.8-python27
-    vars:
-      ansible_test_python: 2.7
-
-- job:
-    name: ansible-test-network-integration-vyos-local-python27-stable210
-    parent: ansible-test-network-integration-vyos-local
-    nodeset: vyos-1.1.8-python27
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-    vars:
-      ansible_test_python: 2.7
-
-- job:
-    name: ansible-test-network-integration-vyos-network_cli-python27-stable210
-    parent: ansible-test-network-integration-vyos-network_cli
-    nodeset: vyos-1.1.8-python27
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-    vars:
-      ansible_test_python: 2.7
-
-- job:
-    name: ansible-test-network-integration-vyos-local-python27-stable29
-    parent: ansible-test-network-integration-vyos-local
-    nodeset: vyos-1.1.8-python27
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    vars:
-      ansible_test_python: 2.7
-
-- job:
-    name: ansible-test-network-integration-vyos-network_cli-python27-stable29
-    parent: ansible-test-network-integration-vyos-network_cli
-    nodeset: vyos-1.1.8-python27
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    vars:
-      ansible_test_python: 2.7
-
-- job:
     name: ansible-test-network-integration-vyos-python35
     parent: ansible-test-network-integration-vyos
     nodeset: vyos-1.1.8-python35
-    vars:
-      ansible_test_python: 3.5
-
-- job:
-    name: ansible-test-network-integration-vyos-local-python35
-    parent: ansible-test-network-integration-vyos-local
-    nodeset: vyos-1.1.8-python35
-    vars:
-      ansible_test_python: 3.5
-
-- job:
-    name: ansible-test-network-integration-vyos-network_cli-python35
-    parent: ansible-test-network-integration-vyos-network_cli
-    nodeset: vyos-1.1.8-python35
-    vars:
-      ansible_test_python: 3.5
-
-- job:
-    name: ansible-test-network-integration-vyos-local-python35-stable210
-    parent: ansible-test-network-integration-vyos-local
-    nodeset: vyos-1.1.8-python35
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-    vars:
-      ansible_test_python: 3.5
-
-- job:
-    name: ansible-test-network-integration-vyos-network_cli-python35-stable210
-    parent: ansible-test-network-integration-vyos-network_cli
-    nodeset: vyos-1.1.8-python35
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    vars:
-      ansible_test_python: 3.5
-
-- job:
-    name: ansible-test-network-integration-vyos-local-python35-stable29
-    parent: ansible-test-network-integration-vyos-local
-    nodeset: vyos-1.1.8-python35
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    vars:
-      ansible_test_python: 3.5
-
-- job:
-    name: ansible-test-network-integration-vyos-network_cli-python35-stable29
-    parent: ansible-test-network-integration-vyos-network_cli
-    nodeset: vyos-1.1.8-python35
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
     vars:
       ansible_test_python: 3.5
 
@@ -2542,101 +2465,6 @@
     nodeset: vyos-1.1.8-python37
     vars:
       ansible_test_python: 3.7
-
-- job:
-    name: ansible-test-network-integration-vyos-local-python37
-    parent: ansible-test-network-integration-vyos-local
-    nodeset: vyos-1.1.8-python37
-    vars:
-      ansible_test_python: 3.7
-
-- job:
-    name: ansible-test-network-integration-vyos-network_cli-python37
-    parent: ansible-test-network-integration-vyos-network_cli
-    nodeset: vyos-1.1.8-python37
-    vars:
-      ansible_test_python: 3.7
-
-- job:
-    name: ansible-test-network-integration-vyos-local-python37-stable210
-    parent: ansible-test-network-integration-vyos-local
-    nodeset: vyos-1.1.8-python37
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-    vars:
-      ansible_test_python: 3.7
-
-- job:
-    name: ansible-test-network-integration-vyos-network_cli-python37-stable210
-    parent: ansible-test-network-integration-vyos-network_cli
-    nodeset: vyos-1.1.8-python37
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-    vars:
-      ansible_test_python: 3.7
-
-- job:
-    name: ansible-test-network-integration-vyos-local-python37-stable29
-    parent: ansible-test-network-integration-vyos-local
-    nodeset: vyos-1.1.8-python37
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    vars:
-      ansible_test_python: 3.7
-
-- job:
-    name: ansible-test-network-integration-vyos-network_cli-python37-stable29
-    parent: ansible-test-network-integration-vyos-network_cli
-    nodeset: vyos-1.1.8-python37
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    vars:
-      ansible_test_python: 3.7
-
-- job:
-    name: ansible-test-network-integration-vyos-python38
-    parent: ansible-test-network-integration-vyos
-    nodeset: vyos-1.1.8-python38
-    vars:
-      ansible_test_python: 3.8
-
-- job:
-    name: ansible-test-network-integration-vyos-local-python38
-    parent: ansible-test-network-integration-vyos-local
-    nodeset: vyos-1.1.8-python38
-    vars:
-      ansible_test_python: 3.8
-
-- job:
-    name: ansible-test-network-integration-vyos-network_cli-python38
-    parent: ansible-test-network-integration-vyos-network_cli
-    nodeset: vyos-1.1.8-python38
-    vars:
-      ansible_test_python: 3.8
-
-- job:
-    name: ansible-test-network-integration-vyos-local-python38-stable210
-    parent: ansible-test-network-integration-vyos-local
-    nodeset: vyos-1.1.8-python38
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-    vars:
-      ansible_test_python: 3.8
-
-- job:
-    name: ansible-test-network-integration-vyos-network_cli-python38-stable210
-    parent: ansible-test-network-integration-vyos-network_cli
-    nodeset: vyos-1.1.8-python38
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-    vars:
-      ansible_test_python: 3.8
 
 - job:
     name: ansible-test-sanity-frr

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -807,47 +807,27 @@
 - project-template:
     name: ansible-collections-vyos-vyos-units
     check:
-      jobs:
+      jobs: &ansible-collections-vyos-vyos-units-jobs
         - ansible-test-sanity-vyos
-        - ansible-test-units-vyos
+        - ansible-test-units-vyos-python27
+        - ansible-test-units-vyos-python35
+        - ansible-test-units-vyos-python36
+        - ansible-test-units-vyos-python37
+        - ansible-test-units-vyos-python38
     gate:
       queue: integrated
-      jobs:
-        - ansible-test-sanity-vyos
-        - ansible-test-units-vyos
+      jobs: *ansible-collections-vyos-vyos-units-jobs
 
 - project-template:
     name: ansible-collections-vyos-vyos
     check:
       jobs: &ansible-collections-vyos-vyos-jobs
-        - ansible-test-network-integration-vyos-local-python27
-        - ansible-test-network-integration-vyos-local-python27-stable210
-        - ansible-test-network-integration-vyos-local-python27-stable29
-        - ansible-test-network-integration-vyos-local-python35
-        - ansible-test-network-integration-vyos-local-python35-stable210
-        - ansible-test-network-integration-vyos-local-python35-stable29
         - ansible-test-network-integration-vyos-local-python36
         - ansible-test-network-integration-vyos-local-python36-stable210
         - ansible-test-network-integration-vyos-local-python36-stable29
-        - ansible-test-network-integration-vyos-local-python37
-        - ansible-test-network-integration-vyos-local-python37-stable210
-        - ansible-test-network-integration-vyos-local-python37-stable29
-        - ansible-test-network-integration-vyos-local-python38
-        - ansible-test-network-integration-vyos-local-python38-stable210
-        - ansible-test-network-integration-vyos-network_cli-python27
-        - ansible-test-network-integration-vyos-network_cli-python27-stable210
-        - ansible-test-network-integration-vyos-network_cli-python27-stable29
-        - ansible-test-network-integration-vyos-network_cli-python35
-        - ansible-test-network-integration-vyos-network_cli-python35-stable210
-        - ansible-test-network-integration-vyos-network_cli-python35-stable29
         - ansible-test-network-integration-vyos-network_cli-python36
         - ansible-test-network-integration-vyos-network_cli-python36-stable210
         - ansible-test-network-integration-vyos-network_cli-python36-stable29
-        - ansible-test-network-integration-vyos-network_cli-python37
-        - ansible-test-network-integration-vyos-network_cli-python37-stable210
-        - ansible-test-network-integration-vyos-network_cli-python37-stable29
-        - ansible-test-network-integration-vyos-network_cli-python38
-        - ansible-test-network-integration-vyos-network_cli-python38-stable210
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon


### PR DESCRIPTION
With this change, we are now making it more important to use unit
testing to check for python versions over integration jobs.  This is
mostly to help cut down on the amount of time it takes a PR to run.

The idea is, integration testing hasn't been a good indicator of finding
issues with the different versions of python, and we likely can improve
unitesting to account for that.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>