### PR TITLE
sanity: default val for ansible_collections_repo

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -66,11 +66,9 @@
 # sanity
 - job:
     name: ansible-test-sanity-vmware
-    parent: ansible-test-sanity-base-29
+    parent: ansible-test-sanity-base-210
     required-projects:
       - name: github.com/ansible-collections/community.vmware
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
     vars:
       ansible_collections_repo: github.com/ansible-collections/community.vmware
 
@@ -313,14 +311,11 @@
 
 - job:
     name: ansible-test-sanity-vmware-rest
-    parent: ansible-test-sanity-base-29
+    parent: ansible-test-sanity-base-210
     required-projects:
       - name: github.com/ansible-collections/vmware.vmware_rest
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
     vars:
       ansible_collections_repo: github.com/ansible-collections/vmware.vmware_rest
       ansible_test_sanity_skiptests:
         - future-import-boilerplate
         - metaclass-boilerplate
-      ansible_test_enable_ara: false

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -315,7 +315,6 @@
     required-projects:
       - name: github.com/ansible-collections/vmware.vmware_rest
     vars:
-      ansible_collections_repo: github.com/ansible-collections/vmware.vmware_rest
       ansible_test_sanity_skiptests:
         - future-import-boilerplate
         - metaclass-boilerplate

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -135,6 +135,7 @@
         override-checkout: stable-2.10
     timeout: 3600
     vars:
+      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
       ansible_test_collections: true
       ansible_test_command: sanity
       ansible_test_enable_ara: false


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/672

Iniialize `ansible_collections_repo` with `zuul.project.canonical_name`.
This should actually suites all the cases.