### PR TITLE
ansible-test-cloud-integration-aws-py36: turn off non-voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -71,8 +71,7 @@
             required-projects:
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/community.general
-        - ansible-test-cloud-integration-aws-py36:
-            voting: false
+        - ansible-test-cloud-integration-aws-py36
     gate:
       jobs:
         - ansible-test-sanity-docker
@@ -83,8 +82,7 @@
             required-projects:
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/community.general
-        - ansible-test-cloud-integration-aws-py36:
-            voting: false
+        - ansible-test-cloud-integration-aws-py36
 
 - project-template:
     name: ansible-collections-community-aws
@@ -99,8 +97,7 @@
               - name: github.com/ansible-collections/amazon.aws
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/community.general
-        - ansible-test-cloud-integration-aws-py36:
-            voting: false
+        - ansible-test-cloud-integration-aws-py36
     gate:
       jobs:
         - ansible-test-sanity-docker
@@ -112,8 +109,7 @@
               - name: github.com/ansible-collections/amazon.aws
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/community.general
-        - ansible-test-cloud-integration-aws-py36:
-            voting: false
+        - ansible-test-cloud-integration-aws-py36
 
 - project-template:
     name: ansible-collections-arista-eos-units


### PR DESCRIPTION
We now rely on this job to check the AWS PRs.