### PR TITLE
Marked yang-iosxr job as non voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -693,6 +693,7 @@
         - ansible-test-network-integration-community-yang-iosxr-netconf-python36:
             vars:
               ansible_test_collections: true
+            voting: false
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/community.yang


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gosriniv@redhat.com>

The 'socket close' issue is a known failure in iosxr jobs. Hence marking this job as non voting.