### PR TITLE
amazon.aws uses community.aws for its tests

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -70,6 +70,7 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.utils
+              - name: github.com/ansible-collections/community.aws
               - name: github.com/ansible-collections/community.general
         - ansible-test-cloud-integration-aws-py36
     gate:
@@ -81,6 +82,7 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.utils
+              - name: github.com/ansible-collections/community.aws
               - name: github.com/ansible-collections/community.general
         - ansible-test-cloud-integration-aws-py36
 


### PR DESCRIPTION
Ensure community.aws is always here. This is probably a workaround
that we will drop in the future. But for now we need both to pass
the tests.