### PR TITLE
Revert "download-artifact-fork: accept err 304 too (#949)"

### DIFF
--- a/roles/download-artifact-fork/tasks/main.yaml
+++ b/roles/download-artifact-fork/tasks/main.yaml
@@ -32,6 +32,6 @@
     loop_var: artifact
   register: _result
   retries: 5
-  until: _result.status in [200, 304]
+  until: _result.status == 200
   delay: 5
   when: "'metadata' in artifact and 'type' in artifact.metadata and (artifact.metadata.type == download_artifact_type or ((download_artifact_type | type_debug) == 'list' and artifact.metadata.type in download_artifact_type))"


### PR DESCRIPTION
This reverts commit 18d027afc97c54899c9d6ce87e2c688f3fc8da41.

https://github.com/ansible/ansible-zuul-jobs/pull/953 was the right fix.