### PR TITLE
Ansible EE test jobs always create images

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -2432,4 +2432,5 @@
     run: playbooks/ansible-ee-tests-base/run.yaml
     vars:
       container_command: podman
+      use_intermediate_registry: false
     nodeset: ubuntu-bionic-2vcpu


### PR DESCRIPTION
As such, there isn't a need to copy images from the intermediate
registry. It leads to the images that are build, being overwritten.

Depends-On: https://github.com/ansible/project-config/pull/725
Signed-off-by: Paul Belanger <pabelanger@redhat.com>