### PR TITLE
Set nxos integration jobs non-voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -154,57 +154,41 @@
         - ansible-test-network-integration-nxos-cli-python36-scenario01:
             vars:
               ansible_test_collections: true
+            voting: false
         - ansible-test-network-integration-nxos-cli-python36-scenario02:
             vars:
               ansible_test_collections: true
+            voting: false
         - ansible-test-network-integration-nxos-cli-python36-scenario03:
             vars:
               ansible_test_collections: true
+            voting: false
         - ansible-test-network-integration-nxos-cli-python36-scenario04:
             vars:
               ansible_test_collections: true
+            voting: false
         - ansible-test-network-integration-nxos-cli-python36-stable29-scenario01:
             vars:
               ansible_test_collections: true
+            voting: false
         - ansible-test-network-integration-nxos-cli-python36-stable29-scenario02:
             vars:
               ansible_test_collections: true
+            voting: false
         - ansible-test-network-integration-nxos-cli-python36-stable29-scenario03:
             vars:
               ansible_test_collections: true
+            voting: false
         - ansible-test-network-integration-nxos-cli-python36-stable29-scenario04:
             vars:
               ansible_test_collections: true
+            voting: false
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
     gate:
       queue: integrated
       jobs:
-        - ansible-test-network-integration-nxos-cli-python36-scenario01:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-scenario02:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-scenario03:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-scenario04:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29-scenario01:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29-scenario02:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29-scenario03:
-            vars:
-              ansible_test_collections: true
-        - ansible-test-network-integration-nxos-cli-python36-stable29-scenario04:
-            vars:
-              ansible_test_collections: true
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon


### PR DESCRIPTION
We do this, since we only have 1 provider to run nxos jobs. This helps
avoid node_failure from blocking code from merging.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>