### PR TITLE
a-t-c-i-vmware-rest-python36: increase timeout

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -256,6 +256,7 @@
       ansible_test_command: network-integration
       ansible_test_integration_targets: "zuul/"
       ansible_test_collections: true
+    timeout: 3600
     semaphore: ansible-test-cloud-integration-vmware-rest
 
 - job:


### PR DESCRIPTION
Bump the timeout to 1h.

Note. the job is slightly slower because of https://github.com/ansible/ansible-zuul-jobs/commit/178e9779bb8d1345afc5311bee9acf3603259ed5