### PR TITLE
Remove python38 cisco.ios jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -834,14 +834,6 @@
       ansible_collections_repo: github.com/ansible-collections/cisco.ios
 
 - job:
-    name: ansible-test-units-ios-python38
-    parent: ansible-test-units-base-python38
-    required-projects:
-      - name: github.com/ansible-collections/cisco.ios
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/cisco.ios
-
-- job:
     name: ansible-test-network-integration-ios-network_cli
     parent: ansible-test-network-integration-ios
     abstract: true

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -254,12 +254,10 @@
     check:
       jobs: &ansible-collections-cisco-ios-units-jobs
         - ansible-changelog-fragment
-        - ansible-test-sanity-ios
         - ansible-test-units-ios-python27
         - ansible-test-units-ios-python35
         - ansible-test-units-ios-python36
         - ansible-test-units-ios-python37
-        - ansible-test-units-ios-python38
     gate:
       queue: integrated
       fail-fast: true


### PR DESCRIPTION
We now use network-ee jobs to do this.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>