### PR TITLE
Refactor ansible-test-sanity jobs

### DIFF
--- a/zuul.d/ansible-community-jobs.yaml
+++ b/zuul.d/ansible-community-jobs.yaml
@@ -1,9 +1,0 @@
----
-- job:
-    name: ansible-test-sanity-community-asa
-    parent: ansible-test-sanity-base-29
-    required-projects:
-      - name: github.com/ansible-collections/community.asa
-    timeout: 3600
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/community.asa

--- a/zuul.d/ansible-security-jobs.yaml
+++ b/zuul.d/ansible-security-jobs.yaml
@@ -43,15 +43,6 @@
     vars:
       ansible_test_python: 3.6
 
-- job:
-    name: ansible-test-sanity-splunk
-    parent: ansible-test-sanity-base-29
-    required-projects:
-      - name: github.com/ansible-collections/splunk.es
-    timeout: 3600
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/splunk.es
-
 # QRadar
 - job:
     name: ansible-security-qradar-appliance
@@ -96,15 +87,6 @@
     vars:
       ansible_test_python: 3.8
 
-- job:
-    name: ansible-test-sanity-qradar
-    parent: ansible-test-sanity-base-29
-    required-projects:
-      - name: github.com/ansible-collections/ibm.qradar
-    timeout: 3600
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/ibm.qradar
-
 # TrendMicro
 - job:
     name: ansible-security-trendmicro-deepsec-appliance
@@ -142,12 +124,3 @@
       ansible_test_command: network-integration
       ansible_test_integration_targets: ""
       ansible_test_collections: true
-
-- job:
-    name: ansible-test-sanity-trendmicro-deepsec
-    parent: ansible-test-sanity-base-29
-    required-projects:
-      - name: github.com/ansible-collections/trendmicro.deepsec
-    timeout: 3600
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/trendmicro.deepsec

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -170,69 +170,6 @@
       ansible_test_python: 3.6
 
 - job:
-    name: ansible-test-sanity-base-29
-    parent: unittests
-    nodeset: controller-python36
-    dependencies:
-      - name: build-ansible-collection
-        soft: true
-    pre-run:
-      - playbooks/ansible-test-base/pre.yaml
-    run: playbooks/ansible-test-base/run.yaml
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    timeout: 3600
-    vars:
-      ansible_test_collections: true
-      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
-      ansible_test_command: sanity
-      ansible_test_enable_ara: false
-      ansible_test_python: 3.6
-
-- job:
-    name: ansible-test-sanity-base-210
-    parent: unittests
-    nodeset: controller-python36
-    dependencies:
-      - name: build-ansible-collection
-        soft: true
-    pre-run:
-      - playbooks/ansible-test-base/pre.yaml
-    run: playbooks/ansible-test-base/run.yaml
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-    timeout: 3600
-    vars:
-      ansible_test_collections: true
-      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
-      ansible_test_command: sanity
-      ansible_test_enable_ara: false
-      ansible_test_python: 3.6
-
-- job:
-    name: ansible-test-sanity-base-devel
-    parent: unittests
-    nodeset: controller-python36
-    abstract: true
-    dependencies:
-      - name: build-ansible-collection
-        soft: true
-    pre-run:
-      - playbooks/ansible-test-base/pre.yaml
-    run: playbooks/ansible-test-base/run.yaml
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: devel
-    timeout: 3600
-    vars:
-      ansible_test_collections: true
-      ansible_test_command: sanity
-      ansible_test_enable_ara: false
-      ansible_test_python: 3.6
-
-- job:
     name: ansible-network-appliance-base
     pre-run: playbooks/ansible-network-appliance-base/pre.yaml
     post-run: playbooks/ansible-network-appliance-base/post.yaml
@@ -389,15 +326,6 @@
       ansible_test_integration_targets: "asa_.*"
 
 - job:
