### PR TITLE
vmware-ci-set-passwords: avoid space in password

### DIFF
--- a/roles/vmware-ci-set-passwords/files/vcenter_set_password
+++ b/roles/vmware-ci-set-passwords/files/vcenter_set_password
@@ -18,7 +18,7 @@ import subprocess
 
 import time
 
-CHARACTER_BLACKLIST = ["\\", "'", '"', '%', '{', '}']
+CHARACTER_BLACKLIST = ["\\", "'", '"', '%', '{', '}', ' ']
 
 
 def set_new_pw():


### PR DESCRIPTION
Passwords with a space trigger weird side-effect when they are exposed through environment variables. This may also be the root cause of https://github.com/ansible-collections/vmware/issues/303.