### PR TITLE
Remove python38 unit tests

### DIFF
--- a/zuul.d/arista-eos-jobs.yaml
+++ b/zuul.d/arista-eos-jobs.yaml
@@ -72,14 +72,6 @@
       ansible_collections_repo: github.com/ansible-collections/arista.eos
 
 - job:
-    name: ansible-test-units-eos-python38
-    parent: ansible-test-units-base-python38
-    required-projects:
-      - name: github.com/ansible-collections/arista.eos
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/arista.eos
-
-- job:
     name: ansible-test-network-integration-eos-httpapi
     parent: ansible-test-network-integration-eos
     abstract: true

--- a/zuul.d/cisco-asa-jobs.yaml
+++ b/zuul.d/cisco-asa-jobs.yaml
@@ -72,14 +72,6 @@
       ansible_collections_repo: github.com/ansible-collections/cisco.asa
 
 - job:
-    name: ansible-test-units-asa-python38
-    parent: ansible-test-units-base-python38
-    required-projects:
-      - name: github.com/ansible-collections/cisco.asa
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/cisco.asa
-
-- job:
     name: ansible-test-network-integration-asa-python27
     parent: ansible-test-network-integration-asa
     nodeset: asav9-12-3-python27

--- a/zuul.d/cisco-iosxr-jobs.yaml
+++ b/zuul.d/cisco-iosxr-jobs.yaml
@@ -71,14 +71,6 @@
       ansible_collections_repo: github.com/ansible-collections/cisco.iosxr
 
 - job:
-    name: ansible-test-units-iosxr-python38
-    parent: ansible-test-units-base-python38
-    required-projects:
-      - name: github.com/ansible-collections/cisco.iosxr
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/cisco.iosxr
-
-- job:
     name: ansible-test-network-integration-iosxr-netconf
     parent: ansible-test-network-integration-iosxr
     abstract: true

--- a/zuul.d/cisco-nxos-jobs.yaml
+++ b/zuul.d/cisco-nxos-jobs.yaml
@@ -39,15 +39,6 @@
       ansible_test_integration_targets: "nxos_.*"
 
 - job:
-    name: ansible-test-units-nxos
-    parent: ansible-test-units-base
-    required-projects:
-      - name: github.com/ansible-collections/cisco.nxos
-    timeout: 3600
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/cisco.nxos
-
-- job:
     name: ansible-test-network-integration-nxos-cli-python36
     parent: ansible-test-network-integration-nxos
     nodeset: nxos-7.0.3-python36

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -250,14 +250,6 @@
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
 
 - job:
-    name: ansible-test-units-netcommon-python38
-    parent: ansible-test-units-base-python38
-    required-projects:
-      - name: github.com/ansible-collections/ansible.netcommon
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
-
-- job:
     name: ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python36
     parent: ansible-test-network-integration-iosxr-python36
     vars:

--- a/zuul.d/junipernetworks-junos-jobs.yaml
+++ b/zuul.d/junipernetworks-junos-jobs.yaml
@@ -85,14 +85,6 @@
       ansible_collections_repo: github.com/ansible-collections/junipernetworks.junos
 
 - job:
-    name: ansible-test-units-junos-python38
-    parent: ansible-test-units-base-python38
-    required-projects:
-      - name: github.com/ansible-collections/junipernetworks.junos
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/junipernetworks.junos
-
-- job:
     name: ansible-test-network-integration-junos-vsrx-netconf
     parent: ansible-test-network-integration-junos-vsrx
     abstract: true

--- a/zuul.d/openvswitch-openvswitch-jobs.yaml
+++ b/zuul.d/openvswitch-openvswitch-jobs.yaml
@@ -69,14 +69,6 @@
       ansible_collections_repo: github.com/ansible-collections/openvswitch.openvswitch
 
 - job:
-    name: ansible-test-units-openvswitch-python38
-    parent: ansible-test-units-base-python38
-    required-projects:
-      - name: github.com/ansible-collections/openvswitch.openvswitch
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/openvswitch.openvswitch
-
-- job:
     name: ansible-test-network-integration-openvswitch-python27
     parent: ansible-test-network-integration-openvswitch
     nodeset: openvswitch-2.9.0-python27

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -207,7 +207,6 @@
         - ansible-test-units-asa-python35
         - ansible-test-units-asa-python36
         - ansible-test-units-asa-python37
-        - ansible-test-units-asa-python38
     gate:
       queue: integrated
       jobs: *ansible-collections-cisco-asa-units-jobs
@@ -238,7 +237,6 @@
         - ansible-test-sanity-docker-stable-2.9
         - ansible-test-sanity-docker-stable-2.10
         - ansible-test-sanity-docker-stable-2.11
-        - ansible-test-units-nxos
     gate:
       queue: integrated
       jobs: *ansible-collections-cisco-nxos-units-jobs
@@ -358,7 +356,6 @@
         - ansible-test-units-iosxr-python35
         - ansible-test-units-iosxr-python36
         - ansible-test-units-iosxr-python37
-        - ansible-test-units-iosxr-python38
     gate:
       queue: integrated
       jobs: *ansible-collections-cisco-iosxr-units-jobs
@@ -596,7 +593,6 @@
         - ansible-test-units-junos-python35
         - ansible-test-units-junos-python36
         - ansible-test-units-junos-python37
-        - ansible-test-units-junos-python38
     gate:
       queue: integrated
       jobs: *ansible-collections-juniper-junos-units-jobs
@@ -683,7 +679,6 @@
         - ansible-test-units-openvswitch-python35
         - ansible-test-units-openvswitch-python36
         - ansible-test-units-openvswitch-python37
-        - ansible-test-units-openvswitch-python38
     gate:
       queue: integrated
       jobs: *ansible-collections-openvswitch-openvswitch-units-jobs
@@ -720,7 +715,6 @@
         - ansible-test-units-vyos-python35
         - ansible-test-units-vyos-python36
         - ansible-test-units-vyos-python37
-        - ansible-test-units-vyos-python38
     gate:
       queue: integrated
       jobs: *ansible-collections-vyos-vyos-units-jobs
@@ -758,7 +752,6 @@
         - ansible-test-sanity-docker-stable-2.9
         - ansible-test-sanity-docker-stable-2.10
         - ansible-test-sanity-docker-stable-2.11
-        - ansible-test-units-frr
     gate:
       queue: integrated
       jobs: *ansible-collections-ffr-ffr-units-jobs
@@ -776,7 +769,6 @@
         - ansible-test-units-netcommon-python35
         - ansible-test-units-netcommon-python36
         - ansible-test-units-netcommon-python37
-        - ansible-test-units-netcommon-python38
     gate:
       queue: integrated
       jobs: *ansible-collections-ansible-netcommon-units-jobs

--- a/zuul.d/vyos-vyos-jobs.yaml
+++ b/zuul.d/vyos-vyos-jobs.yaml
@@ -71,14 +71,6 @@
       ansible_collections_repo: github.com/ansible-collections/vyos.vyos
 
 - job:
-    name: ansible-test-units-vyos-python38
-    parent: ansible-test-units-base-python38
-    required-projects:
-      - name: github.com/ansible-collections/vyos.vyos
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/vyos.vyos
-
-- job:
     name: ansible-test-network-integration-vyos-local
     parent: ansible-test-network-integration-vyos
     abstract: true


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gosriniv@redhat.com>

Unit tests in python38 are already covered by network-ee tests. 