### PR TITLE
ansible_test_changed: compare with origin/$branch

### DIFF
--- a/roles/ansible-test/tasks/ansible_test_changed.yaml
+++ b/roles/ansible-test/tasks/ansible_test_changed.yaml
@@ -4,7 +4,7 @@
     chdir: "{{ ansible_test_location }}"
     executable: /bin/bash
   shell: |
-    for i in $(git diff {{ zuul.branch }} --name-only|egrep '^plugins/.*.py'|xargs -r basename -s .py) $(git diff {{ zuul.branch }} --name-only|sed -n 's#tests/integration/targets/\(.*\)/.*#\1#p'); do
+    for i in $(git diff origin/{{ zuul.branch }} --name-only|egrep '^plugins/.*.py'|xargs -r basename -s .py) $(git diff origin/{{ zuul.branch }} --name-only|sed -n 's#tests/integration/targets/\(.*\)/.*#\1#p'); do
       test -f tests/integration/targets/${i}/aliases || continue
       echo ${i}
     done


### PR DESCRIPTION
Fix a regression introduced by #898. The local `zuul.branch` is actually
the branch that Zuul uses to test our PR. What we acutally want to do
is to test against origin/$branch which is the original branch.