### PR TITLE
vSphere7: ensure TCP timestamps are ON

### DIFF
--- a/playbooks/ansible-cloud/vcenter-appliance/pre.yaml
+++ b/playbooks/ansible-cloud/vcenter-appliance/pre.yaml
@@ -30,6 +30,12 @@
 - hosts: vcenter
   gather_facts: false
   tasks:
+    - name: Enable TCP timestamp
+      sysctl:
+        name: net.ipv4.tcp_timestamps
+        value: 1
+        state: present
+      become: true
     - import_role:
         name: vmware-ci-memory-configuration
 


### PR DESCRIPTION
If the ESXi and the vSphere are on the same hypervisor, the network
becomes really fast and we can be hit by unpredicable packet order.
The timestamps is used by PAWS (TCP Sequence number wrapping) to
detect this situation. This is the reason why we want to keep it on.

See: https://tejparkash.wordpress.com/2010/12/05/paws-tcp-sequence-number-wrapping-explained/