### PR TITLE
community-okd: fix the k8s.core version

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -548,7 +548,8 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/kubernetes.core
-                override-checkout: stable-2.9
+                override-checkout: stable-1.2
+
 - project-template:
     name: ansible-collections-cloud-common
     check:


### PR DESCRIPTION
The stable branch is `stable-1.2`.