### PR TITLE
vmware_rest: add a missing required-projects

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -261,6 +261,8 @@
     pre-run:
       - playbooks/ansible-cloud/vcenter-appliance/pre.yaml
     run: playbooks/ansible-cloud/vcenter-appliance/run.yaml
+    required-projects:
+      - name: github.com/ansible/ansible-zuul-jobs
     # NOTE: we set ansible_network_os with some generic
     # value to pass the ansible-network playbooks
     host-vars:


### PR DESCRIPTION
`ansible-cloud-vmware-rest-appliance` needs
`github.com/ansible/ansible-zuul-jobs`.