### PR TITLE
ansible-test: add molecule test

### DIFF
--- a/roles/ansible-test/molecule/default/converge.yml
+++ b/roles/ansible-test/molecule/default/converge.yml
@@ -1,0 +1,14 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - include_tasks: ../default/init_env.yml
+    - name: Include ansible-test
+      include_role:
+        name: ansible-test
+      vars:
+        ansible_test_collections: true
+        ansible_test_test_command: sanity
+        ansible_test_collection_namespace: foo
+        ansible_test_collection_name: bar
+        ansible_test_executable: /root/fake-ansible-test

--- a/roles/ansible-test/molecule/default/init_env.yml
+++ b/roles/ansible-test/molecule/default/init_env.yml
@@ -1,0 +1,23 @@
+---
+- name: Prepare the venv
+  command: python3 -m venv /root/venv
+  args:
+    creates: /root/venv
+- name: Create the directory of the fake collection
+  file:
+    path: "{{ item.path }}"
+    state: "{{ item.state }}"
+  with_items:
+    - path: /root/.ansible/collections/ansible_collections/foo/bar
+      state: directory
+    - path: /root/.ansible/collections/ansible_collections/foo/bar/requirements.txt
+      state: touch
+    - path: /root/.ansible/collections/ansible_collections/foo/bar/test-requirements.txt
+      state: touch
+- name: Prepare the fake-ansible-test command
+  copy:
+    dest: /root/fake-ansible-test
+    content: |
+      #!/bin/bash
+      echo $* > /tmp/ansible-test.log
+    mode: 755

--- a/roles/ansible-test/molecule/default/molecule.yml
+++ b/roles/ansible-test/molecule/default/molecule.yml
@@ -1,0 +1,21 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: podman
+platforms:
+  - name: instance
+    image: docker.io/pycontribs/centos:8
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - destroy
+    - create
+    - converge
+    - lint
+    - verify
+    - destroy

--- a/roles/ansible-test/molecule/default/verify.yml
+++ b/roles/ansible-test/molecule/default/verify.yml
@@ -1,0 +1,18 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+  - ini_file:
+      path: ~/.ansible/collections/ansible_collections/foo/bar/tests/integration/sanity.cfg
+      section: defaults
+      option: log_path
+      value: ~/ansible-debug.txt
+    register: _result
+  - assert:
+      that: not(_result is changed)
+  - name: check ansible-test output
+    command: cat /tmp/ansible-test.log
+    register: _result
+  - debug: var=_result
+  - assert:
+      that: _result.stdout == "sanity --requirements --python default -vvvv"

--- a/roles/ansible-test/molecule/sanity-full/converge.yml
+++ b/roles/ansible-test/molecule/sanity-full/converge.yml
@@ -1,0 +1,17 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - include_tasks: ../default/init_env.yml
+    - name: Include ansible-test
+      include_role:
+        name: ansible-test
+      vars:
+        ansible_test_collections: true
+        ansible_test_test_command: sanity
+        ansible_test_collection_namespace: foo
+        ansible_test_collection_name: bar
+        ansible_test_executable: /root/fake-ansible-test
+        ansible_test_sanity_skiptests:
+          - skip_1
+          - skip_2

--- a/roles/ansible-test/molecule/sanity-full/molecule.yml
+++ b/roles/ansible-test/molecule/sanity-full/molecule.yml
@@ -1,0 +1,21 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: podman
+platforms:
+  - name: instance
+    image: docker.io/pycontribs/centos:8
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - destroy
+    - create
+    - converge
+    - lint
+    - verify
+    - destroy

--- a/roles/ansible-test/molecule/sanity-full/verify.yml
+++ b/roles/ansible-test/molecule/sanity-full/verify.yml
@@ -1,0 +1,18 @@
+---
+- name: Verify
+  hosts: all
+  tasks:
+  - ini_file:
+      path: ~/.ansible/collections/ansible_collections/foo/bar/tests/integration/sanity.cfg
+      section: defaults
+      option: log_path
+      value: ~/ansible-debug.txt
+    register: _result
+  - assert:
+      that: not(_result is changed)
+  - name: check ansible-test output
+    command: cat /tmp/ansible-test.log
+    register: _result
+  - debug: var=_result
+  - assert:
+      that: _result.stdout == "sanity --requirements --skip-test skip_1 --skip-test skip_2 --python default -vvvv"

--- a/roles/ansible-test/tasks/enable_ara.yaml
+++ b/roles/ansible-test/tasks/enable_ara.yaml
@@ -9,17 +9,3 @@
     section: defaults
     option: callback_plugins
     value: "{{ _ara_callback_location.stdout }}"
-
-- name: Enable persistent connection logging
-  ini_file:
-    path: "{{ _test_cfg_location }}"
-    section: persistent_connection
-    option: log_messages
-    value: true
-
-- name: Set ansible log path
-  ini_file:
-    path: "{{ _test_cfg_location }}"
-    section: defaults
-    option: log_path
-    value: ~/ansible-debug.txt

--- a/roles/ansible-test/tasks/init_single_mode.yaml
+++ b/roles/ansible-test/tasks/init_single_mode.yaml
@@ -3,4 +3,7 @@
   set_fact:
     _test_location: "{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
     _test_cfg_location: "{{ zuul.projects['github.com/ansible/ansible'].src_dir }}/test/integration/{{ ansible_test_test_command }}.cfg"
-  when: ansible_test_test_command != 'units'
+  when:
+    # TODO: we should not access zuul data structure from a role.
+    - zuul is defined
+    - ansible_test_test_command != 'units'

--- a/roles/ansible-test/tasks/main.yaml
+++ b/roles/ansible-test/tasks/main.yaml
@@ -16,6 +16,20 @@
   import_tasks: init_collection.yaml
   when: ansible_test_collections
 
+- name: Enable persistent connection logging
+  ini_file:
+    path: "{{ _test_cfg_location }}"
+    section: persistent_connection
+    option: log_messages
+    value: true
+
+- name: Set ansible log path
+  ini_file:
+    path: "{{ _test_cfg_location }}"
+    section: defaults
+    option: log_path
+    value: ~/ansible-debug.txt
+
 - name: Enable ara
   import_tasks: enable_ara.yaml
   when: ansible_test_enable_ara


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/627

Add two molecule scenarios for ansible-test role. Both are based on podman and target the `sanity` sub-command.