### PR TITLE
Marked vyos jobs as nonvoting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -740,7 +740,6 @@
             voting: false
         - ansible-test-network-integration-vyos-network_cli-python36
         - ansible-test-network-integration-vyos-network_cli-python36-stable210
-            
         - ansible-test-network-integration-vyos-network_cli-python36-stable29
         - build-ansible-collection:
             required-projects:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -733,10 +733,16 @@
     check:
       jobs: &ansible-collections-vyos-vyos-jobs
         - ansible-test-network-integration-vyos-local-python36
+            vars:
+              ansible_test_collections: true
             voting: false
         - ansible-test-network-integration-vyos-local-python36-stable210
+            vars:
+              ansible_test_collections: true
             voting: false
         - ansible-test-network-integration-vyos-local-python36-stable29
+            vars:
+              ansible_test_collections: true
             voting: false
         - ansible-test-network-integration-vyos-network_cli-python36
         - ansible-test-network-integration-vyos-network_cli-python36-stable210
@@ -746,7 +752,10 @@
               - name: github.com/ansible-collections/ansible.netcommon
     gate:
       queue: integrated
-      jobs: *ansible-collections-vyos-vyos-jobs
+      jobs:
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-collections/ansible.netcommon
 
 - project-template:
     name: ansible-collections-frr-frr-units

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -747,6 +747,9 @@
     gate:
       queue: integrated
       jobs:
+        - ansible-test-network-integration-vyos-network_cli-python36
+        - ansible-test-network-integration-vyos-network_cli-python36-stable210
+        - ansible-test-network-integration-vyos-network_cli-python36-stable29
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -733,10 +733,14 @@
     check:
       jobs: &ansible-collections-vyos-vyos-jobs
         - ansible-test-network-integration-vyos-local-python36
+            voting: false
         - ansible-test-network-integration-vyos-local-python36-stable210
+            voting: false
         - ansible-test-network-integration-vyos-local-python36-stable29
+            voting: false
         - ansible-test-network-integration-vyos-network_cli-python36
         - ansible-test-network-integration-vyos-network_cli-python36-stable210
+            
         - ansible-test-network-integration-vyos-network_cli-python36-stable29
         - build-ansible-collection:
             required-projects:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -731,18 +731,12 @@
 - project-template:
     name: ansible-collections-vyos-vyos
     check:
-      jobs: &ansible-collections-vyos-vyos-jobs
-        - ansible-test-network-integration-vyos-local-python36
-            vars:
-              ansible_test_collections: true
+      jobs:
+        - ansible-test-network-integration-vyos-local-python36:
             voting: false
-        - ansible-test-network-integration-vyos-local-python36-stable210
-            vars:
-              ansible_test_collections: true
+        - ansible-test-network-integration-vyos-local-python36-stable210:
             voting: false
-        - ansible-test-network-integration-vyos-local-python36-stable29
-            vars:
-              ansible_test_collections: true
+        - ansible-test-network-integration-vyos-local-python36-stable29:
             voting: false
         - ansible-test-network-integration-vyos-network_cli-python36
         - ansible-test-network-integration-vyos-network_cli-python36-stable210


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gosriniv@redhat.com>

In order for the PRs to be merged, skipping the authentication timeout failure ([log](https://ab8a58227e448d88606f-57e6674ae8bc147ba9d7addb2c750527.ssl.cf5.rackcdn.com/73/7296efa5ec32410e8ad971c1f7f6bc5ac5e9db37/check/ansible-test-network-integration-vyos-local-python36/93627ae/controller/ansible-debug.html#l18454)) , marked the vyos jobs as non voting, temporarily.