### PR TITLE
rename  ansible-test-provider

### DIFF
--- a/playbooks/ansible-cloud/govcsim-base/pre.yaml
+++ b/playbooks/ansible-cloud/govcsim-base/pre.yaml
@@ -16,7 +16,8 @@
       become: true
     - name: Write the configuration for ansible-test
       import_role:
-        name: vmware-ci-configure-ansible-test
+        name: ansible-test-provider
       vars:
-        vmware_ci_configure_ansible_test_ansible_path: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
-        vmware_ci_configure_ansible_test_with_vcsim: true
+        ansible_test_provider_name: vcenter
+        ansible_test_provider_root_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
+        ansible_test_provider_test_with_vcsim: true

--- a/playbooks/ansible-test-cloud-integration-base/pre.yaml
+++ b/playbooks/ansible-test-cloud-integration-base/pre.yaml
@@ -48,7 +48,8 @@
     # NOTE: We don't need that for vmware_rest
     - name: Write the configuration for ansible-test
       import_role:
-        name: vmware-ci-configure-ansible-test
+        name: ansible-test-provider
       vars:
-        vmware_ci_configure_ansible_test_ansible_path: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
-        vmware_ci_set_passwords_secret_dir: '{{ zuul.executor.work_root }}'
+        ansible_test_provider_name: vcenter
+        ansible_test_provider_root_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
+        ansible_test_provider_passwords_secret_dir: '{{ zuul.executor.work_root }}'

--- a/roles/ansible-test-provider/defaults/main.yaml
+++ b/roles/ansible-test-provider/defaults/main.yaml
@@ -1,0 +1,4 @@
+---
+ansible_test_provider_passwords_secret_dir: /tmp
+# vcenter specific
+ansible_test_provider_test_with_vcsim: false

--- a/roles/ansible-test-provider/tasks/main.yaml
+++ b/roles/ansible-test-provider/tasks/main.yaml
@@ -1,0 +1,6 @@
+---
+- name: Config the provider for ansible-test
+  template:
+    src: "cloud-config-{{ ansible_test_provider_name }}.ini.j2"
+    dest: "{{ ansible_test_provider_root_dir }}/test/integration/cloud-config-{{ ansible_test_provider_name }}.ini"
+    mode: 0644

--- a/roles/ansible-test-provider/templates/cloud-config-vcenter.ini.j2
+++ b/roles/ansible-test-provider/templates/cloud-config-vcenter.ini.j2
@@ -1,5 +1,5 @@
 [DEFAULT]
-{% if vmware_ci_configure_ansible_test_with_vcsim %}
+{% if ansible_test_provider_test_with_vcsim %}
 vcenter_username: user
 vcenter_password: pass
 vcenter_hostname: localhost
@@ -13,17 +13,17 @@ vcsim: true
 vcsim_with: systemd
 {% else %}
 vcenter_username: administrator@vsphere.local
-vcenter_password: {{ lookup('file', vmware_ci_set_passwords_secret_dir + '/vcenter/tmp/vcenter_password.txt') }}
+vcenter_password: {{ lookup('file', ansible_test_provider_passwords_secret_dir + '/vcenter/tmp/vcenter_password.txt') }}
 vcenter_hostname: vcenter.test
 vmware_validate_certs: false
 {% if 'esxi1' in hostvars %}
 esxi1_username: zuul
 esxi1_hostname: esxi1.test
-esxi1_password: {{ lookup('file', vmware_ci_set_passwords_secret_dir + '/vcenter/tmp/esxi_password_zuul.txt') }}
+esxi1_password: {{ lookup('file', ansible_test_provider_passwords_secret_dir + '/vcenter/tmp/esxi_password_zuul.txt') }}
 {% endif %}
 {% if 'esxi2' in hostvars %}
 esxi2_username: zuul
 esxi2_hostname: esxi2.test
-esxi2_password: {{ lookup('file', vmware_ci_set_passwords_secret_dir + '/vcenter/tmp/esxi_password_zuul.txt') }}
+esxi2_password: {{ lookup('file', ansible_test_provider_passwords_secret_dir + '/vcenter/tmp/esxi_password_zuul.txt') }}
 {% endif %}
 {% endif %}

--- a/roles/vmware-ci-configure-ansible-test/defaults/main.yaml
+++ b/roles/vmware-ci-configure-ansible-test/defaults/main.yaml
@@ -1,3 +1,0 @@
----
-vmware_ci_configure_ansible_test_with_vcsim: false
-vmware_ci_set_passwords_secret_dir: /tmp

--- a/roles/vmware-ci-configure-ansible-test/tasks/main.yaml
+++ b/roles/vmware-ci-configure-ansible-test/tasks/main.yaml
@@ -1,6 +1,0 @@
----
-- name: Save the password in the vcenter configuration file (ansible-test)
-  template:
-    src: cloud-config-vcenter.ini.j2
-    dest: "{{ vmware_ci_configure_ansible_test_ansible_path }}/test/integration/cloud-config-vcenter.ini"
-    mode: 0644


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/796

Rename `vmware-ci-configure-ansible-test` to `ansible-test-provider` in
order to be able to use it with aws.