### PR TITLE
[ansible-navigator-tox-smoke] use ansible-tox-py38

### DIFF
--- a/zuul.d/ansible-navigator-jobs.yaml
+++ b/zuul.d/ansible-navigator-jobs.yaml
@@ -1,7 +1,7 @@
 ---
 - job:
     name: ansible-navigator-tox-smoke
-    parent: tox
+    parent: ansible-tox-py38
     vars:
       tox_envlist: smoke
     nodeset: centos-8-1vcpu


### PR DESCRIPTION
Change:
- This makes the job use ansible-tox-py38 as parent so that bindeps
  work.

Tickets:
- Refs https://github.com/ansible/ansible-zuul-jobs/pull/845#discussion_r604488686

Signed-off-by: Rick Elrod <rick@elrod.me>