### PR TITLE
Allow all jobs to use zuul-output/logs directory

### DIFF
--- a/playbooks/ansible-network-appliance-base/post.yaml
+++ b/playbooks/ansible-network-appliance-base/post.yaml
@@ -17,13 +17,3 @@
       always:
         - name: Copy ARA sqlite database
           shell: "cp {{ ansible_user_dir }}/.ara/ansible.sqlite {{ ansible_user_dir }}/zuul-output/logs/controller/ara-report"
-
-        # TODO: Migrate to fetch-zuul-logs when
-        # https://review.openstack.org/#/c/583346/ is merged.
-        - name: Collect log output
-          no_log: true
-          synchronize:
-            dest: "{{ zuul.executor.log_root }}/"
-            mode: pull
-            src: "{{ ansible_user_dir }}/zuul-output/logs/"
-            verify_host: true

--- a/playbooks/ansible-test-integration-base/post.yaml
+++ b/playbooks/ansible-test-integration-base/post.yaml
@@ -5,14 +5,3 @@
       file:
         path: "{{ ansible_user_dir }}/zuul-output/logs/controller/ara-report"
         state: directory
-
-
-    # TODO: Migrate to fetch-zuul-logs when
-    # https://review.openstack.org/#/c/583346/ is merged.
-    - name: Collect log output
-      no_log: true
-      synchronize:
-        dest: "{{ zuul.executor.log_root }}/"
-        mode: pull
-        src: "{{ ansible_user_dir }}/zuul-output/logs/"
-        verify_host: true

--- a/playbooks/ansible-test-units-base/post.yaml
+++ b/playbooks/ansible-test-units-base/post.yaml
@@ -34,15 +34,3 @@
 
     - name: Copy the coverage report
       shell: "cp -rfa {{ test_location }}/tests/output/reports/coverage {{ ansible_user_dir }}/zuul-output/logs/controller/"
-
-
-    # TODO: Migrate to fetch-zuul-logs when
-    # https://review.openstack.org/#/c/583346/ is merged.
-
-    - name: Collect log output
-      no_log: true
-      synchronize:
-        dest: "{{ zuul.executor.log_root }}/"
-        mode: pull
-        src: "{{ ansible_user_dir }}/zuul-output/logs/"
-        verify_host: true

--- a/playbooks/base/post.yaml
+++ b/playbooks/base/post.yaml
@@ -1,0 +1,10 @@
+---
+- hosts: all:!appliance*
+  tasks:
+    - name: Collect log output
+      no_log: true
+      synchronize:
+        dest: "{{ zuul.executor.log_root }}/"
+        mode: pull
+        src: "{{ ansible_user_dir }}/zuul-output/logs/"
+        verify_host: true

--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -24,3 +24,8 @@
     - name: Run configure-mirrors-fork role
       include_role:
         name: configure-mirrors-fork
+
+    - name: Ensure zuul-output folder exists
+      file:
+        path: "{{ ansible_user_dir }}/zuul-output/logs/"
+        state: directory

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -7,6 +7,7 @@
     description: |
       The base job for the Ansible installation of Zuul.
     pre-run: playbooks/base/pre.yaml
+    post-run: playbooks/base/post.yaml
 
 - job:
     name: github-workflows


### PR DESCRIPTION
When a job places files into ~/zuul-output/logs directory, we'll sync
them back and publish them. This will help users debug failures.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>