### PR TITLE
don't fail if WARNING ansible-test --list in output

### DIFF
--- a/roles/ansible-test/tasks/split_targets.yaml
+++ b/roles/ansible-test/tasks/split_targets.yaml
@@ -6,6 +6,7 @@
   environment: "{{ ansible_test_environment | default({}) }}"
   shell: "source {{ ansible_test_venv_path }}/bin/activate; {{ ansible_test_executable }} {{ ansible_test_test_command }} {{ ansible_test_options }} --list {{ ansible_test_integration_targets }} 2>&1|grep -v WARNING"
   register: ansible_test_targets
+  failed_when: ansible_test_targets.rc not in [0, 1]
 - set_fact:
     number_entries: "{{ ansible_test_targets.stdout_lines|length }}"
 - set_fact:


### PR DESCRIPTION
We may get some warning in `ansible-test --list` output, for instance if
a test is not supported. This is fine and we should ignore the error code.

Thanks Daniil Kupchenko.