### PR TITLE
Also install bindep files from projects

### DIFF
--- a/playbooks/ansible-network-appliance-base/pre.yaml
+++ b/playbooks/ansible-network-appliance-base/pre.yaml
@@ -1,7 +1,7 @@
 ---
 - hosts: controller
   tasks:
-    - name: Install binary dependencies
+    - name: Install binary dependencies from ansible/ansible-zuul-jobs
       include_role:
         name: bindep
       vars:

--- a/playbooks/ansible-test-network-integration-base/pre.yaml
+++ b/playbooks/ansible-test-network-integration-base/pre.yaml
@@ -1,6 +1,12 @@
 ---
 - hosts: controller
   tasks:
+    - name: Install binary dependencies
+      include_role:
+        name: bindep
+      vars:
+        bindep_dir: "{{ zuul.project.src_dir }}"
+
     - set_fact:
         _network_appliance_groups: "{{ groups.keys()|select('match', '^(appliance|openvswitch)')|list }}"
 


### PR DESCRIPTION
This also allows each project to included needed build dependencies for
testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>