### PR TITLE
ansible-test: add support for ansible_test_changed

### DIFF
--- a/roles/ansible-test/defaults/main.yaml
+++ b/roles/ansible-test/defaults/main.yaml
@@ -22,3 +22,5 @@ ansible_test_split_in: 1
 ansible_test_do_number: 1
 ansible_test_sanity_skiptests: []
 ansible_test_network_cli_ssh_type: paramiko
+ansible_test_changed: false
+ansible_test_base_branch: main

--- a/roles/ansible-test/tasks/ansible_test_changed.yaml
+++ b/roles/ansible-test/tasks/ansible_test_changed.yaml
@@ -1,0 +1,12 @@
+---
+- name: Identify the changed targets
+  args:
+    chdir: "{{ ansible_test_location }}"
+    executable: /bin/bash
+  shell: |
+    for i in $(git diff origin/main --name-only|egrep '^plugins/.*.py'|xargs -r basename -s .py); do
+      test -f tests/integration/targets/${i}/aliases && echo ${i}
+    done
+  register: _result
+- set_fact:
+    ansible_test_integration_targets: "{{ _result.stdout_lines|join(' ') }}"

--- a/roles/ansible-test/tasks/main.yaml
+++ b/roles/ansible-test/tasks/main.yaml
@@ -41,6 +41,11 @@
 #  import_tasks: enable_ara.yaml
 #  when: ansible_test_enable_ara
 
+
+- name: Identiy the targets associated with the changed files
+  import_tasks: ansible_test_changed.yaml
+  when: ansible_test_changed|bool
+
 - name: Set the targets
   set_fact:
     _integration_targets: "{{ ansible_test_integration_targets }}"
@@ -49,9 +54,13 @@
   import_tasks: split_targets.yaml
   when: ansible_test_split_in > 1
 
+- debug:
+    msg: "About to run: {{ ansible_test_executable }} {{ ansible_test_test_command }} {{ ansible_test_options }} -vvvv {{ _integration_targets }}"
+
 - name: Run the test suite
   args:
     chdir: "{{ _test_location }}"
     executable: /bin/bash
   environment: "{{ ansible_test_environment | default({}) }}"
   shell: "source {{ ansible_test_venv_path }}/bin/activate; {{ ansible_test_executable }} {{ ansible_test_test_command }} {{ ansible_test_options }} -vvvv {{ _integration_targets }}"
+  when: (ansible_test_changed|bool == False) or (ansible_test_changed|bool and _integration_targets|length > 0)


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/799

When the flag is one, one only test the changed files. Use `ansible_test_changed: true` to turn this on.