### PR TITLE
Rework download-artifact logic

### DIFF
--- a/playbooks/ansible-test-base/pre.yaml
+++ b/playbooks/ansible-test-base/pre.yaml
@@ -39,7 +39,12 @@
         ANSIBLE_SKIP_CONFLICT_CHECK: 1
       shell: "~/venv/bin/pip install {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
 
+    # NOTE(pabelanger): For integration jobs, install collections after our
+    # appliance is configured. This stops pre-merged code from failing
+    # to configure appliances.
     - name: Fetch and install the artifacts
       import_role:
         name: deploy-artifacts
-      when: ansible_test_collections | default(False)
+      when:
+        - ansible_test_collections | default(False)
+        - "'integration' not in ansible_test_command"

--- a/playbooks/ansible-test-network-integration-base/pre.yaml
+++ b/playbooks/ansible-test-network-integration-base/pre.yaml
@@ -36,3 +36,9 @@
         ansible_test_inventory_os: "{{ _network_os }}"
         ansible_test_inventory_dest: ~/inventory
         vmware_ci_set_passwords_secret_dir: '{{ zuul.executor.work_root }}'
+
+    - name: Fetch and install the artifacts
+      import_role:
+        name: deploy-artifacts
+      when:
+        - ansible_test_collections | default(False)


### PR DESCRIPTION
For network integration jobs, we want to install collections after our
appliances are properly configured.  This allows us to use release
version of ansible to setup test environments, then pre-merge ansible
for test cases.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>