-    name: ansible-test-sanity-asa
-    parent: ansible-test-sanity-base-29
-    required-projects:
-      - name: github.com/ansible-collections/cisco.asa
-    timeout: 3600
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/cisco.asa
-
-- job:
     name: ansible-test-units-asa-python27
     parent: ansible-test-units-base-python27
     required-projects:
@@ -542,15 +470,6 @@
       ansible_collections_repo: github.com/ansible-collections/arista.eos
       ansible_test_command: network-integration
       ansible_test_integration_targets: "eos_.*"
-
-- job:
-    name: ansible-test-sanity-eos
-    parent: ansible-test-sanity-base-29
-    required-projects:
-      - name: github.com/ansible-collections/arista.eos
-    timeout: 3600
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/arista.eos
 
 - job:
     name: ansible-test-units-eos-python27
@@ -855,15 +774,6 @@
       ansible_test_integration_targets: "ios_.*"
 
 - job:
-    name: ansible-test-sanity-ios
-    parent: ansible-test-sanity-base-29
-    required-projects:
-      - name: github.com/ansible-collections/cisco.ios
-    timeout: 3600
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/cisco.ios
-
-- job:
     name: ansible-test-units-ios-python27
     parent: ansible-test-units-base-python27
     required-projects:
@@ -1032,15 +942,6 @@
       ansible_collections_repo: github.com/ansible-collections/cisco.iosxr
       ansible_test_command: network-integration
       ansible_test_integration_targets: "iosxr_.* netconf_.*"
-
-- job:
-    name: ansible-test-sanity-iosxr
-    parent: ansible-test-sanity-base-29
-    required-projects:
-      - name: github.com/ansible-collections/cisco.iosxr
-    timeout: 3600
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/cisco.iosxr
 
 - job:
     name: ansible-test-units-iosxr-python27
@@ -1320,15 +1221,6 @@
       ansible_test_python: 3.8
 
 - job:
-    name: ansible-test-sanity-netcommon
-    parent: ansible-test-sanity-base-29
-    required-projects:
-      - name: github.com/ansible-collections/ansible.netcommon
-    timeout: 3600
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
-
-- job:
     name: ansible-test-units-netcommon-python27
     parent: ansible-test-units-base-python27
     required-projects:
@@ -1388,15 +1280,6 @@
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
-    name: ansible-test-sanity-posix
-    parent: ansible-test-sanity-base-29
-    required-projects:
-      - name: github.com/ansible-collections/ansible.posix
-    timeout: 3600
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/ansible.posix
-
-- job:
     name: ansible-test-units-posix
     parent: ansible-test-units-base
     required-projects:
@@ -1404,15 +1287,6 @@
     timeout: 3600
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.posix
-
-- job:
-    name: ansible-test-sanity-ansible-utils
-    parent: ansible-test-sanity-base-29
-    required-projects:
-      - name: github.com/ansible-collections/ansible.utils
-    timeout: 3600
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/ansible.utils
 
 - job:
     name: ansible-test-units-ansible-utils-python27
@@ -1468,15 +1342,6 @@
       ansible_collections_repo: github.com/ansible-collections/junipernetworks.junos
       ansible_test_command: network-integration
       ansible_test_integration_targets: "junos_.* netconf_.*"
-
-- job:
-    name: ansible-test-sanity-junos
-    parent: ansible-test-sanity-base-29
-    required-projects:
-      - name: github.com/ansible-collections/junipernetworks.junos
-    timeout: 3600
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/junipernetworks.junos
 
 - job:
     name: ansible-test-units-junos-python27
@@ -1701,15 +1566,6 @@
       ansible_test_integration_targets: "nxos_.*"
 
 - job:
-    name: ansible-test-sanity-nxos
-    parent: ansible-test-sanity-base-29
-    required-projects:
-      - name: github.com/ansible-collections/cisco.nxos
-    timeout: 3600
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/cisco.nxos
-
-- job:
     name: ansible-test-units-nxos
     parent: ansible-test-units-base
     required-projects:
@@ -1912,15 +1768,6 @@
       ansible_test_python: 3.8
 
 - job:
