### PR TITLE
Change ssh key to ECDSA from RSA for Cisco ASA appliance

### DIFF
--- a/playbooks/ansible-network-asa-appliance/files/bootstrap.yaml
+++ b/playbooks/ansible-network-asa-appliance/files/bootstrap.yaml
@@ -11,7 +11,7 @@
   tasks:
     - name: lookup SSH public key
       set_fact:
-        _ssh_key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+        _ssh_key: "{{ lookup('file', '~/.ssh/id_ecdsa.pub') }}"
 
     - name: Setup new user
       become: true


### PR DESCRIPTION
Change ssh key to ECDSA from RSA for Cisco ASA appliance