### PR TITLE
Refactor arista.eos testing

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -401,11 +401,42 @@
       ansible_collections_repo: github.com/ansible-collections/arista.eos
 
 - job:
-    name: ansible-test-units-eos
-    parent: ansible-test-units-base
+    name: ansible-test-units-eos-python27
+    parent: ansible-test-units-base-python27
     required-projects:
       - name: github.com/ansible-collections/arista.eos
-    timeout: 3600
+    vars:
+      ansible_collections_repo: github.com/ansible-collections/arista.eos
+
+- job:
+    name: ansible-test-units-eos-python35
+    parent: ansible-test-units-base-python35
+    required-projects:
+      - name: github.com/ansible-collections/arista.eos
+    vars:
+      ansible_collections_repo: github.com/ansible-collections/arista.eos
+
+- job:
+    name: ansible-test-units-eos-python36
+    parent: ansible-test-units-base-python36
+    required-projects:
+      - name: github.com/ansible-collections/arista.eos
+    vars:
+      ansible_collections_repo: github.com/ansible-collections/arista.eos
+
+- job:
+    name: ansible-test-units-eos-python37
+    parent: ansible-test-units-base-python37
+    required-projects:
+      - name: github.com/ansible-collections/arista.eos
+    vars:
+      ansible_collections_repo: github.com/ansible-collections/arista.eos
+
+- job:
+    name: ansible-test-units-eos-python38
+    parent: ansible-test-units-base-python38
+    required-projects:
+      - name: github.com/ansible-collections/arista.eos
     vars:
       ansible_collections_repo: github.com/ansible-collections/arista.eos
 
@@ -433,145 +464,9 @@
       ansible_test_python: 2.7
 
 - job:
-    name: ansible-test-network-integration-eos-httpapi-python27
-    parent: ansible-test-network-integration-eos-httpapi
-    nodeset: eos-4.20.10-python27
-    vars:
-      ansible_test_python: 2.7
-
-- job:
-    name: ansible-test-network-integration-eos-network_cli-python27
-    parent: ansible-test-network-integration-eos-network_cli
-    nodeset: eos-4.20.10-python27
-    vars:
-      ansible_test_python: 2.7
-
-- job:
-    name: ansible-test-network-integration-eos-httpapi-python27-stable210
-    parent: ansible-test-network-integration-eos-httpapi
-    nodeset: eos-4.20.10-python27
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-    vars:
-      ansible_test_python: 2.7
-
-- job:
-    name: ansible-test-network-integration-eos-network_cli-python27-stable210
-    parent: ansible-test-network-integration-eos-network_cli
-    nodeset: eos-4.20.10-python27
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-    vars:
-      ansible_test_python: 2.7
-      ansible_test_split_in: 2
-
-- job:
-    name: ansible-test-network-integration-eos-network_cli-python27-stable210-scenario01
-    parent: ansible-test-network-integration-eos-network_cli-python27-stable210
-    vars:
-      ansible_test_do_number: 1
-
-- job:
-    name: ansible-test-network-integration-eos-network_cli-python27-stable210-scenario02
-    parent: ansible-test-network-integration-eos-network_cli-python27-stable210
-    vars:
-      ansible_test_do_number: 2
-
-- job:
-    name: ansible-test-network-integration-eos-httpapi-python27-stable29
-    parent: ansible-test-network-integration-eos-httpapi
-    nodeset: eos-4.20.10-python27
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    vars:
-      ansible_test_python: 2.7
-
-- job:
-    name: ansible-test-network-integration-eos-network_cli-python27-stable29
-    parent: ansible-test-network-integration-eos-network_cli
-    nodeset: eos-4.20.10-python27
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    vars:
-      ansible_test_python: 2.7
-
-- job:
     name: ansible-test-network-integration-eos-python35
     parent: ansible-test-network-integration-eos
     nodeset: eos-4.20.10-python35
