### PR TITLE
aws: remove the without-nested suffixes

### DIFF
--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -907,7 +907,7 @@
     name: QRadarCE-7.3.1-python38
     nodes:
       - name: ubuntu-bionic
-        label: ubuntu-bionic-1vcpu-without-nested
+        label: ubuntu-bionic-1vcpu
       - name: QRadarCE-7.3.1
         label: QRadarCE-7.3.1
     groups:
@@ -926,7 +926,7 @@
     name: SplunkEnterprise-SES-8.0.0-python38
     nodes:
       - name: ubuntu-bionic
-        label: ubuntu-bionic-1vcpu-without-nested
+        label: ubuntu-bionic-1vcpu
       - name: SplunkEnterprise-SES-8.0.0
         label: SplunkEnterprise-SES-8.0.0
     groups:
@@ -945,7 +945,7 @@
     name: Trendmicro-DeepSecurity-20.0.198-python38
     nodes:
       - name: ubuntu-bionic
-        label: ubuntu-bionic-1vcpu-without-nested
+        label: ubuntu-bionic-1vcpu
       - name: Trendmicro-DeepSecurity-20.0.198
         label: Trendmicro-DeepSecurity-20.0.198
     groups:


### PR DESCRIPTION
Depends-On: https://github.com/ansible-network/windmill-config/pull/784

Drop the `without-nested` suffixes of the AWS labels.