### PR TITLE
Remove python38 ansible.utils jobs

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -1385,14 +1385,6 @@
       ansible_collections_repo: github.com/ansible-collections/ansible.utils
 
 - job:
-    name: ansible-test-units-ansible-utils-python38
-    parent: ansible-test-units-base-python38
-    required-projects:
-      - name: github.com/ansible-collections/ansible.utils
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/ansible.utils
-
-- job:
     name: ansible-test-network-integration-junos-vsrx
     abstract: true
     dependencies:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -129,13 +129,11 @@
     check:
       jobs: &ansile-collections-ansible-utils-units-jobs
         - ansible-changelog-fragment
-        - ansible-test-sanity-ansible-utils
         - ansible-test-sanity-base-210
         - ansible-test-units-ansible-utils-python27
         - ansible-test-units-ansible-utils-python35
         - ansible-test-units-ansible-utils-python36
         - ansible-test-units-ansible-utils-python37
-        - ansible-test-units-ansible-utils-python38
     gate:
       queue: integrated
       jobs: *ansile-collections-ansible-utils-units-jobs


### PR DESCRIPTION
This will now be covered via our network-ee jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>