### PR TITLE
Add ansible-navigator smoke test job

### DIFF
--- a/zuul.d/ansible-navigator-jobs.yaml
+++ b/zuul.d/ansible-navigator-jobs.yaml
@@ -1,0 +1,7 @@
+---
+- job:
+    name: ansible-navigator-tox-smoke
+    parent: tox
+    vars:
+      tox_envlist: smoke
+    nodeset: centos-8-1vcpu

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -463,10 +463,3 @@
     vars:
       container_command: podman
     nodeset: ubuntu-bionic-2vcpu
-
-- job:
-    name: ansible-navigator-tox-smoke
-    parent: tox
-    vars:
-      tox_envlist: smoke
-    nodeset: centos-8-1vcpu

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -463,3 +463,10 @@
     vars:
       container_command: podman
     nodeset: ubuntu-bionic-2vcpu
+
+- job:
+    name: ansible-navigator-tox-smoke
+    parent: tox
+    vars:
+      tox_envlist: smoke
+    nodeset: centos-8-1vcpu

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -54,6 +54,7 @@
     check:
       jobs: &ansible-navigator-jobs
         - ansible-tox-linters
+        - ansible-navigator-tox-smoke
     gate:
       jobs: *ansible-navigator-jobs
 


### PR DESCRIPTION
Adds a job that can run `tox -e smoke` for running `ansible-navigator` smoke tests...