### PR TITLE
ansible-test-inventory: use root account

### DIFF
--- a/roles/ansible-test-inventory/templates/inventory-vmware_rest.j2
+++ b/roles/ansible-test-inventory/templates/inventory-vmware_rest.j2
@@ -7,11 +7,11 @@ vcenter_username=administrator@vsphere.local
 vcenter_password={{ lookup('file', vmware_ci_set_passwords_secret_dir + '/vcenter/tmp/vcenter_password.txt') }}
 {% if 'esxi1' in hostvars %}
 esxi1_hostname=esxi1.test
-esxi1_username=zuul
-esxi1_password={{ lookup('file', vmware_ci_set_passwords_secret_dir + '/vcenter/tmp/esxi_password_zuul.txt') }}
+esxi1_username=root
+esxi1_password={{ lookup('file', vmware_ci_set_passwords_secret_dir + '/vcenter/tmp/esxi_password_root.txt') }}
 {% endif %}
 {% if 'esxi2' in hostvars %}
 esxi2_hostname=esxi2.test
-esxi2_username=zuul
-esxi2_password={{ lookup('file', vmware_ci_set_passwords_secret_dir + '/vcenter/tmp/esxi_password_zuul.txt') }}
+esxi2_username=root
+esxi2_password={{ lookup('file', vmware_ci_set_passwords_secret_dir + '/vcenter/tmp/esxi_password_root.txt') }}
 {% endif %}

--- a/roles/ansible-test-provider/templates/cloud-config-vcenter.ini.j2
+++ b/roles/ansible-test-provider/templates/cloud-config-vcenter.ini.j2
@@ -17,13 +17,13 @@ vcenter_password: {{ lookup('file', ansible_test_provider_passwords_secret_dir +
 vcenter_hostname: vcenter.test
 vmware_validate_certs: false
 {% if 'esxi1' in hostvars %}
-esxi1_username: zuul
+esxi1_username: root
 esxi1_hostname: esxi1.test
-esxi1_password: {{ lookup('file', ansible_test_provider_passwords_secret_dir + '/vcenter/tmp/esxi_password_zuul.txt') }}
+esxi1_password: {{ lookup('file', ansible_test_provider_passwords_secret_dir + '/vcenter/tmp/esxi_password_root.txt') }}
 {% endif %}
 {% if 'esxi2' in hostvars %}
-esxi2_username: zuul
+esxi2_username: root
 esxi2_hostname: esxi2.test
-esxi2_password: {{ lookup('file', ansible_test_provider_passwords_secret_dir + '/vcenter/tmp/esxi_password_zuul.txt') }}
+esxi2_password: {{ lookup('file', ansible_test_provider_passwords_secret_dir + '/vcenter/tmp/esxi_password_root.txt') }}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
Since ESXi7, we cannot use a non-root account to add a host to a vSphere
instance.