### PR TITLE
vmware_rest_code_generator: update modules before testing

### DIFF
--- a/playbooks/ansible-cloud/build-ansible-collection-vmware-rest/pre.yaml
+++ b/playbooks/ansible-cloud/build-ansible-collection-vmware-rest/pre.yaml
@@ -1,0 +1,11 @@
+---
+- hosts: all
+  tasks:
+    - name: Refresh the vmware_rest modules
+      include_role:
+        name: tox
+      vars:
+        tox_envlist: refresh_modules,refresh_examples
+        tox_install_siblings: true
+        zuul_work_dir: "{{ zuul.projects['github.com/ansible-collections/vmware.vmware_rest'].src_dir }}"
+      when: refresh_vmware_rest

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -276,7 +276,7 @@
     parent: ansible-cloud-vmware-rest-appliance
     abstract: true
     dependencies:
-      - name: build-ansible-collection
+      - name: build-ansible-collection-vmware-rest
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-test-network-integration-base/pre.yaml
@@ -299,3 +299,10 @@
     parent: ansible-test-cloud-integration-vmware-rest
     vars:
       ansible_test_python: 3.6
+- job:
+    name: build-ansible-collection-vmware-rest
+    parent: build-ansible-collection
+    pre-run:
+      - playbooks/ansible-cloud/build-ansible-collection-vmware-rest/pre.yaml
+    vars:
+      refresh_vmware_rest: false

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -391,7 +391,7 @@
         - ansible-test-cloud-integration-vmware-rest-python36:
             required-projects:
               - name: github.com/ansible-collections/vmware.vmware_rest
-        - build-ansible-collection:
+        - build-ansible-collection-vmware-rest:
             required-projects:
               - name: github.com/ansible-collections/community.vmware
               - name: github.com/ansible-collections/vmware.vmware_rest
@@ -437,7 +437,7 @@
     check:
       jobs:
         - ansible-test-cloud-integration-vmware-rest-python36
-        - build-ansible-collection:
+        - build-ansible-collection-vmware-rest:
             required-projects:
               - name: github.com/ansible-collections/cloud.common
               - name: github.com/ansible-collections/community.vmware
@@ -446,7 +446,7 @@
     gate:
       jobs:
         - ansible-test-cloud-integration-vmware-rest-python36
-        - build-ansible-collection:
+        - build-ansible-collection-vmware-rest:
             required-projects:
               - name: github.com/ansible-collections/cloud.common
               - name: github.com/ansible-collections/community.vmware
@@ -459,17 +459,23 @@
     check:
       jobs:
         - ansible-test-cloud-integration-vmware-rest-python36
-        - build-ansible-collection:
+        - build-ansible-collection-vmware-rest:
             required-projects:
               - name: github.com/ansible-collections/cloud.common
               - name: github.com/ansible-collections/community.vmware
+              - name: github.com/ansible-collections/vmware.vmware_rest
+            vars:
+              refresh_vmware_rest: true
     gate:
       jobs:
         - ansible-test-cloud-integration-vmware-rest-python36
-        - build-ansible-collection:
+        - build-ansible-collection-vmware-rest:
             required-projects:
               - name: github.com/ansible-collections/cloud.common
               - name: github.com/ansible-collections/community.vmware
+              - name: github.com/ansible-collections/vmware.vmware_rest
+            vars:
+              refresh_vmware_rest: true
 
 - project-template:
     name: ansible-collections-community-asa


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/685

Refresh the modules before the test. This way we validate the new
`vmware_rest_code_generator` changeset won't break the modules
generation.