### PR TITLE
AWS should only be sanity tested on python3

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -323,6 +323,7 @@
       ansible_test_python: 3.6
       ansible_test_changed: true
 
+#### units
 - job:
     name: ansible-test-units-community-aws-python38
     parent: ansible-test-units-base-python38
@@ -335,195 +336,96 @@
     vars:
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
 
+#### sanity
+- job:
+    name: ansible-test-sanity-aws-ansible
+    parent: unittests
+    nodeset: controller-python36
+    dependencies:
+      - name: build-ansible-collection
+        soft: true
+    pre-run: playbooks/ansible-test-base/pre.yaml
+    run: playbooks/ansible-test-base/run.yaml
+    required-projects:
+      - name: github.com/ansible/ansible
+    timeout: 3600
+    vars:
+      ansible_test_collections: true
+      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
+      ansible_test_command: sanity
+      ansible_test_docker: true
+      ansible_test_enable_ara: false
+      ansible_test_python: 3.6
+
+- job:
+    name: ansible-test-sanity-aws-ansible-2.9-python36
+    parent: ansible-test-sanity-aws-ansible
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
+
+- job:
+    name: ansible-test-sanity-aws-ansible-2.11-python36
+    parent: ansible-test-sanity-aws-ansible
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
+
+- job:
+    name: ansible-test-sanity-aws-ansible-devel-python36
+    parent: ansible-test-sanity-aws-ansible
+
+- job:
+    name: ansible-test-sanity-aws-ansible-2.9-python37
+    parent: ansible-test-sanity-aws-ansible
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
+    vars:
+      ansible_test_python: 3.7
+
+- job:
+    name: ansible-test-sanity-aws-ansible-2.11-python37
+    parent: ansible-test-sanity-aws-ansible
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
+    vars:
+      ansible_test_python: 3.7
+
+- job:
+    name: ansible-test-sanity-aws-ansible-devel-python37
+    parent: ansible-test-sanity-aws-ansible
+    vars:
+      ansible_test_python: 3.7
+
+- job:
+    name: ansible-test-sanity-aws-ansible-2.9-python38
+    parent: ansible-test-sanity-aws-ansible
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
+    vars:
+      ansible_test_python: 3.8
+
+- job:
+    name: ansible-test-sanity-aws-ansible-2.11-python38
+    parent: ansible-test-sanity-aws-ansible
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
+    vars:
+      ansible_test_python: 3.8
+
+- job:
+    name: ansible-test-sanity-aws-ansible-devel-python38
+    parent: ansible-test-sanity-aws-ansible
+    vars:
+      ansible_test_python: 3.8
+
 ### Cloud Common
 - job:
     name: ansible-test-units-cloud-common-python38
     parent: ansible-test-units-base-python38
     vars:
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
-
-- job:
-    name: ansible-test-sanity-aws-ansible-2.9-python36
-    parent: unittests
-    nodeset: controller-python36
-    dependencies:
-      - name: build-ansible-collection
-        soft: true
-    pre-run: playbooks/ansible-test-base/pre.yaml
-    run: playbooks/ansible-test-base/run.yaml
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    timeout: 3600
-    vars:
-      ansible_test_collections: true
-      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
-      ansible_test_command: sanity
-      ansible_test_docker: true
-      ansible_test_enable_ara: false
-      ansible_test_python: 3.6
-
-- job:
-    name: ansible-test-sanity-aws-ansible-2.11-python36
-    parent: unittests
-    nodeset: controller-python36
-    dependencies:
-      - name: build-ansible-collection
-        soft: true
-    pre-run: playbooks/ansible-test-base/pre.yaml
-    run: playbooks/ansible-test-base/run.yaml
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.11
-    timeout: 3600
-    vars:
-      ansible_test_collections: true
-      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
-      ansible_test_command: sanity
-      ansible_test_docker: true
-      ansible_test_enable_ara: false
-      ansible_test_python: 3.6
-
-- job:
-    name: ansible-test-sanity-aws-ansible-devel-python36
-    parent: unittests
-    nodeset: controller-python36
-    dependencies:
-      - name: build-ansible-collection
-        soft: true
-    pre-run: playbooks/ansible-test-base/pre.yaml
-    run: playbooks/ansible-test-base/run.yaml
-    required-projects:
-      - name: github.com/ansible/ansible
-    timeout: 3600
-    vars:
-      ansible_test_collections: true
-      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
-      ansible_test_command: sanity
-      ansible_test_docker: true
-      ansible_test_enable_ara: false
-      ansible_test_python: 3.6
-
-- job:
-    name: ansible-test-sanity-aws-ansible-2.9-python37
-    parent: unittests
-    nodeset: controller-python36
-    dependencies:
-      - name: build-ansible-collection
-        soft: true
-    pre-run: playbooks/ansible-test-base/pre.yaml
-    run: playbooks/ansible-test-base/run.yaml
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    timeout: 3600
-    vars:
-      ansible_test_collections: true
-      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
-      ansible_test_command: sanity
-      ansible_test_docker: true
-      ansible_test_enable_ara: false
-      ansible_test_python: 3.7
-
-- job:
-    name: ansible-test-sanity-aws-ansible-2.11-python37
-    parent: unittests
-    nodeset: controller-python36
-    dependencies:
-      - name: build-ansible-collection
-        soft: true
-    pre-run: playbooks/ansible-test-base/pre.yaml
-    run: playbooks/ansible-test-base/run.yaml
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.11
-    timeout: 3600
-    vars:
-      ansible_test_collections: true
-      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
-      ansible_test_command: sanity
-      ansible_test_docker: true
-      ansible_test_enable_ara: false
-      ansible_test_python: 3.7
-
-- job:
-    name: ansible-test-sanity-aws-ansible-devel-python37
-    parent: unittests
-    nodeset: controller-python36
-    dependencies:
-      - name: build-ansible-collection
-        soft: true
-    pre-run: playbooks/ansible-test-base/pre.yaml
-    run: playbooks/ansible-test-base/run.yaml
-    required-projects:
-      - name: github.com/ansible/ansible
-    timeout: 3600
-    vars:
-      ansible_test_collections: true
-      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
-      ansible_test_command: sanity
-      ansible_test_docker: true
-      ansible_test_enable_ara: false
-      ansible_test_python: 3.7
-
-- job:
-    name: ansible-test-sanity-aws-ansible-2.9-python38
-    parent: unittests
-    nodeset: controller-python36
-    dependencies:
-      - name: build-ansible-collection
-        soft: true
-    pre-run: playbooks/ansible-test-base/pre.yaml
-    run: playbooks/ansible-test-base/run.yaml
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    timeout: 3600
-    vars:
-      ansible_test_collections: true
-      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
-      ansible_test_command: sanity
-      ansible_test_docker: true
-      ansible_test_enable_ara: false
-      ansible_test_python: 3.8
-
-- job:
-    name: ansible-test-sanity-aws-ansible-2.11-python38
-    parent: unittests
-    nodeset: controller-python36
-    dependencies:
-      - name: build-ansible-collection
-        soft: true
-    pre-run: playbooks/ansible-test-base/pre.yaml
-    run: playbooks/ansible-test-base/run.yaml
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.11
-    timeout: 3600
-    vars:
-      ansible_test_collections: true
-      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
-      ansible_test_command: sanity
-      ansible_test_docker: true
-      ansible_test_enable_ara: false
-      ansible_test_python: 3.8
-
-- job:
-    name: ansible-test-sanity-aws-ansible-devel-python38
-    parent: unittests
-    nodeset: controller-python36
-    dependencies:
-      - name: build-ansible-collection
-        soft: true
-    pre-run: playbooks/ansible-test-base/pre.yaml
-    run: playbooks/ansible-test-base/run.yaml
-    required-projects:
-      - name: github.com/ansible/ansible
-    timeout: 3600
-    vars:
-      ansible_test_collections: true
-      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
-      ansible_test_command: sanity
-      ansible_test_docker: true
-      ansible_test_enable_ara: false
-      ansible_test_python: 3.8

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -344,7 +344,7 @@
 
 - job:
     name: ansible-test-sanity-aws-ansible-2.9-python36
