### PR TITLE
Allow for project to not have test-requirements.txt

### DIFF
--- a/roles/ansible-test/tasks/init_collection.yaml
+++ b/roles/ansible-test/tasks/init_collection.yaml
@@ -4,8 +4,20 @@
     _test_location: "{{ ansible_test_collection_dir }}/{{ ansible_test_collection_namespace }}/{{ ansible_test_collection_name }}"
     _test_cfg_location: "{{ ansible_test_collection_dir }}/{{ ansible_test_collection_namespace }}/{{ ansible_test_collection_name }}/tests/integration/{{ ansible_test_test_command }}.cfg"
 
-- name: Install python requirements
+- name: Check for test-requirements.txt
+  stat:
+    path: "{{ _test_location }}/test-requirements.txt"
+  register: p
+
+- name: Install python requirements.txt
+  shell: "{{ ansible_test_venv_path }}/bin/pip install -r {{ _test_location }}/requirements.txt"
+  when:
+    - not p.stat.exists
+
+- name: Install python requirements.txt / test-requirements.txt
   shell: "{{ ansible_test_venv_path }}/bin/pip install -r {{ _test_location }}/requirements.txt -r {{ _test_location }}/test-requirements.txt"
+  when:
+    - p.stat.exists
 
 - name: Copy potential cloud provider configuration for ansible-test in the collection
   shell: "cp -v {{ ansible_test_ansible_path }}/test/integration/cloud-config-*.ini {{ _test_location }}/tests/integration/"


### PR DESCRIPTION
Some collections might not have test-requirement.txt files.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>