### PR TITLE
Update vyos.vyos to use EEs for testing

### DIFF
--- a/playbooks/ansible-ee-tests-base/run.yaml
+++ b/playbooks/ansible-ee-tests-base/run.yaml
@@ -1,0 +1,15 @@
+---
+- hosts: all
+  tasks:
+    - name: Setup collection_namespace
+      set_fact:
+        collection_namespace: "{{ zuul.project.short_name.split('.')[0] }}"
+      when: collection_namespace is not defined
+
+    - name: Setup collection_name
+      set_fact:
+        collection_name: "{{ zuul.project.short_name.split('.')[1] }}"
+      when: collection_name is not defined
+
+    - name: Run test container
+      shell: "podman run -w /usr/share/ansible/collections/ansible_collections/{{ collection_namespace }}/{{ collection_name }} {{ container_image_name }}-{{ container_image_test }}-tests:{{ container_image_version }}"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -2424,3 +2424,12 @@
     vars:
       tox_envlist: ansible-base
     nodeset: fedora-latest-1vcpu
+
+- job:
+    name: ansible-ee-tests-base
+    parent: ansible-buildset-registry-consumer
+    abstract: true
+    run: playbooks/ansible-ee-tests-base/run.yaml
+    vars:
+      container_command: podman
+    nodeset: ubuntu-bionic-1vcpu

--- a/zuul.d/network-jobs.yaml
+++ b/zuul.d/network-jobs.yaml
@@ -1,0 +1,57 @@
+---
+- job:
+    name: network-ee-tests-base
+    parent: ansible-ee-tests-base
+    abstract: true
+    vars:
+      container_image_name: quay.io/ansible/network-ee
+
+- job:
+    name: network-ee-tests
+    parent: network-ee-tests-base
+    abstract: true
+    dependencies:
+      - network-ee-build-container-image
+    vars:
+      container_image_version: latest
+
+- job:
+    name: network-ee-sanity-tests
+    parent: network-ee-tests
+    requires:
+      - network-ee-sanity-tests-container-image
+    vars:
+      container_image_test: sanity
+
+- job:
+    name: network-ee-unit-tests
+    parent: network-ee-tests
+    requires:
+      - network-ee-unit-tests-container-image
+    vars:
+      container_image_test: unit
+
+- job:
+    name: network-ee-tests-stable-2.9
+    parent: network-ee-tests-base
+    abstract: true
+    dependencies:
+      - network-ee-build-container-image-stable-2.9
+    vars:
+      container_image_version: stable-2.9
+
+- job:
+    name: network-ee-sanity-tests-stable-2.9
+    parent: network-ee-tests-stable-2.9
+    requires:
+      - network-ee-sanity-tests-stable-2.9-container-image
+    vars:
+      container_image_test: sanity
+
+- job:
+    name: network-ee-unit-tests-stable-2.9
+    parent: network-ee-tests-stable-2.9
+    requires:
+      - network-ee-unit-tests-stable-2.9-container-image
+    vars:
+      container_image_test: unit

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1407,6 +1407,23 @@
               - ^test/integration/targets/prepare_vyos_tests/.*
 
 - project-template:
+    name: network-ee-tests
+    description: |
+      This is a set of jobs, run from within a network execution environment
+      to validate network collections are working properly.
+    check:
+      jobs: &network-ee-test-jobs
+        - ansible-buildset-registry
+        - network-ee-build-container-image
+        - network-ee-sanity-tests
+        - network-ee-unit-tests
+        - network-ee-build-container-image-stable-2.9
+        - network-ee-sanity-tests-stable-2.9
+        - network-ee-unit-tests-stable-2.9
+    gate:
+      jobs: *network-ee-test-jobs
+
+- project-template:
     name: noop-jobs
     description: |
       This template runs no jobs, it is needed if a project does not use


### PR DESCRIPTION
This is our first collection to be updated to use the network-ee for all
testing for unit / sanity tests.

Depends-On: https://github.com/ansible/network-ee/pull/26
Signed-off-by: Paul Belanger <pabelanger@redhat.com>