### PR TITLE
Add depends-on support for ansible/pylibssh

### DIFF
--- a/playbooks/ansible-test-base/pre.yaml
+++ b/playbooks/ansible-test-base/pre.yaml
@@ -59,6 +59,10 @@
         ANSIBLE_SKIP_CONFLICT_CHECK: 1
       shell: "~/venv/bin/pip install {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
 
+    - name: Install ansible-pylibssh into virtualenv
+      shell: "~/venv/bin/pip install {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/pylibssh'].src_dir }}"
+      when: "'integration' in ansible_test_command"
+
     # NOTE(pabelanger): For integration jobs, install collections after our
     # appliance is configured. This stops pre-merged code from failing
     # to configure appliances.

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -318,6 +318,7 @@
       - playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible/pylibssh
       - name: github.com/ansible-collections/cisco.asa
     timeout: 9000
     vars:
@@ -454,6 +455,7 @@
     parent: ansible-test-integration-base
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible/pylibssh
       - name: github.com/ansible-collections/ansible.utils
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.utils
@@ -474,6 +476,7 @@
       - playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible/pylibssh
       - name: github.com/ansible-collections/arista.eos
     timeout: 10800
     vars:
@@ -785,6 +788,7 @@
       - playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible/pylibssh
       - name: github.com/ansible-collections/cisco.ios
     timeout: 10800
     vars:
@@ -964,6 +968,7 @@
       - playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible/pylibssh
       - name: github.com/ansible-collections/cisco.iosxr
     timeout: 10800
     vars:
@@ -1400,6 +1405,7 @@
       - playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible/pylibssh
       - name: github.com/ansible-collections/junipernetworks.junos
     timeout: 10800
     vars:
@@ -1631,6 +1637,7 @@
       - playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible/pylibssh
       - name: github.com/ansible-collections/cisco.nxos
     timeout: 10800
     vars:
@@ -1777,6 +1784,7 @@
       - playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible/pylibssh
       - name: github.com/ansible-collections/openvswitch.openvswitch
     timeout: 3600
     vars:
@@ -1993,6 +2001,7 @@
       - playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+      - name: github.com/ansible/pylibssh
       - name: github.com/ansible-collections/vyos.vyos
     timeout: 10800
     vars:


### PR DESCRIPTION
This will bootstrap ansible/pylibssh from source, so we can do pre-merge
testing on the project.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>