### PR TITLE
vmware_rest needs cloud.common for functional tests

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -298,7 +298,6 @@
       - playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
-      - name: github.com/ansible-collections/vmware
       - name: github.com/ansible-collections/vmware_rest
     vars:
       ansible_collections_repo: github.com/ansible-collections/vmware_rest

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -353,9 +353,9 @@
         - ansible-test-cloud-integration-vmware-rest-python36
         - build-ansible-collection:
             required-projects:
+              - name: github.com/ansible-collections/cloud.common
               - name: github.com/ansible-collections/vmware
         - ansible-tox-linters
-        - build-ansible-collection
         - ansible-test-sanity-vmware
     gate:
       jobs:


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/cloud.common/pull/1

cloud.common now embed the modules that were previously in `ansible_module.turbo`.