### PR TITLE
Refactor ansible_test_python flag

### DIFF
--- a/roles/ansible-test/tasks/init_test_options.yaml
+++ b/roles/ansible-test/tasks/init_test_options.yaml
@@ -40,3 +40,8 @@
       set_fact:
         ansible_test_options: "{{ ansible_test_options }} --skip-test {{ ansible_test_sanity_skiptests|join(' --skip-test ') }} "
       when: ansible_test_sanity_skiptests|length > 0
+
+- name: Setup --python option
+  set_fact:
+    ansible_test_options: "{{ ansible_test_options }} --python {{ ansible_test_python }}"
+  when: ansible_test_python

--- a/roles/ansible-test/tasks/main.yaml
+++ b/roles/ansible-test/tasks/main.yaml
@@ -54,4 +54,4 @@
     chdir: "{{ _test_location }}"
     executable: /bin/bash
   environment: "{{ ansible_test_environment | default({}) }}"
-  shell: "source {{ ansible_test_venv_path }}/bin/activate; {{ ansible_test_executable }} {{ ansible_test_test_command }} {{ ansible_test_options }} --python {{ ansible_test_python }} -vvvv {{ _integration_targets }}"
+  shell: "source {{ ansible_test_venv_path }}/bin/activate; {{ ansible_test_executable }} {{ ansible_test_test_command }} {{ ansible_test_options }} -vvvv {{ _integration_targets }}"


### PR DESCRIPTION
To prepare for docker, we don't have to setup ansible_test_python.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>