-    vars:
-      ansible_test_python: 3.5
-
-- job:
-    name: ansible-test-network-integration-eos-httpapi-python35
-    parent: ansible-test-network-integration-eos-httpapi
-    nodeset: eos-4.20.10-python35
-    vars:
-      ansible_test_python: 3.5
-
-- job:
-    name: ansible-test-network-integration-eos-network_cli-python35
-    parent: ansible-test-network-integration-eos-network_cli
-    nodeset: eos-4.20.10-python35
-    vars:
-      ansible_test_python: 3.5
-
-- job:
-    name: ansible-test-network-integration-eos-httpapi-python35-stable210
-    parent: ansible-test-network-integration-eos-httpapi
-    nodeset: eos-4.20.10-python35
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-    vars:
-      ansible_test_python: 3.5
-
-- job:
-    name: ansible-test-network-integration-eos-network_cli-python35-stable210
-    parent: ansible-test-network-integration-eos-network_cli
-    nodeset: eos-4.20.10-python35
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-    vars:
-      ansible_test_python: 3.5
-      ansible_test_split_in: 2
-
-
-- job:
-    name: ansible-test-network-integration-eos-network_cli-python35-stable210-scenario01
-    parent: ansible-test-network-integration-eos-network_cli-python35-stable210
-    vars:
-      ansible_test_do_number: 1
-
-- job:
-    name: ansible-test-network-integration-eos-network_cli-python35-stable210-scenario02
-    parent: ansible-test-network-integration-eos-network_cli-python35-stable210
-    vars:
-      ansible_test_do_number: 2
-
-
-- job:
-    name: ansible-test-network-integration-eos-httpapi-python35-stable29
-    parent: ansible-test-network-integration-eos-httpapi
-    nodeset: eos-4.20.10-python35
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    vars:
-      ansible_test_python: 3.5
-
-- job:
-    name: ansible-test-network-integration-eos-network_cli-python35-stable29
-    parent: ansible-test-network-integration-eos-network_cli
-    nodeset: eos-4.20.10-python35
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
     vars:
       ansible_test_python: 3.5
 
@@ -657,127 +552,11 @@
       ansible_test_python: 3.7
 
 - job:
-    name: ansible-test-network-integration-eos-httpapi-python37
-    parent: ansible-test-network-integration-eos-httpapi
-    nodeset: eos-4.20.10-python37
-    vars:
-      ansible_test_python: 3.7
-
-- job:
-    name: ansible-test-network-integration-eos-network_cli-python37
-    parent: ansible-test-network-integration-eos-network_cli
-    nodeset: eos-4.20.10-python37
-    vars:
-      ansible_test_python: 3.7
-
-- job:
-    name: ansible-test-network-integration-eos-httpapi-python37-stable210
-    parent: ansible-test-network-integration-eos-httpapi
-    nodeset: eos-4.20.10-python37
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-    vars:
-      ansible_test_python: 3.7
-
-- job:
-    name: ansible-test-network-integration-eos-network_cli-python37-stable210
-    parent: ansible-test-network-integration-eos-network_cli
-    nodeset: eos-4.20.10-python37
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-    vars:
-      ansible_test_python: 3.7
-      ansible_test_split_in: 2
-
-- job:
-    name: ansible-test-network-integration-eos-network_cli-python37-stable210-scenario01
-    parent: ansible-test-network-integration-eos-network_cli-python37-stable210
-    vars:
-      ansible_test_do_number: 1
-
-- job:
-    name: ansible-test-network-integration-eos-network_cli-python37-stable210-scenario02
-    parent: ansible-test-network-integration-eos-network_cli-python37-stable210
-    vars:
-      ansible_test_do_number: 2
-
-
-- job:
-    name: ansible-test-network-integration-eos-httpapi-python37-stable29
-    parent: ansible-test-network-integration-eos-httpapi
-    nodeset: eos-4.20.10-python37
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    vars:
-      ansible_test_python: 3.7
-
-- job:
-    name: ansible-test-network-integration-eos-network_cli-python37-stable29
-    parent: ansible-test-network-integration-eos-network_cli
-    nodeset: eos-4.20.10-python37
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    vars:
-      ansible_test_python: 3.7
-
-- job:
     name: ansible-test-network-integration-eos-python38
     parent: ansible-test-network-integration-eos
     nodeset: eos-4.20.10-python38
     vars:
       ansible_test_python: 3.8
