### PR TITLE
Create ansible-runner-upload-container-image job

### DIFF
--- a/zuul.d/ansible-runner-jobs.yaml
+++ b/zuul.d/ansible-runner-jobs.yaml
@@ -6,7 +6,7 @@
     pre-run: playbooks/ansible-runner-build-container-image/pre.yaml
     timeout: 2700
     provides: ansible-runner-container-image
-    vars:
+    vars: &ansible_runner_image_vars
       container_images:
         - context: .
           registry: quay.io
@@ -15,3 +15,12 @@
             # If zuul.tag is defined: [ '3', '3.19', '3.19.0' ].  Only works for 3-component tags.
             # Otherwise: ['latest']
             &imagetag "{{ zuul.tag is defined | ternary([zuul.get('tag', '').split('.')[0], '.'.join(zuul.get('tag', '').split('.')[:2]), zuul.get('tag', '')], ['devel']) }}"
+
+- job:
+    name: ansible-runner-upload-container-image
+    parent: ansible-upload-container-image
+    description: Build ansible-runner container image and upload to quay.io
+    pre-run: playbooks/ansible-runner-build-container-image/pre.yaml
+    timeout: 2700
+    provides: ansible-runner-container-image
+    vars: *ansible_runner_image_vars

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1390,6 +1390,9 @@
       jobs:
         - ansible-buildset-registry
         - ansible-runner-build-container-image
+    post:
+      jobs:
+        - ansible-runner-upload-container-image
 
 - project-template:
     name: noop-jobs


### PR DESCRIPTION
This runs in the post pipeline and publishes ansible-runner to quay.io.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>