### PR TITLE
vcenter7_1esxi split the list in two

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -180,6 +180,7 @@
     vars:
       ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_1esxi/
+      ansible_test_split_in: 2
     # 5h
     timeout: 10800
 


### PR DESCRIPTION
Set `ansible_test_split_in` to actually split the job list.