### PR TITLE
vcenter: defines ansible_network_os on esxi2

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -155,6 +155,15 @@
     vars:
       ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_2esxi/
+    # NOTE: we set ansible_network_os with some generic
+    # value to pass the ansible-network playbooks
+    host-vars:
+      vcenter:
+        ansible_network_os: vmware_rest
+      esxi1:
+        ansible_network_os: vmware_rest
+      esxi2:
+        ansible_network_os: vmware_rest
 
 # vcenter 7.0.0
 - job:


### PR DESCRIPTION
Jobs now inherite from `ansible-network-appliance-base`, instead
of `ansible-cloud-appliance-base`. As a result we need to have
`ansible_network_os` defined everywhere.