### PR TITLE
Revert "Drop network-ee 2.9 tests for now"

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1414,6 +1414,8 @@
       jobs: &network-ee-test-jobs
         - network-ee-sanity-tests
         - network-ee-unit-tests
+        - network-ee-sanity-tests-stable-2.9
+        - network-ee-unit-tests-stable-2.9
     gate:
       jobs: *network-ee-test-jobs
 


### PR DESCRIPTION
This reverts commit 18067d69dee5df5a85041828e2a8d7ebe0350e89.

Depends-On: https://github.com/ansible/ansible/pull/73355