### PR TITLE
bump controller-python37 to fedora-32

### DIFF
--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -20,14 +20,14 @@
 - nodeset:
     name: fedora-latest-1vcpu
     nodes:
-      - name: fedora-31
-        label: fedora-31-1vcpu
+      - name: fedora-32
+        label: fedora-32-1vcpu
 
 - nodeset:
     name: fedora-latest-4vcpu
     nodes:
-      - name: fedora-31
-        label: fedora-31-4vcpu
+      - name: fedora-32
+        label: fedora-32-4vcpu
 
 - nodeset:
     name: ubuntu-bionic-1vcpu
@@ -879,12 +879,12 @@
 - nodeset:
     name: controller-python37
     nodes:
-      - name: fedora-31
-        label: fedora-31-1vcpu
+      - name: fedora-32
+        label: fedora-32-1vcpu
     groups:
       - name: controller
         nodes:
-          - fedora-31
+          - fedora-32
 
 - nodeset:
     name: controller-python38


### PR DESCRIPTION
Bump the following nodesets to Fedora 32:

- fedora-latest-1vcpu
- fedora-latest-4vcpu
- controller-python37

This to address a kernel/systemd issue:

See: https://github.com/ansible/ansible/issues/71528
See: https://bugzilla.redhat.com/show_bug.cgi?id=1853736