### PR TITLE
Update vyos.vyos to use EEs for testing

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -653,12 +653,6 @@
     check:
       jobs: &ansible-collections-vyos-vyos-units-jobs
         - ansible-changelog-fragment
-        - ansible-test-sanity-vyos
-        - ansible-test-units-vyos-python27
-        - ansible-test-units-vyos-python35
-        - ansible-test-units-vyos-python36
-        - ansible-test-units-vyos-python37
-        - ansible-test-units-vyos-python38
     gate:
       queue: integrated
       jobs: *ansible-collections-vyos-vyos-units-jobs


### PR DESCRIPTION
This is our first collection to be updated to use the network-ee for all
testing for unit / sanity tests.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>