### PR TITLE
AWS: drop the py37 jobs

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -376,30 +376,6 @@
     parent: ansible-test-sanity-aws-ansible
 
 - job:
-    name: ansible-test-sanity-aws-ansible-2.9-python37
-    parent: ansible-test-sanity-aws-ansible
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    vars:
-      ansible_test_python: 3.7
-
-- job:
-    name: ansible-test-sanity-aws-ansible-2.11-python37
-    parent: ansible-test-sanity-aws-ansible
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.11
-    vars:
-      ansible_test_python: 3.7
-
-- job:
-    name: ansible-test-sanity-aws-ansible-devel-python37
-    parent: ansible-test-sanity-aws-ansible
-    vars:
-      ansible_test_python: 3.7
-
-- job:
     name: ansible-test-sanity-aws-ansible-2.9-python38
     parent: ansible-test-sanity-aws-ansible
     required-projects:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -64,13 +64,10 @@
     check:
       jobs:
         - ansible-test-sanity-aws-ansible-2.9-python36
-        - ansible-test-sanity-aws-ansible-2.9-python37
         - ansible-test-sanity-aws-ansible-2.9-python38
         - ansible-test-sanity-aws-ansible-2.11-python36
-        - ansible-test-sanity-aws-ansible-2.11-python37
         - ansible-test-sanity-aws-ansible-2.11-python38
         - ansible-test-sanity-aws-ansible-devel-python36
-        - ansible-test-sanity-aws-ansible-devel-python37
         - ansible-test-sanity-aws-ansible-devel-python38
         - ansible-test-units-amazon-aws-python38
         - build-ansible-collection:
@@ -82,13 +79,10 @@
     gate:
       jobs:
         - ansible-test-sanity-aws-ansible-2.9-python36
-        - ansible-test-sanity-aws-ansible-2.9-python37
         - ansible-test-sanity-aws-ansible-2.9-python38
         - ansible-test-sanity-aws-ansible-2.11-python36
-        - ansible-test-sanity-aws-ansible-2.11-python37
         - ansible-test-sanity-aws-ansible-2.11-python38
         - ansible-test-sanity-aws-ansible-devel-python36
-        - ansible-test-sanity-aws-ansible-devel-python37
         - ansible-test-sanity-aws-ansible-devel-python38
         - ansible-test-units-amazon-aws-python38
         - build-ansible-collection:


### PR DESCRIPTION
They are built on top of ansible-test-sanity-aws-ansible which itself
use centos8. The CentOS8 image does not provide python37 by default.