-    name: ansible-test-sanity-openvswitch
-    parent: ansible-test-sanity-base-29
-    required-projects:
-      - name: github.com/ansible-collections/openvswitch.openvswitch
-    timeout: 3600
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/openvswitch.openvswitch
-
-- job:
     name: ansible-test-units-openvswitch-python27
     parent: ansible-test-units-base-python27
     required-projects:
@@ -2061,24 +1908,6 @@
       ansible_collections_repo: github.com/ansible-collections/vyos.vyos
       ansible_test_command: network-integration
       ansible_test_integration_targets: "vyos_.*"
-
-- job:
-    name: ansible-test-sanity-symantec-epm
-    parent: ansible-test-sanity-base-29
-    required-projects:
-      - name: github.com/ansible-collections/symantec.epm
-    timeout: 3600
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/symantec.epm
-
-- job:
-    name: ansible-test-sanity-vyos
-    parent: ansible-test-sanity-base-29
-    required-projects:
-      - name: github.com/ansible-collections/vyos.vyos
-    timeout: 3600
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/vyos.vyos
 
 - job:
     name: ansible-test-units-vyos-python27
@@ -2284,15 +2113,6 @@
       ansible_test_python: 3.7
 
 - job:
-    name: ansible-test-sanity-frr
-    parent: ansible-test-sanity-base-29
-    required-projects:
-      - name: github.com/ansible-collections/frr.frr
-    timeout: 3600
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/frr.frr
-
-- job:
     name: ansible-test-units-frr
     parent: ansible-test-units-base
     required-projects:
@@ -2300,15 +2120,6 @@
     timeout: 3600
     vars:
       ansible_collections_repo: github.com/ansible-collections/frr.frr
-
-- job:
-    name: ansible-test-sanity-yang
-    parent: ansible-test-sanity-base-29
-    required-projects:
-      - name: github.com/ansible-collections/community.yang
-    timeout: 3600
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/community.yang
 
 - job:
     name: ansible-test-units-yang-python27

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -145,7 +145,9 @@
     check:
       jobs: &ansible-collections-cisco-asa-units-jobs
         - ansible-changelog-fragment
-        - ansible-test-sanity-asa
+        - ansible-test-sanity-docker
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.10
         - ansible-test-units-asa-python27
         - ansible-test-units-asa-python35
         - ansible-test-units-asa-python36
@@ -175,16 +177,15 @@
 - project-template:
     name: ansible-collections-cisco-nxos-units
     check:
-      jobs:
+      jobs: &ansible-collections-cisco-nxos-units-jobs
         - ansible-changelog-fragment
-        - ansible-test-sanity-nxos
+        - ansible-test-sanity-docker
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.10
         - ansible-test-units-nxos
     gate:
       queue: integrated
-      jobs:
-        - ansible-changelog-fragment
-        - ansible-test-sanity-nxos
-        - ansible-test-units-nxos
+      jobs: *ansible-collections-cisco-nxos-units-jobs
 
 - project-template:
     name: ansible-collections-cisco-nxos
@@ -289,7 +290,9 @@
     check:
       jobs: &ansible-collections-cisco-iosxr-units-jobs
         - ansible-changelog-fragment
-        - ansible-test-sanity-iosxr
+        - ansible-test-sanity-docker
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.10
         - ansible-test-units-iosxr-python27
         - ansible-test-units-iosxr-python35
         - ansible-test-units-iosxr-python36
@@ -412,10 +415,10 @@
 - project-template:
     name: ansible-collections-cloud-common
     check:
-      jobs:
-        - build-ansible-collection
-        - ansible-test-sanity-base-29
-        - ansible-test-sanity-base-210
+      jobs: &ansible-collections-cloud-common-jobs
+        - ansible-test-sanity-docker
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.10
         - ansible-test-cloud-integration-vmware-rest-python36:
             required-projects:
               - name: github.com/ansible-collections/vmware.vmware_rest
