### PR TITLE
Drop network-ee 2.9 tests for now

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1414,8 +1414,6 @@
       jobs: &network-ee-test-jobs
         - network-ee-sanity-tests
         - network-ee-unit-tests
-        - network-ee-sanity-tests-stable-2.9
-        - network-ee-unit-tests-stable-2.9
     gate:
       jobs: *network-ee-test-jobs
 


### PR DESCRIPTION
Until we fix python38 issues, remove so we can merge code.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>