### PR TITLE
Reduce verbosity of ansible-test sanity

### DIFF
--- a/roles/ansible-test/tasks/init_test_options.yaml
+++ b/roles/ansible-test/tasks/init_test_options.yaml
@@ -40,6 +40,10 @@
         ansible_test_options: "{{ ansible_test_options }} --skip-test {{ ansible_test_sanity_skiptests|join(' --skip-test ') }} "
       when: ansible_test_sanity_skiptests|length > 0
 
+    - name: Reduce verbosity
+      set_fact:
+        ansible_test_verbosity: "-v"
+
 - name: Setup --python option
   set_fact:
     ansible_test_options: "{{ ansible_test_options }} --python {{ ansible_test_python }}"

--- a/roles/ansible-test/tasks/main.yaml
+++ b/roles/ansible-test/tasks/main.yaml
@@ -55,7 +55,7 @@
   when: ansible_test_split_in > 1
 
 - debug:
-    msg: "About to run: {{ ansible_test_executable }} {{ ansible_test_test_command }} {{ ansible_test_options }} -vvvv {{ _integration_targets }}"
+    msg: "About to run: {{ ansible_test_executable }} {{ ansible_test_test_command }} {{ ansible_test_options }} {{ ansible_test_verbosity }} {{ _integration_targets }}"
 
 - name: Run the test suite
   args:

--- a/roles/ansible-test/tasks/main.yaml
+++ b/roles/ansible-test/tasks/main.yaml
@@ -62,5 +62,5 @@
     chdir: "{{ _test_location }}"
     executable: /bin/bash
   environment: "{{ ansible_test_environment | default({}) }}"
-  shell: "source {{ ansible_test_venv_path }}/bin/activate; {{ ansible_test_executable }} {{ ansible_test_test_command }} {{ ansible_test_options }} -vvvv {{ _integration_targets }}"
+  shell: "source {{ ansible_test_venv_path }}/bin/activate; {{ ansible_test_executable }} {{ ansible_test_test_command }} {{ ansible_test_options }} {{ ansible_test_verbosity }} {{ _integration_targets }}"
   when: (ansible_test_changed|bool == False) or (ansible_test_changed|bool and _integration_targets|length > 0)

--- a/roles/ansible-test/vars/default.yaml
+++ b/roles/ansible-test/vars/default.yaml
@@ -1,3 +1,4 @@
 ---
 ansible_test_executable: "ansible-test"
 ansible_test_options: "--diff --no-temp-workdir"
+ansible_test_verbosity: "-vvvv"


### PR DESCRIPTION
Currently, `ansible-test sanity` is run with `-vvvv`. This is **way too much** and makes the output almost impossible to read. (If you don't know that searching for `ERROR: ` - the space is important - will find you the errors in acceptable amount of time, you will be lost by many thousands of irrelevant lines of log output.)

This PR reduces verbosity to `-v` for `ansible-test sanity`, while preserving `-vvvv` for other `ansible-test` commands. (Assuming I understood Zuul correctly :) )