### PR TITLE
Create ansible-buildset-registry job

### DIFF
--- a/playbooks/buildset-registry/post.yaml
+++ b/playbooks/buildset-registry/post.yaml
@@ -1,0 +1,3 @@
+---
+- hosts: all
+  tasks: []

--- a/playbooks/buildset-registry/pre.yaml
+++ b/playbooks/buildset-registry/pre.yaml
@@ -1,0 +1,15 @@
+---
+- hosts: all
+  tasks:
+    - name: Install docker
+      include_role:
+        name: ensure-docker
+
+    - name: Run buildset registry (if not already running)
+      when: buildset_registry is not defined
+      include_role:
+        name: run-buildset-registry
+
+    - name: Use buildset registry
+      include_role:
+        name: use-buildset-registry

--- a/playbooks/buildset-registry/run.yaml
+++ b/playbooks/buildset-registry/run.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  tasks:
+    - name: Pause the job
+      zuul_return:
+        data:
+          zuul:
+            pause: true

--- a/playbooks/container-image/run.yaml
+++ b/playbooks/container-image/run.yaml
@@ -1,0 +1,12 @@
+---
+- hosts: all
+  tasks:
+    - name: Setup build-docker-image role
+      include_role:
+        name: build-docker-image
+
+    - name: Pause the job
+      zuul_return:
+        data:
+          zuul:
+            pause: true

--- a/zuul.d/jobs-container-images.yaml
+++ b/zuul.d/jobs-container-images.yaml
@@ -1,0 +1,32 @@
+---
+- job:
+    name: ansible-buildset-registry
+    description: |
+      Starts a buildset registry which interacts with the intermediate
+      CI registry to share speculative container images between
+      projects.
+
+      Configure any jobs which require the use of a buildset registry
+      to depend on this job using the "dependencies" job attribute.
+
+      This job will pause after starting the registry so that it is
+      available to any jobs which depend on it.  Once all such jobs
+      are complete, this job will finish.
+    pre-run: playbooks/buildset-registry/pre.yaml
+    run: playbooks/buildset-registry/run.yaml
+    post-run: playbooks/buildset-registry/post.yaml
+    requires: container-image
+    nodeset: ubuntu-bionic-1vcpu
+
+- job:
+    name: ansible-build-container-image
+    description: |
+      This is a parent for an image build job which expects a
+      buildset registry to be running and pulls images from the
+      intermediate registry into it.  It mostly exists so that
+      the intermediate registry secret need not be supplied to the
+      image build playbook.
+    parent: ansible-buildset-registry
+    run: playbooks/container-image/run.yaml
+    provides: container-image
+    nodeset: ubuntu-bionic-1vcpu


### PR DESCRIPTION
Jobs that need to share docker images between jobs, will use this job.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>