### PR TITLE
Drop ansible stable-2.8 testing

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -917,106 +917,81 @@
         - ansible-test-network-integration-eos-python27:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-eos-python35:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-eos-python36:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-eos-python37:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-ios-python27:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-ios-python35:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-ios-python36:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-ios-python37:
             branches:
               - stable-2.9
-              - stable-2.8
             voting: false
         - ansible-test-network-integration-iosxr-python27:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-iosxr-python35:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-iosxr-python36:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-iosxr-python37:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-junos-vsrx-python27:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-junos-vsrx-python35:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-junos-vsrx-python36:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-junos-vsrx-python37:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-openvswitch-python27:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-openvswitch-python35:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-openvswitch-python36:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-openvswitch-python37:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-vyos-python27:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-vyos-python35:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-vyos-python36:
             branches:
               - stable-2.9
-              - stable-2.8
         - ansible-test-network-integration-vyos-python37:
             branches:
               - stable-2.9
-              - stable-2.8
     third-party-check:
       jobs:
         - ansible-test-network-integration-eos-python27:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1038,7 +1013,6 @@
         - ansible-test-network-integration-eos-python35:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1060,7 +1034,6 @@
         - ansible-test-network-integration-eos-python36:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1082,7 +1055,6 @@
         - ansible-test-network-integration-eos-python37:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1104,7 +1076,6 @@
         - ansible-test-network-integration-ios-python27:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1123,7 +1094,6 @@
         - ansible-test-network-integration-ios-python35:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1142,7 +1112,6 @@
         - ansible-test-network-integration-ios-python36:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1161,7 +1130,6 @@
         - ansible-test-network-integration-ios-python37:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1181,7 +1149,6 @@
         - ansible-test-network-integration-iosxr-python27:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1205,7 +1172,6 @@
         - ansible-test-network-integration-iosxr-python35:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1229,7 +1195,6 @@
         - ansible-test-network-integration-iosxr-python36:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1253,7 +1218,6 @@
         - ansible-test-network-integration-iosxr-python37:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1277,7 +1241,6 @@
         - ansible-test-network-integration-junos-vsrx-python27:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1301,7 +1264,6 @@
         - ansible-test-network-integration-junos-vsrx-python35:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1325,7 +1287,6 @@
         - ansible-test-network-integration-junos-vsrx-python36:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1349,7 +1310,6 @@
         - ansible-test-network-integration-junos-vsrx-python37:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1373,7 +1333,6 @@
         - ansible-test-network-integration-openvswitch-python27:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1384,7 +1343,6 @@
         - ansible-test-network-integration-openvswitch-python35:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1395,7 +1353,6 @@
         - ansible-test-network-integration-openvswitch-python36:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1406,7 +1363,6 @@
         - ansible-test-network-integration-openvswitch-python37:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1417,7 +1373,6 @@
         - ansible-test-network-integration-vyos-python27:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1436,7 +1391,6 @@
         - ansible-test-network-integration-vyos-python35:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1455,7 +1409,6 @@
         - ansible-test-network-integration-vyos-python36:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*
@@ -1474,7 +1427,6 @@
         - ansible-test-network-integration-vyos-python37:
             branches:
               - stable-2.9
-              - stable-2.8
             files:
               - ^lib/ansible/cli/scripts/ansible_connection_cli_stub.py
               - ^lib/ansible/modules/network/cli/.*


### PR DESCRIPTION
With the release of ansible 2.11, stable-2.8 is EOL. We can stop testing
it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>