### PR TITLE
vcenter7: split jobs

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -183,6 +183,20 @@
     # 5h
     timeout: 10800
 
+
+- job:
+    name: ansible-test-cloud-integration-vcenter7_1esxi_without_nested-python36_1_of_2
+    parent: ansible-test-cloud-integration-vcenter7_1esxi_without_nested-python36
+    vars:
+      ansible_test_do_number: 1
+
+- job:
+    name: ansible-test-cloud-integration-vcenter7_1esxi_without_nested-python36_2_of_2
+    parent: ansible-test-cloud-integration-vcenter7_1esxi_without_nested-python36
+    vars:
+      ansible_test_do_number: 2
+
+
 - job:
     name: ansible-test-cloud-integration-vcenter7_2esxi_without_nested-python36
     parent: ansible-test-cloud-integration-vcenter

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -446,7 +446,8 @@
         - ansible-test-cloud-integration-govcsim-python36_3_of_3
         - ansible-test-cloud-integration-vcenter7_only-python36
         - ansible-test-cloud-integration-vcenter7_1esxi_with_nested-python36
-        - ansible-test-cloud-integration-vcenter7_1esxi_without_nested-python36
+        - ansible-test-cloud-integration-vcenter7_1esxi_without_nested-python36_1_of_2
+        - ansible-test-cloud-integration-vcenter7_1esxi_without_nested-python36_2_of_2
         - ansible-test-cloud-integration-vcenter7_2esxi_without_nested-python36
         - ansible-tox-linters
         - build-ansible-collection


### PR DESCRIPTION
Split the ansible-test-cloud-integration-vcenter7_1esxi_without_nested-python36
job in two. This will speed up the execution time and avoid the 3h
timeout.