### PR TITLE
Create shared queue for Execution Environments

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -9,6 +9,13 @@
       queue: integrated
 
 - project-template:
+    name: execution-environments-queue
+    description: |
+      Group projects together into a shared change queue for Execution Environments.
+    gate:
+      queue: execution-environments
+
+- project-template:
     name: ansible-python-jobs
     description: |
       A common set of python jobs to run.


### PR DESCRIPTION
Allow projects related to creating execution environments share a change
queue. This will help ensure we don't break things between those
projects.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>