### PR TITLE
Refactor cisco.asa jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -270,6 +270,7 @@
       - README.md
     vars:
       ansible_collections_repo: github.com/ansible-collections/cisco.asa
+      ansible_test_collections: true
       ansible_test_command: network-integration
       ansible_test_integration_targets: "asa_.*"
 
@@ -283,52 +284,59 @@
       ansible_collections_repo: github.com/ansible-collections/cisco.asa
 
 - job:
-    name: ansible-test-units-asa
-    parent: ansible-test-units-base
+    name: ansible-test-units-asa-python27
+    parent: ansible-test-units-base-python27
     required-projects:
       - name: github.com/ansible-collections/cisco.asa
-    timeout: 3600
     vars:
       ansible_collections_repo: github.com/ansible-collections/cisco.asa
 
 - job:
-    name: ansible-test-network-integration-asa-python27
-    parent: ansible-test-network-integration-asa
-    nodeset: asav9-12-3-python27
-    vars:
-      ansible_test_python: 2.7
-
-- job:
-    name: ansible-test-network-integration-asa-python27-stable29
-    parent: ansible-test-network-integration-asa
-    nodeset: asav9-12-3-python27
+    name: ansible-test-units-asa-python35
+    parent: ansible-test-units-base-python35
     required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
+      - name: github.com/ansible-collections/cisco.asa
     vars:
-      ansible_test_python: 2.7
+      ansible_collections_repo: github.com/ansible-collections/cisco.asa
 
 - job:
-    name: ansible-test-network-integration-asa-python35
-    parent: ansible-test-network-integration-asa
-    nodeset: asav9-12-3-python35
-    vars:
-      ansible_test_python: 3.5
-
-- job:
-    name: ansible-test-network-integration-asa-python35-stable29
-    parent: ansible-test-network-integration-asa
-    nodeset: asav9-12-3-python35
+    name: ansible-test-units-asa-python36
+    parent: ansible-test-units-base-python36
     required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
+      - name: github.com/ansible-collections/cisco.asa
     vars:
-      ansible_test_python: 3.5
+      ansible_collections_repo: github.com/ansible-collections/cisco.asa
+
+- job:
+    name: ansible-test-units-asa-python37
+    parent: ansible-test-units-base-python37
+    required-projects:
+      - name: github.com/ansible-collections/cisco.asa
+    vars:
+      ansible_collections_repo: github.com/ansible-collections/cisco.asa
+
+- job:
+    name: ansible-test-units-asa-python38
+    parent: ansible-test-units-base-python38
+    required-projects:
+      - name: github.com/ansible-collections/cisco.asa
+    vars:
+      ansible_collections_repo: github.com/ansible-collections/cisco.asa
 
 - job:
     name: ansible-test-network-integration-asa-python36
     parent: ansible-test-network-integration-asa
     nodeset: asav9-12-3-python36
+    vars:
+      ansible_test_python: 3.6
+
+- job:
+    name: ansible-test-network-integration-asa-python36-stable210
+    parent: ansible-test-network-integration-asa
+    nodeset: asav9-12-3-python36
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.10
     vars:
       ansible_test_python: 3.6
 
@@ -341,30 +349,6 @@
         override-checkout: stable-2.9
     vars:
       ansible_test_python: 3.6
-
-- job:
-    name: ansible-test-network-integration-asa-python37
-    parent: ansible-test-network-integration-asa
-    nodeset: asav9-12-3-python37
-    vars:
-      ansible_test_python: 3.7
-
-- job:
-    name: ansible-test-network-integration-asa-python37-stable29
-    parent: ansible-test-network-integration-asa
-    nodeset: asav9-12-3-python37
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    vars:
-      ansible_test_python: 3.7
-
-- job:
-    name: ansible-test-network-integration-asa-python38
-    parent: ansible-test-network-integration-asa
-    nodeset: asav9-12-3-python38
-    vars:
-      ansible_test_python: 3.8
 
 - job:
     name: ansible-test-network-integration-eos

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -96,78 +96,30 @@
 - project-template:
     name: ansible-collections-cisco-asa-units
     check:
-      jobs:
+      jobs: &ansible-collections-cisco-asa-units-jobs
         - ansible-test-sanity-asa
-        - ansible-test-units-asa
+        - ansible-test-units-asa-python27
+        - ansible-test-units-asa-python35
+        - ansible-test-units-asa-python36
+        - ansible-test-units-asa-python37
+        - ansible-test-units-asa-python38
     gate:
       queue: integrated
-      jobs:
-        - ansible-test-sanity-asa
-        - ansible-test-units-asa
+      jobs: *ansible-collections-cisco-asa-units-jobs
 
 - project-template:
     name: ansible-collections-cisco-asa
     check:
-      jobs:
-        - ansible-test-network-integration-asa-python27:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-asa-python27-stable29:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-asa-python35:
-            vars:
-              ansible_test_collections: true
-            voting: false
-        - ansible-test-network-integration-asa-python35-stable29:
-            vars:
-              ansible_test_collections: true
-            voting: false
-        - ansible-test-network-integration-asa-python36:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-asa-python36-stable29:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-asa-python37:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-asa-python37-stable29:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-asa-python38:
-            vars:
-              ansible_test_collections: true
+      jobs: &ansible-collections-cisco-asa-jobs
+        - ansible-test-network-integration-asa-python36
+        - ansible-test-network-integration-asa-python36-stable210
+        - ansible-test-network-integration-asa-python36-stable29
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
     gate:
       queue: integrated
-      jobs:
-        - ansible-test-network-integration-asa-python27:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-asa-python27-stable29:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-asa-python36:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-asa-python36-stable29:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-asa-python37:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-asa-python37-stable29:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-asa-python38:
-            vars:
-              ansible_test_collections: true
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/ansible.netcommon
+      jobs: *ansible-collections-cisco-asa-jobs
 
 - project-template:
     name: ansible-collections-cisco-nxos-units


### PR DESCRIPTION
This adds stable-2.10 support for jobs. As well removes all but
python3.6 for integration jobs.  We now are expanding our unit tests to
help valiate different python versions.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>