### PR TITLE
Don't require network-ee test images

### DIFF
--- a/zuul.d/network-jobs.yaml
+++ b/zuul.d/network-jobs.yaml
@@ -18,16 +18,12 @@
 - job:
     name: network-ee-sanity-tests
     parent: network-ee-tests
-    requires:
-      - network-ee-sanity-tests-container-image
     vars:
       container_image_test: sanity
 
 - job:
     name: network-ee-unit-tests
     parent: network-ee-tests
-    requires:
-      - network-ee-unit-tests-container-image
     vars:
       container_image_test: unit
 
@@ -43,15 +39,11 @@
 - job:
     name: network-ee-sanity-tests-stable-2.9
     parent: network-ee-tests-stable-2.9
-    requires:
-      - network-ee-sanity-tests-stable-2.9-container-image
     vars:
       container_image_test: sanity
 
 - job:
     name: network-ee-unit-tests-stable-2.9
     parent: network-ee-tests-stable-2.9
-    requires:
-      - network-ee-unit-tests-stable-2.9-container-image
     vars:
       container_image_test: unit


### PR DESCRIPTION
Given we always rebuild these images, there is no real reason to provide
them for other jobs to use.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>