### PR TITLE
security: adjust the label of the controller nodes

### DIFF
--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -895,7 +895,7 @@
     name: QRadarCE-7.3.1-python38
     nodes:
       - name: ubuntu-bionic
-        label: ubuntu-bionic-1vcpu-aws
+        label: ubuntu-bionic-1vcpu-without-nested
       - name: QRadarCE-7.3.1
         label: QRadarCE-7.3.1
     groups:
@@ -914,7 +914,7 @@
     name: SplunkEnterprise-SES-8.0.0-python38
     nodes:
       - name: ubuntu-bionic
-        label: ubuntu-bionic-1vcpu-aws
+        label: ubuntu-bionic-1vcpu-without-nested
       - name: SplunkEnterprise-SES-8.0.0
         label: SplunkEnterprise-SES-8.0.0
     groups:


### PR DESCRIPTION
The controller label name has changed:
- from `ubuntu-bionic-1vcpu-aws`
- to `ubuntu-bionic-1vcpu-without-nested`

See: https://github.com/ansible-network/windmill-config/pull/743