### PR TITLE
vmware: start the vcenter7 transition

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -190,6 +190,16 @@
     vars:
       ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_2esxi/
+    # NOTE: we set ansible_network_os with some generic
+    # value to pass the ansible-network playbooks
+    host-vars:
+      vcenter:
+        ansible_python_interpreter: python
+        ansible_network_os: vmware_rest
+      esxi1:
+        ansible_network_os: vmware_rest
+      esxi2:
+        ansible_network_os: vmware_rest
 
 # stable29
 - job:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -443,7 +443,10 @@
         - ansible-test-cloud-integration-vcenter_1esxi_with_nested-python36
         - ansible-test-cloud-integration-vcenter_1esxi_without_nested-python36_1_of_2
         - ansible-test-cloud-integration-vcenter_1esxi_without_nested-python36_2_of_2
-        - ansible-test-cloud-integration-vcenter_2esxi_without_nested-python36
+        - ansible-test-cloud-integration-vcenter7_only-python36
+        - ansible-test-cloud-integration-vcenter7_1esxi_with_nested-python36
+        - ansible-test-cloud-integration-vcenter7_1esxi_without_nested-python36
+        - ansible-test-cloud-integration-vcenter7_2esxi_without_nested-python36
         - ansible-tox-linters
         - build-ansible-collection
         - ansible-test-sanity-base-210


### PR DESCRIPTION
The ultimate goal is to phase out vcenter6.7 in the CI, and use vcenter7 instead.