### PR TITLE
To add and enable 2.11 jobs to Cisco ASA

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -189,6 +189,7 @@
         - ansible-test-sanity-docker
         - ansible-test-sanity-docker-stable-2.9
         - ansible-test-sanity-docker-stable-2.10
+        - ansible-test-sanity-docker-stable-2.11
         - ansible-test-units-asa-python27
         - ansible-test-units-asa-python35
         - ansible-test-units-asa-python36


### PR DESCRIPTION
To add and enable 2.11 jobs to Cisco ASA