### PR TITLE
Stop publishing every commit to galaxy

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1536,10 +1536,6 @@
       jobs:
         - ansible-galaxy-importer
         - build-ansible-collection
-    post:
-      jobs:
-        - release-ansible-collection-galaxy:
-            branches: master
     pre-release:
       jobs:
         - release-ansible-collection-galaxy
@@ -1581,9 +1577,6 @@
       jobs:
         - ansible-galaxy-importer
         - build-ansible-collection
-    post:
-      jobs:
-        - release-ansible-collection-galaxy
     pre-release:
       jobs:
         - release-ansible-collection-galaxy
@@ -1618,9 +1611,6 @@
       jobs:
         - ansible-galaxy-importer
         - build-ansible-collection
-    post:
-      jobs:
-        - release-ansible-collection-galaxy-dev
     post-release:
       jobs:
         - release-ansible-collection-galaxy-dev


### PR DESCRIPTION
There seems to be rate limit / preformance issues on galaxy side. This
means people will need to git clone collections / build tarballs for
them if they want the latest unreleased code.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>