### PR TITLE
ansible-test: match changef tests

### DIFF
--- a/roles/ansible-test/tasks/ansible_test_changed.yaml
+++ b/roles/ansible-test/tasks/ansible_test_changed.yaml
@@ -4,7 +4,7 @@
     chdir: "{{ ansible_test_location }}"
     executable: /bin/bash
   shell: |
-    for i in $(git diff origin/main --name-only|egrep '^plugins/.*.py'|xargs -r basename -s .py); do
+    for i in $(git diff {{ zuul.branch }} --name-only|egrep '^plugins/.*.py'|xargs -r basename -s .py) $(git diff {{ zuul.branch }} --name-only|sed -n 's#tests/integration/targets/\(.*\)/.*#\1#p'); do
       test -f tests/integration/targets/${i}/aliases || continue
       echo ${i}
     done


### PR DESCRIPTION
When `ansible_test_changed` is enabled, we should also identify
the test modifications.