### PR TITLE
vmware-rest needs cloud.common for gating too

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -362,6 +362,7 @@
         - ansible-test-cloud-integration-vmware-rest-python36
         - build-ansible-collection:
             required-projects:
+              - name: github.com/ansible-collections/cloud.common
               - name: github.com/ansible-collections/vmware
         - ansible-tox-linters
         - build-ansible-collection


### PR DESCRIPTION
Ensure `build-ansible-collection` also prepare the `vmware.cloud` artifact.