### PR TITLE
Only install ara for (network-)integration jobs

### DIFF
--- a/playbooks/ansible-test-base/pre.yaml
+++ b/playbooks/ansible-test-base/pre.yaml
@@ -30,7 +30,10 @@
 
     - name: Install ara into virtualenv
       shell: ~/venv/bin/pip install "ara<1.0.0"
-      when: ansible_test_command != 'sanity'
+      when: "'integration' in ansible_test_command"
 
     - name: Install ansible into virtualenv
+      # TODO(pabelanger): Remove ANSIBLE_SKIP_CONFLICT_CHECK in the future.
+      environment:
+        ANSIBLE_SKIP_CONFLICT_CHECK: 1
       shell: "~/venv/bin/pip install {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1910,10 +1910,12 @@
     post-run: playbooks/ansible-test-units-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
     timeout: 3600
     vars:
       ansible_test_collections: true
       ansible_test_command: units
+      ansible_test_enable_ara: false
       ansible_test_integration_targets: ""
       # NOTE(pabelanger): ansible_test_python to be removed
       ansible_test_python: 3.8


### PR DESCRIPTION
This removes ARA for units / sanity test jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>