@@ -424,17 +427,7 @@
               - name: github.com/ansible-collections/community.vmware
               - name: github.com/ansible-collections/vmware.vmware_rest
     gate:
-      jobs:
-        - build-ansible-collection
-        - ansible-test-sanity-base-29
-        - ansible-test-sanity-base-210
-        - ansible-test-cloud-integration-vmware-rest-python36:
-            required-projects:
-              - name: github.com/ansible-collections/vmware.vmware_rest
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/community.vmware
-              - name: github.com/ansible-collections/vmware.vmware_rest
+      jobs: *ansible-collections-cloud-common-jobs
 
 - project-template:
     name: ansible-collections-community-vmware
@@ -450,7 +443,9 @@
         - ansible-test-cloud-integration-vcenter7_2esxi_without_nested-python36
         - ansible-tox-linters
         - build-ansible-collection
-        - ansible-test-sanity-base-210
+        - ansible-test-sanity-docker
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.10
     gate:
       jobs:
         - ansible-test-cloud-integration-govcsim-python36_1_of_3
@@ -458,34 +453,31 @@
         - ansible-test-cloud-integration-govcsim-python36_3_of_3
         - ansible-tox-linters
         - build-ansible-collection
-        - ansible-test-sanity-base-210
+        - ansible-test-sanity-docker
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.10
     periodic:
       jobs:
         - ansible-test-cloud-integration-vcenter_only-python36
         - ansible-test-cloud-integration-vcenter_1esxi_with_nested-python36
         - ansible-test-cloud-integration-vcenter_1esxi_without_nested-python36_1_of_2
         - ansible-test-cloud-integration-vcenter_1esxi_without_nested-python36_2_of_2
+
 - project-template:
     name: ansible-collections-community-vmware-rest
     check:
-      jobs:
+      jobs: &ansible-collections-community-vmware-rest-jobs
         - ansible-test-cloud-integration-vmware-rest-python36
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/cloud.common
               - name: github.com/ansible-collections/community.vmware
         - ansible-tox-linters
-        - ansible-test-sanity-base-210
+        - ansible-test-sanity-docker
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.10
     gate:
-      jobs:
-        - ansible-test-cloud-integration-vmware-rest-python36
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/cloud.common
-              - name: github.com/ansible-collections/community.vmware
-        - ansible-tox-linters
-        - build-ansible-collection
-        - ansible-test-sanity-base-210
+      jobs: *ansible-collections-community-vmware-rest-jobs
 
 - project-template:
     name: ansible-collections-community-vmware-rest-code-generator
@@ -522,18 +514,21 @@
 - project-template:
     name: ansible-collections-community-asa-units
     check:
-      jobs:
-        - ansible-test-sanity-community-asa
+      jobs: &ansible-collections-community-asa-units-jobs
+        - ansible-test-sanity-docker
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.10
     gate:
-      jobs:
-        - ansible-test-sanity-community-asa
+      jobs: *ansible-collections-community-asa-units-jobs
 
 - project-template:
     name: ansible-collections-juniper-junos-units
     check:
       jobs: &ansible-collections-juniper-junos-units-jobs
         - ansible-changelog-fragment
-        - ansible-test-sanity-junos
+        - ansible-test-sanity-docker
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.10
         - ansible-test-units-junos-python27
         - ansible-test-units-junos-python35
         - ansible-test-units-junos-python36
@@ -617,7 +612,9 @@
     check:
       jobs: &ansible-collections-openvswitch-openvswitch-units-jobs
         - ansible-changelog-fragment
-        - ansible-test-sanity-openvswitch
+        - ansible-test-sanity-docker
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.10
         - ansible-test-units-openvswitch-python27
         - ansible-test-units-openvswitch-python35
         - ansible-test-units-openvswitch-python36
@@ -651,7 +648,9 @@
     check:
       jobs: &ansible-collections-vyos-vyos-units-jobs
         - ansible-changelog-fragment
