### PR TITLE
Disable selinux on python3.7 jobs

### DIFF
--- a/playbooks/ansible-test-base/pre.yaml
+++ b/playbooks/ansible-test-base/pre.yaml
@@ -17,6 +17,26 @@
         - ansible_os_family == "Debian"
         - ansible_test_python is version('3.8', '==')
 
+    # NOTE(pabelanger): fedora-32 jobs, currently python3.7 only have
+    # selinux bindings for python3.8. For now, disable selinux.
+    - name: Disable selinux for python3.7 jobs
+      block:
+        - name: Disable selinux
+          become: true
+          selinux:
+            state: disabled
+
+        - name: Reboot node
+          become: true
+          reboot:
+
+        - name: Run start-zuul-console role
+          include_role:
+            name: start-zuul-console
+      when:
+        - ansible_os_family == "RedHat"
+        - ansible_test_python is version('3.7', '==')
+
     - name: Setup base virtualenv_options
       set_fact:
         _virtualenv_options: "--python python{{ ansible_test_python }}"


### PR DESCRIPTION
This is becaue fedora-32 only support selinux for python3.8.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>