### PR TITLE
Revert "Marked vyos jobs as nonvoting"

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -501,13 +501,10 @@
 - project-template:
     name: ansible-collections-vyos-vyos
     check:
-      jobs:
-        - ansible-test-network-integration-vyos-local-python36:
-            voting: false
-        - ansible-test-network-integration-vyos-local-python36-stable210:
-            voting: false
-        - ansible-test-network-integration-vyos-local-python36-stable29:
-            voting: false
+      jobs: &ansible-collections-vyos-vyos-jobs
+        - ansible-test-network-integration-vyos-local-python36
+        - ansible-test-network-integration-vyos-local-python36-stable210
+        - ansible-test-network-integration-vyos-local-python36-stable29
         - ansible-test-network-integration-vyos-network_cli-python36
         - ansible-test-network-integration-vyos-network_cli-python36-stable210
         - ansible-test-network-integration-vyos-network_cli-python36-stable29
@@ -516,13 +513,7 @@
               - name: github.com/ansible-collections/ansible.netcommon
     gate:
       queue: integrated
-      jobs:
-        - ansible-test-network-integration-vyos-network_cli-python36
-        - ansible-test-network-integration-vyos-network_cli-python36-stable210
-        - ansible-test-network-integration-vyos-network_cli-python36-stable29
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/ansible.netcommon
+      jobs: *ansible-collections-vyos-vyos-jobs
 
 - project-template:
     name: ansible-collections-frr-frr-units


### PR DESCRIPTION
Reverts ansible/ansible-zuul-jobs#616

This [PR](https://github.com/ansible/ansible/pull/71057) fixes the vyos authentication time out issue for local connection. Hence removing **voting: false** for the vyos jobs.