### PR TITLE
Refactor ansible-buildset-registry to only be docker

### DIFF
--- a/playbooks/buildset-registry/pre.yaml
+++ b/playbooks/buildset-registry/pre.yaml
@@ -1,16 +1,14 @@
 ---
 - hosts: all
   tasks:
-    - name: Install docker
+    - name: Install container runtime
       include_role:
-        name: ensure-docker
+        name: "ensure-{{ (container_command == 'docker') | ternary('docker', 'podman') }}"
 
     - name: Run buildset registry (if not already running)
       when: buildset_registry is not defined
       include_role:
         name: run-buildset-registry
-      vars:
-        container_command: docker
 
     - name: Use buildset registry
       include_role:

--- a/playbooks/container-image/run.yaml
+++ b/playbooks/container-image/run.yaml
@@ -1,12 +1,6 @@
 ---
 - hosts: all
   tasks:
-    - name: Setup build-docker-image role
+    - name: Setup build-container-image role
       include_role:
-        name: build-docker-image
-
-    - name: Pause the job
-      zuul_return:
-        data:
-          zuul:
-            pause: true
+        name: build-container-image

--- a/zuul.d/ansible-runner-jobs.yaml
+++ b/zuul.d/ansible-runner-jobs.yaml
@@ -7,7 +7,7 @@
     timeout: 2700
     provides: ansible-runner-container-image
     vars:
-      docker_images:
+      container_images:
         - context: .
           repository: quay.io/ansible/ansible-runner
           tags:

--- a/zuul.d/jobs-container-images.yaml
+++ b/zuul.d/jobs-container-images.yaml
@@ -17,6 +17,8 @@
     post-run: playbooks/buildset-registry/post.yaml
     requires: container-image
     nodeset: ubuntu-bionic-1vcpu
+    vars:
+      container_command: docker
 
 - job:
     name: ansible-build-container-image
@@ -28,5 +30,10 @@
       image build playbook.
     parent: ansible-buildset-registry
     run: playbooks/container-image/run.yaml
+    dependencies:
+      - name: ansible-buildset-registry
+        soft: true
     provides: container-image
     nodeset: ubuntu-bionic-1vcpu
+    vars:
+      container_command: podman

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1384,9 +1384,11 @@
     name: ansible-runner-container-image-jobs
     check:
       jobs:
+        - ansible-buildset-registry
         - ansible-runner-build-container-image
     gate:
       jobs:
+        - ansible-buildset-registry
         - ansible-runner-build-container-image
 
 - project-template:


### PR DESCRIPTION
Until we fix podman ipv6 issues, lets see if we can run the registry as
docker but all jobs as podman.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>