-    parent:  unittests
+    parent: unittests
     nodeset: controller-python36
     dependencies:
       - name: build-ansible-collection
@@ -365,7 +365,7 @@
 
 - job:
     name: ansible-test-sanity-aws-ansible-2.11-python36
-    parent:  unittests
+    parent: unittests
     nodeset: controller-python36
     dependencies:
       - name: build-ansible-collection
@@ -386,7 +386,7 @@
 
 - job:
     name: ansible-test-sanity-aws-ansible-devel-python36
-    parent:  unittests
+    parent: unittests
     nodeset: controller-python36
     dependencies:
       - name: build-ansible-collection
@@ -406,7 +406,7 @@
 
 - job:
     name: ansible-test-sanity-aws-ansible-2.9-python37
-    parent:  unittests
+    parent: unittests
     nodeset: controller-python36
     dependencies:
       - name: build-ansible-collection
@@ -427,7 +427,7 @@
 
 - job:
     name: ansible-test-sanity-aws-ansible-2.11-python37
-    parent:  unittests
+    parent: unittests
     nodeset: controller-python36
     dependencies:
       - name: build-ansible-collection
@@ -448,7 +448,7 @@
 
 - job:
     name: ansible-test-sanity-aws-ansible-devel-python37
-    parent:  unittests
+    parent: unittests
     nodeset: controller-python36
     dependencies:
       - name: build-ansible-collection