-
-- job:
-    name: ansible-test-network-integration-eos-httpapi-python38
-    parent: ansible-test-network-integration-eos-httpapi
-    nodeset: eos-4.20.10-python38
-    vars:
-      ansible_test_python: 3.8
-
-- job:
-    name: ansible-test-network-integration-eos-network_cli-python38
-    parent: ansible-test-network-integration-eos-network_cli
-    nodeset: eos-4.20.10-python38
-    vars:
-      ansible_test_python: 3.8
-
-- job:
-    name: ansible-test-network-integration-eos-httpapi-python38-stable210
-    parent: ansible-test-network-integration-eos-httpapi
-    nodeset: eos-4.20.10-python38
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-    vars:
-      ansible_test_python: 3.8
-
-- job:
-    name: ansible-test-network-integration-eos-network_cli-python38-stable210
-    parent: ansible-test-network-integration-eos-network_cli
-    nodeset: eos-4.20.10-python38
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-    vars:
-      ansible_test_python: 3.8
-      ansible_test_split_in: 2
-
-- job:
-    name: ansible-test-network-integration-eos-network_cli-python38-stable210-scenario01
-    parent: ansible-test-network-integration-eos-network_cli-python38-stable210
-    vars:
-      ansible_test_do_number: 1
-
-- job:
-    name: ansible-test-network-integration-eos-network_cli-python38-stable210-scenario02
-    parent: ansible-test-network-integration-eos-network_cli-python38-stable210
-    vars:
-      ansible_test_do_number: 2
-
 
 - job:
     name: ansible-test-network-integration-ios

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -64,52 +64,28 @@
 - project-template:
     name: ansible-collections-arista-eos-units
     check:
-      jobs:
+      jobs: &ansile-collections-arista-eos-units-jobs
         - ansible-test-sanity-eos
-        - ansible-test-units-eos
+        - ansible-test-units-eos-python27
+        - ansible-test-units-eos-python35
+        - ansible-test-units-eos-python36
+        - ansible-test-units-eos-python37
+        - ansible-test-units-eos-python38
     gate:
       queue: integrated
-      jobs:
-        - ansible-test-sanity-eos
-        - ansible-test-units-eos
+      jobs: *ansile-collections-arista-eos-units-jobs
 
 - project-template:
     name: ansible-collections-arista-eos
     check:
       jobs: &ansible-collections-arista-eos-jobs
-        - ansible-test-network-integration-eos-httpapi-python27
-        - ansible-test-network-integration-eos-httpapi-python27-stable210
-        - ansible-test-network-integration-eos-httpapi-python27-stable29
-        - ansible-test-network-integration-eos-httpapi-python35
-        - ansible-test-network-integration-eos-httpapi-python35-stable210
-        - ansible-test-network-integration-eos-httpapi-python35-stable29
         - ansible-test-network-integration-eos-httpapi-python36
         - ansible-test-network-integration-eos-httpapi-python36-stable210
         - ansible-test-network-integration-eos-httpapi-python36-stable29
-        - ansible-test-network-integration-eos-httpapi-python37
-        - ansible-test-network-integration-eos-httpapi-python37-stable210
-        - ansible-test-network-integration-eos-httpapi-python37-stable29
-        - ansible-test-network-integration-eos-httpapi-python38
-        - ansible-test-network-integration-eos-httpapi-python38-stable210
-        - ansible-test-network-integration-eos-network_cli-python27
-        - ansible-test-network-integration-eos-network_cli-python27-stable210-scenario01
-        - ansible-test-network-integration-eos-network_cli-python27-stable210-scenario02
-        - ansible-test-network-integration-eos-network_cli-python27-stable29
-        - ansible-test-network-integration-eos-network_cli-python35
-        - ansible-test-network-integration-eos-network_cli-python35-stable210-scenario01
-        - ansible-test-network-integration-eos-network_cli-python35-stable210-scenario02
-        - ansible-test-network-integration-eos-network_cli-python35-stable29
         - ansible-test-network-integration-eos-network_cli-python36
         - ansible-test-network-integration-eos-network_cli-python36-stable210-scenario01
         - ansible-test-network-integration-eos-network_cli-python36-stable210-scenario02
         - ansible-test-network-integration-eos-network_cli-python36-stable29
-        - ansible-test-network-integration-eos-network_cli-python37
-        - ansible-test-network-integration-eos-network_cli-python37-stable210-scenario01
-        - ansible-test-network-integration-eos-network_cli-python37-stable210-scenario02
-        - ansible-test-network-integration-eos-network_cli-python37-stable29
-        - ansible-test-network-integration-eos-network_cli-python38
-        - ansible-test-network-integration-eos-network_cli-python38-stable210-scenario01
-        - ansible-test-network-integration-eos-network_cli-python38-stable210-scenario02
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon


### PR DESCRIPTION
Move towards more unit testing for arista.eos jobs, then integration.
This should help us save a lot of CI resources.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>