### PR TITLE
Stop running python27 jobs on main

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -80,10 +80,8 @@
     name: ansible-collections-arista-eos
     check:
       jobs: &ansible-collections-arista-eos-jobs
-        - ansible-test-network-integration-eos-httpapi-python27
         - ansible-test-network-integration-eos-httpapi-python27-stable210
         - ansible-test-network-integration-eos-httpapi-python27-stable29
-        - ansible-test-network-integration-eos-network_cli-python27
         - ansible-test-network-integration-eos-network_cli-python27-stable210-scenario01
         - ansible-test-network-integration-eos-network_cli-python27-stable210-scenario02
         - ansible-test-network-integration-eos-network_cli-python27-stable29
@@ -120,7 +118,6 @@
     name: ansible-collections-cisco-asa
     check:
       jobs: &ansible-collections-cisco-asa-jobs
-        - ansible-test-network-integration-asa-python27
         - ansible-test-network-integration-asa-python27-stable210
         - ansible-test-network-integration-asa-python27-stable29
         - ansible-test-network-integration-asa-python36
@@ -213,10 +210,8 @@
     name: ansible-collections-cisco-ios
     check:
       jobs: &ansible-collections-cisco-ios-jobs
-        - ansible-test-network-integration-ios-local-python27
         - ansible-test-network-integration-ios-local-python27-stable210
         - ansible-test-network-integration-ios-local-python27-stable29
-        - ansible-test-network-integration-ios-network_cli-python27
         - ansible-test-network-integration-ios-network_cli-python27-stable210
         - ansible-test-network-integration-ios-network_cli-python27-stable29
         - ansible-test-network-integration-ios-local-python36
@@ -251,23 +246,11 @@
     name: ansible-collections-cisco-iosxr
     check:
       jobs:
-        - ansible-test-network-integration-iosxr-netconf-python27:
-            vars:
-              ansible_test_integration_targets: "iosxr_.*"
-            voting: false
         - ansible-test-network-integration-iosxr-netconf-python27-stable210:
             vars:
               ansible_test_integration_targets: "iosxr_.*"
             voting: false
         - ansible-test-network-integration-iosxr-netconf-python27-stable29:
-            vars:
-              ansible_test_integration_targets: "iosxr_.*"
-            voting: false
-        - ansible-test-network-integration-iosxr-network_cli-python27-scenario01:
-            vars:
-              ansible_test_integration_targets: "iosxr_.*"
-            voting: false
-        - ansible-test-network-integration-iosxr-network_cli-python27-scenario02:
             vars:
               ansible_test_integration_targets: "iosxr_.*"
             voting: false
@@ -496,19 +479,11 @@
     name: ansible-collections-juniper-junos
     check:
       jobs: &ansible-collections-juniper-junos-jobs
-        - ansible-test-network-integration-junos-vsrx-netconf-python27:
-            vars:
-              ansible_test_collections: true
-              ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-netconf-python27-stable210:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-netconf-python27-stable29:
-            vars:
-              ansible_test_collections: true
-              ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-network_cli-python27:
             vars:
               ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
@@ -586,9 +561,6 @@
     name: ansible-collections-openvswitch-openvswitch
     check:
       jobs: &ansible-collections-openvswitch-openvswitch-jobs
-        - ansible-test-network-integration-openvswitch-python27:
-            vars:
-              ansible_test_collections: true
         - ansible-test-network-integration-openvswitch-python27-stable210
         - ansible-test-network-integration-openvswitch-python27-stable29
         - ansible-test-network-integration-openvswitch-python36:
@@ -622,10 +594,8 @@
     name: ansible-collections-vyos-vyos
     check:
       jobs: &ansible-collections-vyos-vyos-jobs
-        - ansible-test-network-integration-vyos-local-python27
         - ansible-test-network-integration-vyos-local-python27-stable210
         - ansible-test-network-integration-vyos-local-python27-stable29
-        - ansible-test-network-integration-vyos-network_cli-python27
         - ansible-test-network-integration-vyos-network_cli-python27-stable210
         - ansible-test-network-integration-vyos-network_cli-python27-stable29
         - ansible-test-network-integration-vyos-local-python36


### PR DESCRIPTION
This is because ansible/ansible will no longer be testing it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>