### PR TITLE
Remove ansible_connection variables

### DIFF
--- a/zuul.d/ansible-security-jobs.yaml
+++ b/zuul.d/ansible-security-jobs.yaml
@@ -7,7 +7,6 @@
     run: playbooks/ansible-security-splunk-appliance/run.yaml
     host-vars:
       SplunkEnterprise-SES-8.0.0:
-        ansible_connection: network_cli
         ansible_network_os: splunk
         ansible_python_interpreter: python
     required-projects:
@@ -63,7 +62,6 @@
     run: playbooks/ansible-security-qradar-appliance/run.yaml
     host-vars:
       QRadarCE-7.3.1:
-        ansible_connection: network_cli
         ansible_network_os: qradar
         ansible_python_interpreter: python
     required-projects:

--- a/zuul.d/arista-eos-jobs.yaml
+++ b/zuul.d/arista-eos-jobs.yaml
@@ -8,7 +8,6 @@
     run: playbooks/ansible-network-eos-appliance/run.yaml
     host-vars:
       eos-4.20.10:
-        ansible_connection: network_cli
         ansible_network_os: eos
         ansible_python_interpreter: python
     required-projects:

--- a/zuul.d/cisco-asa-jobs.yaml
+++ b/zuul.d/cisco-asa-jobs.yaml
@@ -8,7 +8,6 @@
     run: playbooks/ansible-network-asa-appliance/run.yaml
     host-vars:
       asav9-12-3:
-        ansible_connection: network_cli
         ansible_network_os: asa
         ansible_python_interpreter: python
     required-projects:

--- a/zuul.d/cisco-ios-jobs.yaml
+++ b/zuul.d/cisco-ios-jobs.yaml
@@ -8,7 +8,6 @@
     run: playbooks/ansible-network-ios-appliance/run.yaml
     host-vars:
       ios-15.6-2T:
-        ansible_connection: network_cli
         ansible_network_os: ios
         ansible_python_interpreter: python
     required-projects:

--- a/zuul.d/cisco-iosxr-jobs.yaml
+++ b/zuul.d/cisco-iosxr-jobs.yaml
@@ -8,7 +8,6 @@
     run: playbooks/ansible-network-iosxr-appliance/run.yaml
     host-vars:
       iosxr-7.0.2:
-        ansible_connection: network_cli
         ansible_network_os: iosxr
         ansible_python_interpreter: python
     required-projects:

--- a/zuul.d/cisco-nxos-jobs.yaml
+++ b/zuul.d/cisco-nxos-jobs.yaml
@@ -8,7 +8,6 @@
     run: playbooks/ansible-network-nxos-appliance/run.yaml
     host-vars:
       nxos-7.0.3:
-        ansible_connection: network_cli
         ansible_network_os: nxos
         ansible_python_interpreter: python
     required-projects:

--- a/zuul.d/junipernetworks-junos-jobs.yaml
+++ b/zuul.d/junipernetworks-junos-jobs.yaml
@@ -14,7 +14,6 @@
     parent: ansible-network-junos-appliance
     host-vars:
       vsrx3-18.4R1:
-        ansible_connection: network_cli
         ansible_network_os: junos
         ansible_python_interpreter: python
     nodeset: vsrx3-18.4R1-python36
@@ -24,7 +23,6 @@
     parent: ansible-network-junos-appliance
     host-vars:
       vqfx-18.1R3:
-        ansible_connection: network_cli
         ansible_network_os: junos
         ansible_python_interpreter: python
     nodeset: vqfx-18.1R3-python36

--- a/zuul.d/vyos-vyos-jobs.yaml
+++ b/zuul.d/vyos-vyos-jobs.yaml
@@ -8,7 +8,6 @@
     run: playbooks/ansible-network-vyos-appliance/run.yaml
     host-vars:
       vyos-1.1.8:
-        ansible_connection: network_cli
         ansible_network_os: vyos
         ansible_python_interpreter: python
     required-projects:


### PR DESCRIPTION
We cannot use these variables in zuul any more.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>