### PR TITLE
enable sanity for vmware_rest

### DIFF
--- a/roles/ansible-test/defaults/main.yaml
+++ b/roles/ansible-test/defaults/main.yaml
@@ -19,3 +19,4 @@ ansible_test_collection_dir: ~/.ansible/collections/ansible_collections
 ansible_test_enable_ara: true
 ansible_test_split_in: 1
 ansible_test_do_number: 1
+ansible_test_sanity_skiptests: []

--- a/roles/ansible-test/tasks/init_test_options.yaml
+++ b/roles/ansible-test/tasks/init_test_options.yaml
@@ -29,7 +29,14 @@
     ansible_test_options: "--coverage"
   when: ansible_test_test_command == 'units'
 
-- name: Enable coverage commands for unit tests
-  set_fact:
-    ansible_test_options: "--requirements"
-  when: ansible_test_test_command == 'sanity'
+
+- when: ansible_test_test_command == 'sanity'
+  block:
+    - name: Enable coverage commands for unit tests
+      set_fact:
+        ansible_test_options: "--requirements"
+
+    - name: Set --skip-test
+      set_fact:
+        ansible_test_options: "{{ ansible_test_options }} --skip-test {{ ansible_test_sanity_skiptests|join(' --skip-test ') }} "
+      when: ansible_test_sanity_skiptests|length > 0

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -310,3 +310,17 @@
     parent: ansible-test-cloud-integration-vmware-rest
     vars:
       ansible_test_python: 3.6
+
+- job:
+    name: ansible-test-sanity-vmware-rest
+    parent: ansible-test-sanity-base
+    required-projects:
+      - name: github.com/ansible-collections/vmware_rest
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.10
+    vars:
+      ansible_collections_repo: github.com/ansible-collections/vmware_rest
+      ansible_test_sanity_skiptests:
+        - future-import-boilerplate
+        - metaclass-boilerplate
+      ansible_test_enable_ara: false

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -362,7 +362,7 @@
               - name: github.com/ansible-collections/cloud.common
               - name: github.com/ansible-collections/vmware
         - ansible-tox-linters
-        - ansible-test-sanity-vmware
+        - ansible-test-sanity-vmware-rest
     gate:
       jobs:
         - ansible-test-cloud-integration-vmware-rest-python36
@@ -372,7 +372,7 @@
               - name: github.com/ansible-collections/vmware
         - ansible-tox-linters
         - build-ansible-collection
-        - ansible-test-sanity-vmware
+        - ansible-test-sanity-vmware-rest
 
 - project-template:
     name: ansible-collections-community-asa


### PR DESCRIPTION
`vmware_rest` is py36+ and so we can skip the py2 tests. I use an `ansible-test` parameter for that: `ansible_test_sanity_skiptests`