### PR TITLE
Enable FIPs mode on CentOS-8

### DIFF
--- a/playbooks/ansible-test-base/run.yaml
+++ b/playbooks/ansible-test-base/run.yaml
@@ -13,6 +13,31 @@
             file: '{{ _fetch.dest }}'
             name: galaxy_info
 
+    - name: Enable FIPS mode
+      become: true
+      shell: fips-mode-setup --enable
+
+    - name: Update /etc/default/grub
+      become: true
+      shell: sed -ie 's|GRUB_CMDLINE_LINUX_DEFAULT=\"\(.*\)\"|GRUB_CMDLINE_LINUX_DEFAULT=\"\1 fips=1\"|' /etc/default/grub
+
+    - name: Rebuild grub.cfg file
+      become: true
+      shell: grub2-mkconfig -o /boot/grub2/grub.cfg
+
+    - name: Reboot server for FIPS mode
+      become: true
+      reboot:
+        reboot_timeout: 1800
+
+    - name: Run start-zuul-console role
+      include_role:
+        name: start-zuul-console
+
+    - name: Ensure FIPS mode is enabled
+      become: true
+      shell: fips-mode-setup --check
+
     - name: Run ansible-test
       import_role:
         name: ansible-test


### PR DESCRIPTION
In some cases, we want to test FIPS mode for ansible content.

Depends-On: https://github.com/ansible/ansible/pull/72411
Signed-off-by: Paul Belanger <pabelanger@redhat.com>