### PR TITLE
Enable ssh with ecdsa key in vyos

### DIFF
--- a/playbooks/ansible-network-vyos-appliance/files/bootstrap.yaml
+++ b/playbooks/ansible-network-vyos-appliance/files/bootstrap.yaml
@@ -9,7 +9,7 @@
   tasks:
     - name: lookup SSH public key
       set_fact:
-        _ssh_key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+        _ssh_key: "{{ lookup('file', '~/.ssh/id_ecdsa.pub') }}"
 
     - name: Setup new user
       vyos_config:

--- a/zuul.d/vyos-vyos-jobs.yaml
+++ b/zuul.d/vyos-vyos-jobs.yaml
@@ -37,6 +37,7 @@
       ansible_collections_repo: github.com/ansible-collections/vyos.vyos
       ansible_test_command: network-integration
       ansible_test_integration_targets: "vyos_.*"
+      ansible_test_fips_mode: true
 
 - job:
     name: ansible-test-units-vyos-python27


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gosriniv@redhat.com>

In order to enable FIPS mode, the appliance should be logged in using ecdsa key (ssh).