### PR TITLE
ansible-test-sanity-aws-ansible: avoid dup playbook calls

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -345,8 +345,6 @@
     dependencies:
       - name: build-ansible-collection
         soft: true
-    pre-run: playbooks/ansible-test-base/pre.yaml
-    run: playbooks/ansible-test-base/run.yaml
     required-projects:
       - name: github.com/ansible/ansible
     timeout: 3600


### PR DESCRIPTION
ansible-test-sanity-docker aleady import these playbooks. If we declare
them a second time, we rerun same, which leads to the situation when
we download a second time the artifcats and get an HTTP 304 instead of 200.