### PR TITLE
vmware: prepare a NFS share for content library

### DIFF
--- a/playbooks/ansible-cloud/vcenter-appliance/pre.yaml
+++ b/playbooks/ansible-cloud/vcenter-appliance/pre.yaml
@@ -120,7 +120,7 @@
           import_role:
             name: vmware-ci-nfs-share
           vars:
-            vmware_ci_nfs_share_allow_ips: "{{ groups['esxis'] | map('extract', hostvars, ['nodepool'])|map(attribute='interface_ip')|list }}"
+            vmware_ci_nfs_share_allow_ips: "{{ groups['all'] | map('extract', hostvars, ['ansible_host'])|list }}"
 
     # NOTE: We don't need that for vmware_rest
     - name: Write the configuration for ansible-test

--- a/roles/vmware-ci-nfs-share/defaults/main.yaml
+++ b/roles/vmware-ci-nfs-share/defaults/main.yaml
@@ -1,6 +1,7 @@
 ---
 vmware_ci_nfs_share_allowed_ips: []
 vmware_ci_nfs_share_owner_uid: '1000'
+vmware_ci_nfs_share_content_library_uid: '1006'
 vmware_ci_nfs_share_owner_gid: '1000'
 vmware_ci_nfs_share_iso_files:
     fedora.iso:

--- a/roles/vmware-ci-nfs-share/tasks/main.yaml
+++ b/roles/vmware-ci-nfs-share/tasks/main.yaml
@@ -10,6 +10,14 @@
     - /srv/share/isos
   become: true
 
+- name: Prepare the content-library share
+  file:
+    path: /srv/share/content-library
+    state: directory
+    owner: '{{ vmware_ci_nfs_share_content_library_uid }}'
+    group: '{{ vmware_ci_nfs_share_owner_gid }}'
+  become: true
+
 - name: Download ISO
   get_url:
     url: '{{ item.value.url }}'

--- a/roles/vmware-ci-nfs-share/templates/exports.j2
+++ b/roles/vmware-ci-nfs-share/templates/exports.j2
@@ -1,3 +1,5 @@
 /srv/share/isos {% for allowed_ip in vmware_ci_nfs_share_allow_ips -%}{{ allowed_ip }}(ro,anonuid={{ vmware_ci_nfs_share_owner_uid }},anongid={{ vmware_ci_nfs_share_owner_gid }}) {% endfor %}
 
 /srv/share/vms {% for allowed_ip in vmware_ci_nfs_share_allow_ips -%}{{ allowed_ip }}(rw,anonuid={{ vmware_ci_nfs_share_owner_uid }},anongid={{ vmware_ci_nfs_share_owner_gid }}) {% endfor %}
+
+/srv/share/content-library {% for allowed_ip in vmware_ci_nfs_share_allow_ips -%}{{ allowed_ip }}(rw,anonuid={{ vmware_ci_nfs_share_content_library_uid }},anongid={{ vmware_ci_nfs_share_owner_gid }}) {% endfor %}


### PR DESCRIPTION
Content Library needs a NFS with a different UID (1006) and the
vCenter should be able to mount it.