### PR TITLE
Add ansible-cloud-vcenter-appliance semaphore

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -1,5 +1,13 @@
 ---
 ####################### vmware #####################
+# NOTE(pabelanger): Due to low memory capacity in vexxhost, it is
+# possible to wedge the provider.  For now, only run 4 job at a time.
+# We will have acces to a new region shortly, which would allow us
+# to remove this.
+- semaphore:
+    name: ansible-cloud-vcenter-appliance
+    max: 4
+
 - job:
     name: ansible-cloud-vcenter-appliance
     parent: ansible-network-appliance-base
@@ -16,6 +24,7 @@
       esxi1:
         ansible_network_os: vmware_rest
     nodeset: vmware-vcsa-7.0.2-python36
+    semaphore: ansible-cloud-vcenter-appliance
 
 # govcsim
 


### PR DESCRIPTION
Cap the amount of jobs we run, until we bring another region online.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>