### PR TITLE
Forcing galaxy installation

### DIFF
--- a/roles/deploy-artifacts/tasks/main.yaml
+++ b/roles/deploy-artifacts/tasks/main.yaml
@@ -20,4 +20,4 @@
   args:
     chdir: "{{ ansible_user_dir }}/downloads"
     executable: /bin/bash
-  shell: "source {{ deploy_artifacts_venv_path }}/bin/activate; ansible-galaxy collection install {{ __collections }}"
+  shell: "source {{ deploy_artifacts_venv_path }}/bin/activate; ansible-galaxy collection install {{ __collections }} --force"


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gosriniv@redhat.com>

The devel jobs are failing with the following error.

https://f5e076b49b0dd061f642-97e6cb0e04fa5e79735f25a0e6bdd526.ssl.cf5.rackcdn.com/141/800af76ed72fcffa85b9becf0c2dd4c8678b2e00/check/ansible-test-network-integration-eos-httpapi-python36/55774db/job-output.html#l1189

So added --force to force the galaxy installation.