### PR TITLE
Enable expose ansible_test_network_cli_ssh_type setting

### DIFF
--- a/playbooks/ansible-network-appliance-base/templates/ansible.cfg.j2
+++ b/playbooks/ansible-network-appliance-base/templates/ansible.cfg.j2
@@ -5,3 +5,4 @@
 command_timeout = 60
 connect_timeout = 60
 connect_retry_timeout = 60
+ssh_type = {{ ansible_test_network_cli_ssh_type }}

--- a/playbooks/ansible-test-network-integration-base/post.yaml
+++ b/playbooks/ansible-test-network-integration-base/post.yaml
@@ -6,5 +6,8 @@
         path: "{{ ansible_user_dir }}/zuul-output/logs/controller/"
         state: directory
 
-    - name: Copy appliance inventory file
+    - name: Copy controller ansible.cfg file
+      shell: "cp {{ ansible_user_dir }}/.ansible.cfg {{ ansible_user_dir }}/zuul-output/logs/controller/ansible.cfg"
+
+    - name: Copy controller inventory file
       shell: "cp {{ ansible_user_dir }}/inventory {{ ansible_user_dir }}/zuul-output/logs/controller/inventory"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -165,6 +165,8 @@
     name: ansible-network-appliance-base
     pre-run: playbooks/ansible-network-appliance-base/pre.yaml
     post-run: playbooks/ansible-network-appliance-base/post.yaml
+    vars:
+      ansible_test_network_cli_ssh_type: paramiko
 
 - job:
     name: ansible-network-asa-appliance


### PR DESCRIPTION
This will allow us to create libssh jobs for ansible network
collections.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>