### PR TITLE
don't update vcsa

### DIFF
--- a/playbooks/ansible-cloud/vcenter-appliance/pre.yaml
+++ b/playbooks/ansible-cloud/vcenter-appliance/pre.yaml
@@ -38,9 +38,6 @@
       become: true
     - import_role:
         name: vmware-ci-memory-configuration
-    - name: Update the VCSA packages
-      command: tdnf update -y
-      become: true
 
 - hosts: all
   gather_facts: false


### PR DESCRIPTION
Follow up to a recent Photon Linux update, the REST interface is broken.
We disable the update until we've got a better fix.

See: https://github.com/ansible-collections/community.vmware/issues/875