### PR TITLE
DNM - test ansible-test-cloud-integration-aws-py36

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -72,7 +72,9 @@
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/community.aws
               - name: github.com/ansible-collections/community.general
-        - ansible-test-cloud-integration-aws-py36
+        - ansible-test-cloud-integration-aws-py36:
+            vars:
+              ansible_test_changed: false
     gate:
       jobs:
         - ansible-test-sanity-docker
@@ -99,7 +101,9 @@
               - name: github.com/ansible-collections/amazon.aws
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/community.general
-        - ansible-test-cloud-integration-aws-py36
+        - ansible-test-cloud-integration-aws-py36:
+            vars:
+              ansible_test_changed: false
     gate:
       jobs:
         - ansible-test-sanity-docker


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/880

Ensure we can do a full integration test run with the AWS collections.