### PR TITLE
Don't configure-swap by default

### DIFF
--- a/playbooks/base/pre.yaml
+++ b/playbooks/base/pre.yaml
@@ -17,10 +17,6 @@
 
 - hosts: all:!appliance*
   tasks:
-    - name: Run configure-swap role
-      include_role:
-        name: configure-swap
-
     - name: Run configure-mirrors-fork role
       include_role:
         name: configure-mirrors-fork


### PR DESCRIPTION
This may cause some jobs to start failing, but in general all other jobs
will be faster.

This means, the jobs that need the extra buffer will opt into using this
role in a pre-run playbook.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>