### PR TITLE
Keep ios fail fast only for gate job and remove for check job

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -212,7 +212,6 @@
 - project-template:
     name: ansible-collections-cisco-ios-units
     check:
-      fail-fast: true
       jobs: &ansible-collections-cisco-ios-units-jobs
         - ansible-changelog-fragment
         - ansible-test-sanity-ios


### PR DESCRIPTION
Keep ios fail fast only for gate job and remove for check job