@@ -468,7 +468,7 @@
 
 - job:
     name: ansible-test-sanity-aws-ansible-2.9-python38
-    parent:  unittests
+    parent: unittests
     nodeset: controller-python36
     dependencies:
       - name: build-ansible-collection
@@ -489,7 +489,7 @@
 
 - job:
     name: ansible-test-sanity-aws-ansible-2.11-python38
-    parent:  unittests
+    parent: unittests
     nodeset: controller-python36
     dependencies:
       - name: build-ansible-collection
@@ -510,7 +510,7 @@
 
 - job:
     name: ansible-test-sanity-aws-ansible-devel-python38
-    parent:  unittests
+    parent: unittests
     nodeset: controller-python36
     dependencies:
       - name: build-ansible-collection

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -339,7 +339,7 @@
 #### sanity
 - job:
     name: ansible-test-sanity-aws-ansible
-    parent: unittests
+    parent: ansible-test-sanity-docker
     nodeset: controller-python36
     dependencies:
       - name: build-ansible-collection
@@ -353,7 +353,6 @@
       ansible_test_collections: true
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
       ansible_test_command: sanity
-      ansible_test_docker: true
       ansible_test_enable_ara: false
       ansible_test_python: 3.6
 

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -335,10 +335,195 @@
     vars:
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
 
-
 ### Cloud Common
 - job:
     name: ansible-test-units-cloud-common-python38
     parent: ansible-test-units-base-python38
     vars:
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
+
+- job:
+    name: ansible-test-sanity-aws-ansible-2.9-python36
+    parent:  unittests
+    nodeset: controller-python36
+    dependencies:
+      - name: build-ansible-collection
+        soft: true
+    pre-run: playbooks/ansible-test-base/pre.yaml
+    run: playbooks/ansible-test-base/run.yaml
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
+    timeout: 3600
+    vars:
+      ansible_test_collections: true
+      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
+      ansible_test_command: sanity
+      ansible_test_docker: true
+      ansible_test_enable_ara: false
+      ansible_test_python: 3.6
+
+- job:
+    name: ansible-test-sanity-aws-ansible-2.11-python36
+    parent:  unittests
+    nodeset: controller-python36
+    dependencies:
+      - name: build-ansible-collection
+        soft: true
+    pre-run: playbooks/ansible-test-base/pre.yaml
+    run: playbooks/ansible-test-base/run.yaml
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
+    timeout: 3600
+    vars:
+      ansible_test_collections: true
+      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
+      ansible_test_command: sanity
+      ansible_test_docker: true
+      ansible_test_enable_ara: false
+      ansible_test_python: 3.6
+
+- job:
+    name: ansible-test-sanity-aws-ansible-devel-python36
+    parent:  unittests
+    nodeset: controller-python36
+    dependencies:
+      - name: build-ansible-collection
+        soft: true
+    pre-run: playbooks/ansible-test-base/pre.yaml
+    run: playbooks/ansible-test-base/run.yaml
+    required-projects:
+      - name: github.com/ansible/ansible
+    timeout: 3600
+    vars:
+      ansible_test_collections: true
+      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
+      ansible_test_command: sanity
+      ansible_test_docker: true
+      ansible_test_enable_ara: false
+      ansible_test_python: 3.6
+
+- job:
+    name: ansible-test-sanity-aws-ansible-2.9-python37
+    parent:  unittests
+    nodeset: controller-python36
+    dependencies:
+      - name: build-ansible-collection
+        soft: true
+    pre-run: playbooks/ansible-test-base/pre.yaml
+    run: playbooks/ansible-test-base/run.yaml
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
+    timeout: 3600
+    vars:
+      ansible_test_collections: true
+      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
+      ansible_test_command: sanity
+      ansible_test_docker: true
+      ansible_test_enable_ara: false
+      ansible_test_python: 3.7
+
+- job:
+    name: ansible-test-sanity-aws-ansible-2.11-python37
+    parent:  unittests
+    nodeset: controller-python36
+    dependencies:
+      - name: build-ansible-collection
+        soft: true
+    pre-run: playbooks/ansible-test-base/pre.yaml
+    run: playbooks/ansible-test-base/run.yaml
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
+    timeout: 3600
+    vars:
+      ansible_test_collections: true
+      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
+      ansible_test_command: sanity
+      ansible_test_docker: true
+      ansible_test_enable_ara: false
+      ansible_test_python: 3.7
+
+- job:
+    name: ansible-test-sanity-aws-ansible-devel-python37
+    parent:  unittests
+    nodeset: controller-python36
+    dependencies:
+      - name: build-ansible-collection
+        soft: true
+    pre-run: playbooks/ansible-test-base/pre.yaml
+    run: playbooks/ansible-test-base/run.yaml
+    required-projects:
+      - name: github.com/ansible/ansible
+    timeout: 3600
+    vars:
+      ansible_test_collections: true
+      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
+      ansible_test_command: sanity
+      ansible_test_docker: true
+      ansible_test_enable_ara: false
+      ansible_test_python: 3.7
+
+- job:
+    name: ansible-test-sanity-aws-ansible-2.9-python38
+    parent:  unittests
+    nodeset: controller-python36
+    dependencies:
+      - name: build-ansible-collection
+        soft: true
+    pre-run: playbooks/ansible-test-base/pre.yaml
+    run: playbooks/ansible-test-base/run.yaml
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
+    timeout: 3600
+    vars:
+      ansible_test_collections: true
+      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
+      ansible_test_command: sanity
+      ansible_test_docker: true
+      ansible_test_enable_ara: false
+      ansible_test_python: 3.8
+
+- job:
+    name: ansible-test-sanity-aws-ansible-2.11-python38
+    parent:  unittests
+    nodeset: controller-python36
+    dependencies:
+      - name: build-ansible-collection
+        soft: true
+    pre-run: playbooks/ansible-test-base/pre.yaml
+    run: playbooks/ansible-test-base/run.yaml
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
+    timeout: 3600
+    vars:
+      ansible_test_collections: true
+      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
+      ansible_test_command: sanity
+      ansible_test_docker: true
+      ansible_test_enable_ara: false
+      ansible_test_python: 3.8
+
+- job:
+    name: ansible-test-sanity-aws-ansible-devel-python38
+    parent:  unittests
+    nodeset: controller-python36
+    dependencies:
+      - name: build-ansible-collection
+        soft: true
+    pre-run: playbooks/ansible-test-base/pre.yaml
+    run: playbooks/ansible-test-base/run.yaml
+    required-projects:
+      - name: github.com/ansible/ansible
+    timeout: 3600
+    vars:
+      ansible_test_collections: true
+      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
+      ansible_test_command: sanity
+      ansible_test_docker: true
+      ansible_test_enable_ara: false
+      ansible_test_python: 3.8

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -63,10 +63,15 @@
     name: ansible-collections-amazon-aws
     check:
       jobs:
