### PR TITLE
use a role to call ansible-galaxy-exporter

### DIFF
--- a/playbooks/ansible-galaxy-importer/pre.yaml
+++ b/playbooks/ansible-galaxy-importer/pre.yaml
@@ -4,18 +4,3 @@
     - name: Setup ensure-tox role
       include_role:
         name: ensure-tox
-
-    - name: Setup tox role
-      include_role:
-        name: tox
-      vars:
-        tox_envlist: venv
-        tox_extra_args: -vv --notest
-        tox_install_siblings: false
-        zuul_work_dir: "{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"
-
-    - name: Fetch and install the artifacts
-      import_role:
-        name: deploy-artifacts
-      vars:
-        deploy_artifacts_venv_path: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv"

--- a/playbooks/ansible-galaxy-importer/run.yaml
+++ b/playbooks/ansible-galaxy-importer/run.yaml
@@ -1,13 +1,5 @@
 ---
 - hosts: all
   tasks:
-    - name: Generate version number for ansible collection
-      args:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
-      shell: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv/bin/python -W ignore {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv/bin/generate-ansible-collection"
-      register: _version
-
-    - name: Confirm collection can be imported into galaxy
-      args:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"
-      shell: "source .tox/venv/bin/activate; ./tools/validate-collection.sh {{ ansible_user_dir }}/downloads/{{ _version.stdout }}"
+    - import_role:
+        name: ansible_galaxy_importer

--- a/roles/ansible_galaxy_importer/defaults/main.yaml
+++ b/roles/ansible_galaxy_importer/defaults/main.yaml
@@ -1,0 +1,5 @@
+---
+# Absolute path pointing on a local copy of releases.git
+ansible_galaxy_importer_releases_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"
+# Absolute path pointing on a copy of the collection to test
+ansible_galaxy_importer_collection_dir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"

--- a/roles/ansible_galaxy_importer/tasks/main.yaml
+++ b/roles/ansible_galaxy_importer/tasks/main.yaml
@@ -1,0 +1,12 @@
+---
+- import_tasks: prepare_venv.yaml
+- name: Generate version number for ansible collection
+  args:
+    chdir: "{{ ansible_galaxy_importer_collection_dir }}"
+  shell: "{{ ansible_galaxy_importer_releases_dir }}/.tox/venv/bin/python -W ignore {{ ansible_galaxy_importer_releases_dir }}/.tox/venv/bin/generate-ansible-collection"
+  register: _version
+
+- name: Confirm collection can be imported into galaxy
+  args:
+    chdir: "{{ ansible_galaxy_importer_releases_dir }}"
+  shell: "source .tox/venv/bin/activate; ./tools/validate-collection.sh {{ ansible_user_dir }}/downloads/{{ _version.stdout }}"

--- a/roles/ansible_galaxy_importer/tasks/prepare_venv.yaml
+++ b/roles/ansible_galaxy_importer/tasks/prepare_venv.yaml
@@ -1,0 +1,15 @@
+---
+- name: Setup tox role
+  include_role:
+    name: tox
+  vars:
+    tox_envlist: venv
+    tox_extra_args: -vv --notest
+    tox_install_siblings: false
+    zuul_work_dir: "{{ ansible_galaxy_importer_releases_dir }}"
+
+- name: Fetch and install the artifacts
+  import_role:
+    name: deploy-artifacts
+  vars:
+    deploy_artifacts_venv_path: "{{ ansible_galaxy_importer_releases_dir }}/.tox/venv"


### PR DESCRIPTION
Isolate the logic of `ansible-galaxy-exporter`. There is still
some strong dependencies with Zuul in the `prepare_venv.yaml` play.