### PR TITLE
ansible-test: set ansible_test_python default to ''

### DIFF
--- a/roles/ansible-test/defaults/main.yaml
+++ b/roles/ansible-test/defaults/main.yaml
@@ -13,7 +13,7 @@ ansible_test_location: "{{ ~/ansible-test | expanduser }}"
 ansible_test_docker: false
 # Default ansible-test options
 ansible_test_git_branch: 'devel'
-ansible_test_python: default
+ansible_test_python:
 ansible_test_venv_path: ~/venv
 ansible_test_inventory_path: ~/inventory
 ansible_test_collection_dir: ~/.ansible/collections/ansible_collections


### PR DESCRIPTION
Keep an empty `ansible_test_python` by default. This way, the
test in `roles/ansible-test/tasks/init_test_options.yaml` works as
expected.