### PR TITLE
Cap jinja2 version to 3.0.0

### DIFF
--- a/playbooks/ansible-test-base/pre.yaml
+++ b/playbooks/ansible-test-base/pre.yaml
@@ -63,7 +63,7 @@
       # TODO(pabelanger): Remove ANSIBLE_SKIP_CONFLICT_CHECK in the future.
       environment:
         ANSIBLE_SKIP_CONFLICT_CHECK: 1
-      shell: "~/venv/bin/pip install {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
+      shell: "~/venv/bin/pip install {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }} 'jinja2<3.0.0'"
 
     # NOTE(pabelanger): For integration jobs, install collections after our
     # appliance is configured. This stops pre-merged code from failing


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gosriniv@redhat.com>


With the release of jinja2 3.0.0, pip install of packages failed, due to incompatibility.

Capping it to < 3.0.0 version, resolves the conflicts.

```
ERROR: aiohttp-swagger 1.0.15 has requirement jinja2~=2.11.2, but you'll have jinja2 3.0.0 which is incompatible.
ERROR: aiohttp-swagger 1.0.15 has requirement markupsafe~=1.1.1, but you'll have markupsafe 2.0.0 which is incompatible.
ERROR: pyats-log 21.4 has requirement Jinja2==2.11.3, but you'll have jinja2 3.0.0 which is incompatible.
ERROR: pyats-utils 21.4 has requirement cryptography<=3.3.1, but you'll have cryptography 3.4.7 which is incompatible.

```
