### PR TITLE
AWS collections: run sanity test with 2.11

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -66,6 +66,7 @@
         - ansible-test-sanity-docker
         - ansible-test-sanity-docker-stable-2.9
         - ansible-test-sanity-docker-stable-2.10
+        - ansible-test-sanity-docker-stable-2.11
         - ansible-test-units-amazon-aws-python38
         - build-ansible-collection:
             required-projects:
@@ -78,6 +79,7 @@
         - ansible-test-sanity-docker
         - ansible-test-sanity-docker-stable-2.9
         - ansible-test-sanity-docker-stable-2.10
+        - ansible-test-sanity-docker-stable-2.11
         - ansible-test-units-amazon-aws-python38
         - build-ansible-collection:
             required-projects:
@@ -93,6 +95,7 @@
         - ansible-test-sanity-docker
         - ansible-test-sanity-docker-stable-2.9
         - ansible-test-sanity-docker-stable-2.10
+        - ansible-test-sanity-docker-stable-2.11
         - ansible-test-units-community-aws-python38
         - build-ansible-collection:
             required-projects:
@@ -105,6 +108,7 @@
         - ansible-test-sanity-docker
         - ansible-test-sanity-docker-stable-2.9
         - ansible-test-sanity-docker-stable-2.10
+        - ansible-test-sanity-docker-stable-2.11
         - ansible-test-units-community-aws-python38
         - build-ansible-collection:
             required-projects:


### PR DESCRIPTION
Enable `ansible-test-sanity-docker-stable-2.11` with the two collections.