### PR TITLE
ignore ansible-galaxy-importer in some cases

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -103,6 +103,8 @@
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/community.general
         - ansible-test-cloud-integration-aws-py36
+        - ansible-galaxy-importer:
+            voting: false
     gate:
       jobs:
         - ansible-test-sanity-docker
@@ -116,6 +118,8 @@
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/community.general
         - ansible-test-cloud-integration-aws-py36
+        - ansible-galaxy-importer:
+            voting: false
 
 - project-template:
     name: ansible-collections-arista-eos-units
@@ -549,6 +553,8 @@
             required-projects:
               - name: github.com/ansible-collections/kubernetes.core
                 override-checkout: stable-1.2
+        - ansible-galaxy-importer:
+            voting: false
 
 - project-template:
     name: ansible-collections-cloud-common


### PR DESCRIPTION
Ignore `ansible-galaxy-importer` for:

- community.aws
- community.okd

See: https://github.com/ansible/ansible-zuul-jobs/issues/934