### PR TITLE
Create publish-to-pypi-poetry project-template

### DIFF
--- a/playbooks/ansible-build-python-tarball/run.yaml
+++ b/playbooks/ansible-build-python-tarball/run.yaml
@@ -1,6 +1,26 @@
 ---
 - hosts: all
   tasks:
+    # NOTE(pabelanger): This is kinda hacky, but poetry doesn't have a good
+    # way to automate this.
+    - name: Update poetry version
+      block:
+        - name: Setup tox role
+          include_role:
+            name: tox
+          vars:
+            tox_envlist: generate_poetry_version
+            tox_extra_args: -vv --notest
+            tox_install_siblings: false
+            zuul_work_dir: "{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"
+
+        - name: Generate version number for poetry
+          args:
+            chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
+            executable: /bin/bash
+          shell: "source {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/generate_poetry_version/bin/activate; generate-poetry-version"
+      when: release_poetry_project is defined
+
     - name: Run build-python-release role
       include_role:
         name: build-python-release

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -83,9 +83,17 @@
     pre-run: playbooks/ansible-build-python-tarball/pre.yaml
     run: playbooks/ansible-build-python-tarball/run.yaml
     post-run: playbooks/ansible-build-python-tarball/post.yaml
+    required-projects:
+      - github.com/ansible-network/releases
     nodeset: centos-8-1vcpu
     vars:
       release_python: python3
+
+- job:
+    name: ansible-build-python-tarball-poetry
+    parent: ansible-build-python-tarball
+    vars:
+      release_poetry_project: true
 
 - job:
     name: ansible-galaxy-importer

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1542,6 +1542,23 @@
         - release-ansible-python
 
 - project-template:
+    name: publish-to-pypi-poetry
+    description: |
+      Publish a Python package (using poetry) to PyPI.
+    check:
+      jobs:
+        - ansible-build-python-tarball-poetry
+    gate:
+      jobs:
+        - ansible-build-python-tarball-poetry
+    pre-release:
+      jobs:
+        - release-ansible-python-poetry
+    release:
+      jobs:
+        - release-ansible-python-poetry
+
+- project-template:
     name: system-required
     description: |
       Jobs that *every* project in Ansible should have by default.


### PR DESCRIPTION
This will allow poetry projects to use pbr to build / release tarballs
to pypi.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>