### PR TITLE
Split AWS integration jobs

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -323,6 +323,25 @@
       ansible_test_enable_ara: false
       ansible_test_python: 3.6
       ansible_test_changed: true
+      ansible_test_split_in: 3
+
+- job:
+    name: ansible-test-cloud-integration-aws-py36_1_of_3
+    parent: ansible-test-cloud-integration-aws-py36
+    vars:
+      ansible_test_do_number: 1
+
+- job:
+    name: ansible-test-cloud-integration-aws-py36_2_of_3
+    parent: ansible-test-cloud-integration-aws-py36
+    vars:
+      ansible_test_do_number: 2
+
+- job:
+    name: ansible-test-cloud-integration-aws-py36_3_of_3
+    parent: ansible-test-cloud-integration-aws-py36
+    vars:
+      ansible_test_do_number: 3
 
 #### units
 - job:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -75,7 +75,6 @@
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/community.aws
               - name: github.com/ansible-collections/community.general
-        - ansible-test-cloud-integration-aws-py36
         - ansible-test-cloud-integration-aws-py36_1_of_3
         - ansible-test-cloud-integration-aws-py36_2_of_3
         - ansible-test-cloud-integration-aws-py36_3_of_3
@@ -93,7 +92,6 @@
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/community.aws
               - name: github.com/ansible-collections/community.general
-        - ansible-test-cloud-integration-aws-py36
         - ansible-test-cloud-integration-aws-py36_1_of_3
         - ansible-test-cloud-integration-aws-py36_2_of_3
         - ansible-test-cloud-integration-aws-py36_3_of_3
@@ -112,7 +110,6 @@
               - name: github.com/ansible-collections/amazon.aws
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/community.general
-        - ansible-test-cloud-integration-aws-py36
         - ansible-test-cloud-integration-aws-py36_1_of_3
         - ansible-test-cloud-integration-aws-py36_2_of_3
         - ansible-test-cloud-integration-aws-py36_3_of_3
@@ -130,7 +127,6 @@
               - name: github.com/ansible-collections/amazon.aws
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/community.general
-        - ansible-test-cloud-integration-aws-py36
         - ansible-test-cloud-integration-aws-py36_1_of_3
         - ansible-test-cloud-integration-aws-py36_2_of_3
         - ansible-test-cloud-integration-aws-py36_3_of_3

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -76,6 +76,9 @@
               - name: github.com/ansible-collections/community.aws
               - name: github.com/ansible-collections/community.general
         - ansible-test-cloud-integration-aws-py36
+        - ansible-test-cloud-integration-aws-py36_1_of_3
+        - ansible-test-cloud-integration-aws-py36_2_of_3
+        - ansible-test-cloud-integration-aws-py36_3_of_3
     gate:
       jobs:
         - ansible-test-sanity-aws-ansible-2.9-python36
@@ -91,6 +94,9 @@
               - name: github.com/ansible-collections/community.aws
               - name: github.com/ansible-collections/community.general
         - ansible-test-cloud-integration-aws-py36
+        - ansible-test-cloud-integration-aws-py36_1_of_3
+        - ansible-test-cloud-integration-aws-py36_2_of_3
+        - ansible-test-cloud-integration-aws-py36_3_of_3
 
 - project-template:
     name: ansible-collections-community-aws
@@ -107,6 +113,9 @@
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/community.general
         - ansible-test-cloud-integration-aws-py36
+        - ansible-test-cloud-integration-aws-py36_1_of_3
+        - ansible-test-cloud-integration-aws-py36_2_of_3
+        - ansible-test-cloud-integration-aws-py36_3_of_3
         - ansible-galaxy-importer:
             voting: false
     gate:
@@ -122,6 +131,9 @@
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/community.general
         - ansible-test-cloud-integration-aws-py36
+        - ansible-test-cloud-integration-aws-py36_1_of_3
+        - ansible-test-cloud-integration-aws-py36_2_of_3
+        - ansible-test-cloud-integration-aws-py36_3_of_3
         - ansible-galaxy-importer:
             voting: false
 


### PR DESCRIPTION
With shippable we used 4 statically defined groups as some tests were known to take significantly longer than others.  Try splitting them automagically.