### PR TITLE
vmware: don't wait for govcsim to start the real tests

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -70,12 +70,6 @@
     parent: ansible-cloud-vcenter-appliance
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-cloud-integration-govcsim-python36_1_of_3
-        soft: true
-      - name: ansible-test-cloud-integration-govcsim-python36_2_of_3
-        soft: true
-      - name: ansible-test-cloud-integration-govcsim-python36_3_of_3
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
     run: playbooks/ansible-test-base/run.yaml


### PR DESCRIPTION
The govcsim tests are pretty much always green now. There is no point
waiting for them.