### PR TITLE
add --requirements for units testing on cloud.common

### DIFF
--- a/roles/ansible-test/defaults/main.yaml
+++ b/roles/ansible-test/defaults/main.yaml
@@ -25,3 +25,4 @@ ansible_test_network_cli_ssh_type: paramiko
 ansible_test_changed: false
 ansible_test_base_branch: main
 ansible_test_verbosity: "-vvvv"
+ansible_test_requirements: false

--- a/roles/ansible-test/tasks/init_test_options.yaml
+++ b/roles/ansible-test/tasks/init_test_options.yaml
@@ -22,7 +22,7 @@
 - name: Enable --requirements
   set_fact:
     ansible_test_options: "{{ ansible_test_options }} --requirements"
-  when: not ansible_test_collections
+  when: not ansible_test_collections or ansible_test_requirements
 
 - name: Enable coverage commands for unit tests
   set_fact:

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -429,3 +429,4 @@
     parent: ansible-test-units-base-python38
     vars:
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
+      ansible_test_collections: false

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -429,4 +429,4 @@
     parent: ansible-test-units-base-python38
     vars:
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
-      ansible_test_collections: false
+      ansible_test_requirements: true


### PR DESCRIPTION
Seems that unit tests are failling for cloud.common

command: ``ansible-test units --coverage --python 3.8 -vvvv``

output

```
No module named 'pytest'
Command exited with status 1 after 0.22428584098815918 seconds.
ERROR: Command "pytest --boxed -r a -n auto --color no -p no:cacheprovider -c /home/zuul/venv/lib/python3.8/site-packages/ansible_test/_data/pytest.ini --junit-xml /home/zuul/.ansible/collections/ansible_collections/cloud/common/tests/output/junit/python3.8-units.xml --strict-markers -vvvv tests/unit/module_utils/test_turbo_module.py" returned exit status 1.
Cleaning up temporary python directory: /tmp/python-yk5tjmj5-ansible
```