-        - ansible-test-sanity-docker
-        - ansible-test-sanity-docker-stable-2.9
-        - ansible-test-sanity-docker-stable-2.10
-        - ansible-test-sanity-docker-stable-2.11
+        - ansible-test-sanity-aws-ansible-2.9-python36
+        - ansible-test-sanity-aws-ansible-2.9-python37
+        - ansible-test-sanity-aws-ansible-2.9-python38
+        - ansible-test-sanity-aws-ansible-2.11-python36
+        - ansible-test-sanity-aws-ansible-2.11-python37
+        - ansible-test-sanity-aws-ansible-2.11-python38
+        - ansible-test-sanity-aws-ansible-devel-python36
+        - ansible-test-sanity-aws-ansible-devel-python37
+        - ansible-test-sanity-aws-ansible-devel-python38
         - ansible-test-units-amazon-aws-python38
         - build-ansible-collection:
             required-projects:
@@ -76,10 +81,15 @@
         - ansible-test-cloud-integration-aws-py36
     gate:
       jobs:
-        - ansible-test-sanity-docker
-        - ansible-test-sanity-docker-stable-2.9
-        - ansible-test-sanity-docker-stable-2.10
-        - ansible-test-sanity-docker-stable-2.11
+        - ansible-test-sanity-aws-ansible-2.9-python36
+        - ansible-test-sanity-aws-ansible-2.9-python37
+        - ansible-test-sanity-aws-ansible-2.9-python38
+        - ansible-test-sanity-aws-ansible-2.11-python36
+        - ansible-test-sanity-aws-ansible-2.11-python37
+        - ansible-test-sanity-aws-ansible-2.11-python38
+        - ansible-test-sanity-aws-ansible-devel-python36
+        - ansible-test-sanity-aws-ansible-devel-python37
+        - ansible-test-sanity-aws-ansible-devel-python38
         - ansible-test-units-amazon-aws-python38
         - build-ansible-collection:
             required-projects:


### PR DESCRIPTION
We're dropping python2 support in the next collection release, for both collections