### PR TITLE
Revert "turn the vSphere7 jobs non-voting"

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -450,14 +450,10 @@
         - ansible-test-cloud-integration-vcenter_1esxi_with_nested-python36
         - ansible-test-cloud-integration-vcenter_1esxi_without_nested-python36_1_of_2
         - ansible-test-cloud-integration-vcenter_1esxi_without_nested-python36_2_of_2
-        - ansible-test-cloud-integration-vcenter7_only-python36:
-            voting: false
-        - ansible-test-cloud-integration-vcenter7_1esxi_with_nested-python36:
-            voting: false
-        - ansible-test-cloud-integration-vcenter7_1esxi_without_nested-python36:
-            voting: false
-        - ansible-test-cloud-integration-vcenter7_2esxi_without_nested-python36:
-            voting: false
+        - ansible-test-cloud-integration-vcenter7_only-python36
+        - ansible-test-cloud-integration-vcenter7_1esxi_with_nested-python36
+        - ansible-test-cloud-integration-vcenter7_1esxi_without_nested-python36
+        - ansible-test-cloud-integration-vcenter7_2esxi_without_nested-python36
         - ansible-tox-linters
         - build-ansible-collection
         - ansible-test-sanity-base-210


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.vmware/pull/568
Depends-On: https://github.com/ansible-collections/community.vmware/pull/577

This reverts commit 1cfdd502ff585f6cecd1a677037ecbf58021bc3c. The
vSphere7 CI is now green.