### PR TITLE
Only run ansible-runner-tox-ansible27 on stable branch

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -2445,10 +2445,10 @@
 
 - job:
     name: ansible-runner-tox-ansible27
-    parent: tox
+    parent: ansible-tox-py27
+    branches: '^stable/1.*'
     vars:
       tox_envlist: ansible27
-    nodeset: fedora-latest-1vcpu
 
 - job:
     name: ansible-runner-tox-ansible28


### PR DESCRIPTION
There is no need to run this on devel.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>