### PR TITLE
ansible_test: use a sensible default python version

### DIFF
--- a/roles/ansible-test/defaults/main.yaml
+++ b/roles/ansible-test/defaults/main.yaml
@@ -13,7 +13,7 @@ ansible_test_location: "{{ ~/ansible-test | expanduser }}"
 ansible_test_docker: false
 # Default ansible-test options
 ansible_test_git_branch: 'devel'
-ansible_test_python:
+ansible_test_python: "{{ ansible_python_version.split('.')[:2]|join('.') }}"
 ansible_test_venv_path: ~/venv
 ansible_test_inventory_path: ~/inventory
 ansible_test_collection_dir: ~/.ansible/collections/ansible_collections

--- a/roles/ansible-test/tasks/split_targets.yaml
+++ b/roles/ansible-test/tasks/split_targets.yaml
@@ -4,7 +4,7 @@
     chdir: "{{ _test_location }}"
     executable: /bin/bash
   environment: "{{ ansible_test_environment | default({}) }}"
-  shell: "source {{ ansible_test_venv_path }}/bin/activate; {{ ansible_test_executable }} {{ ansible_test_test_command }} {{ ansible_test_options }} --python {{ ansible_test_python }} --list {{ ansible_test_integration_targets }} 2>&1|grep -v WARNING"
+  shell: "source {{ ansible_test_venv_path }}/bin/activate; {{ ansible_test_executable }} {{ ansible_test_test_command }} {{ ansible_test_options }} --list {{ ansible_test_integration_targets }} 2>&1|grep -v WARNING"
   register: ansible_test_targets
 - set_fact:
     number_entries: "{{ ansible_test_targets.stdout_lines|length }}"


### PR DESCRIPTION
`ansible_test_python` now uses the Python version used by Ansible
itself.
Also, ensure we don't pass the `--python` parameters two times in
`split_targets.yaml`. The second argument was silently ignored.