### PR TITLE
Cap alembic to keep ara happy

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 ara<1.0.0
+alembic<1.5.0
 jxmlease
 ncclient
 yamllint


### PR DESCRIPTION
SQLAlchemy 1.3.0 or greater is required it seems.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>