-        - ansible-test-sanity-vyos
+        - ansible-test-sanity-docker
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.10
         - ansible-test-units-vyos-python27
         - ansible-test-units-vyos-python35
         - ansible-test-units-vyos-python36
@@ -689,21 +688,23 @@
 - project-template:
     name: ansible-collections-frr-frr-units
     check:
-      jobs:
-        - ansible-test-sanity-frr
+      jobs: &ansible-collections-ffr-ffr-units-jobs
+        - ansible-test-sanity-docker
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.10
         - ansible-test-units-frr
     gate:
       queue: integrated
-      jobs:
-        - ansible-test-sanity-frr
-        - ansible-test-units-frr
+      jobs: *ansible-collections-ffr-ffr-units-jobs
 
 - project-template:
     name: ansible-collections-ansible-netcommon-units
     check:
       jobs: &ansible-collections-ansible-netcommon-units-jobs
         - ansible-changelog-fragment
-        - ansible-test-sanity-netcommon
+        - ansible-test-sanity-docker
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.10
         - ansible-test-units-netcommon-python27
         - ansible-test-units-netcommon-python35
         - ansible-test-units-netcommon-python36
@@ -718,7 +719,9 @@
     check:
       jobs: &ansible-collections-community-yang-units-jobs
         - ansible-changelog-fragment
-        - ansible-test-sanity-yang
+        - ansible-test-sanity-docker
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.10
         - ansible-test-units-yang-python27
         - ansible-test-units-yang-python35
         - ansible-test-units-yang-python36
@@ -769,45 +772,45 @@
 - project-template:
     name: ansible-collections-ansible-posix-units
     check:
-      jobs:
-        - ansible-test-sanity-posix
+      jobs: &ansible-collections-ansible-posix-units-jobs
+        - ansible-test-sanity-docker
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.10
         - ansible-test-units-posix
     gate:
-      jobs:
-        - ansible-test-sanity-posix
-        - ansible-test-units-posix
+      jobs: *ansible-collections-ansible-posix-units-jobs
 
 - project-template:
     name: ansible-collections-security-ibm-qradar
     check:
-      jobs:
+      jobs: &ansible-collections-security-ibm-qradar-jobs
         - build-ansible-collection
         - ansible-test-security-integration-qradar-python38
-        - ansible-test-sanity-qradar
+        - ansible-test-sanity-docker
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.10
     gate:
-      jobs:
-        - build-ansible-collection
-        - ansible-test-security-integration-qradar-python38
-        - ansible-test-sanity-qradar
+      jobs: *ansible-collections-security-ibm-qradar-jobs
 
 - project-template:
     name: ansible-collections-security-splunk-es
     check:
-      jobs:
+      jobs: &ansible-collections-security-splunk-es-jobs
         - build-ansible-collection
         - ansible-security-integration-splunk-es-python36
-        - ansible-test-sanity-splunk
+        - ansible-test-sanity-docker
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.10
     gate:
-      jobs:
-        - build-ansible-collection
-        - ansible-security-integration-splunk-es-python36
-        - ansible-test-sanity-splunk
+      jobs: *ansible-collections-security-splunk-es-jobs
 
 - project-template:
     name: ansible-collections-security-trendmicro-deepsec-units
     check:
       jobs: &ansible-collections-security-trendmicro-jobs
-        - ansible-test-sanity-trendmicro-deepsec
+        - ansible-test-sanity-docker
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.10
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
@@ -819,11 +822,12 @@
 - project-template:
     name: ansible-collections-symantec-epm-units
     check:
-      jobs:
-        - ansible-test-sanity-symantec-epm
+      jobs: &ansible-collections-symantec-epm-units-jobs
+        - ansible-test-sanity-docker
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.10
     gate:
-      jobs:
-        - ansible-test-sanity-symantec-epm
+      jobs: *ansible-collections-symantec-epm-units-jobs
 
 - project-template:
     name: ansible-test-network-integration


### PR DESCRIPTION
This moves all collections to use ansible-test-sanity-docker, to help
keep jobs supported in ansible community package.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>