### PR TITLE
unbound is already installed

### DIFF
--- a/roles/configure-unbound/tasks/main.yaml
+++ b/roles/configure-unbound/tasks/main.yaml
@@ -11,22 +11,6 @@
     - "{{ ansible_os_family }}.yaml"
     - "default.yaml"
 
-- name: Ensure /etc/resolv.conf works before pulling packages
-  become: true
-  template:
-    dest: /etc/resolv.conf
-    owner: root
-    group: root
-    mode: 0644
-    src: resolv.conf.j2
-
-- name: Install the packages
-  become: true
-  package:
-    name: "{{ unbound_packages }}"
-    update_cache: true
-    state: present
-
 - name: Ensure Unbound conf.d directory exists
   become: true
   file:

--- a/roles/configure-unbound/vars/Debian.yaml
+++ b/roles/configure-unbound/vars/Debian.yaml
@@ -1,4 +1,2 @@
 ---
 unbound_confd: /etc/unbound/unbound.conf.d
-unbound_packages:
-    - unbound

--- a/roles/configure-unbound/vars/default.yaml
+++ b/roles/configure-unbound/vars/default.yaml
@@ -1,4 +1,2 @@
 ---
 unbound_confd: /etc/unbound/conf.d
-unbound_packages:
-    - unbound


### PR DESCRIPTION
The `unbound` package should always be present before we start the
`configure-unbound` role:

- OpenStack nodes: unbound is part of the default images
- AWS: cloud-init pulls it during the first boot