### PR TITLE
Revert "Add ansible-test-sanity-base-210 to ansible.utils"

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -129,7 +129,6 @@
     check:
       jobs: &ansile-collections-ansible-utils-units-jobs
         - ansible-changelog-fragment
-        - ansible-test-sanity-base-210
         - ansible-test-units-ansible-utils-python27
         - ansible-test-units-ansible-utils-python35
         - ansible-test-units-ansible-utils-python36


### PR DESCRIPTION
This reverts commit a16e9e995e93337a2ea22ad0863333d5aa66bcff.