### PR TITLE
Removing ara installation

### DIFF
--- a/playbooks/ansible-test-base/pre.yaml
+++ b/playbooks/ansible-test-base/pre.yaml
@@ -28,9 +28,10 @@
       shell: ~/venv/bin/pip install selinux "setuptools<50.0.0"
       when: ansible_os_family == "RedHat"
 
-    - name: Install ara into virtualenv
-      shell: ~/venv/bin/pip install "ara<1.0.0"
-      when: "'integration' in ansible_test_command"
+    # ara is installing ansible-2.10, when 2.9 is needed. Commenting to temporarily fix the issue.
+    # - name: Install ara into virtualenv
+    #   shell: ~/venv/bin/pip install "ara<1.0.0"
+    #   when: "'integration' in ansible_test_command"
 
     - name: Install ansible into virtualenv
       # TODO(pabelanger): Remove ANSIBLE_SKIP_CONFLICT_CHECK in the future.

--- a/roles/ansible-test/tasks/main.yaml
+++ b/roles/ansible-test/tasks/main.yaml
@@ -30,9 +30,9 @@
     option: log_path
     value: ~/ansible-debug.txt
 
-- name: Enable ara
-  import_tasks: enable_ara.yaml
-  when: ansible_test_enable_ara
+# - name: Enable ara
+#  import_tasks: enable_ara.yaml
+#  when: ansible_test_enable_ara
 
 - name: Set the targets
   set_fact:


### PR DESCRIPTION
Ara installs ansible2.10, though we want ansible 2.9 . Removing installation of ara, for now, to unblock CI.