### PR TITLE
Remove ansible_* variables

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -11,7 +11,6 @@
     # value to pass the ansible-network playbooks
     host-vars:
       vcenter:
-        ansible_python_interpreter: python
         ansible_network_os: vmware_rest
       esxi1:
         ansible_network_os: vmware_rest
@@ -142,7 +141,6 @@
     # value to pass the ansible-network playbooks
     host-vars:
       vcenter:
-        ansible_python_interpreter: python
         ansible_network_os: vmware_rest
       esxi1:
         ansible_network_os: vmware_rest
@@ -223,7 +221,6 @@
     # value to pass the ansible-network playbooks
     host-vars:
       vcenter:
-        ansible_python_interpreter: python
         ansible_network_os: vmware_rest
       esxi1:
         ansible_network_os: vmware_rest

--- a/zuul.d/ansible-security-jobs.yaml
+++ b/zuul.d/ansible-security-jobs.yaml
@@ -7,9 +7,7 @@
     run: playbooks/ansible-security-splunk-appliance/run.yaml
     host-vars:
       SplunkEnterprise-SES-8.0.0:
-        ansible_connection: network_cli
         ansible_network_os: splunk
-        ansible_python_interpreter: python
     required-projects:
       - name: github.com/ansible/ansible-zuul-jobs
     nodeset: SplunkEnterprise-SES-8.0.0-python38
@@ -63,9 +61,7 @@
     run: playbooks/ansible-security-qradar-appliance/run.yaml
     host-vars:
       QRadarCE-7.3.1:
-        ansible_connection: network_cli
         ansible_network_os: qradar
-        ansible_python_interpreter: python
     required-projects:
       - name: github.com/ansible/ansible-zuul-jobs
     nodeset: QRadarCE-7.3.1-python38
@@ -120,7 +116,6 @@
     host-vars:
       Trendmicro-DeepSecurity-20.0.344:
         ansible_network_os: trendmicro.deepsec.deepsec
-        ansible_python_interpreter: python
     required-projects:
       - name: github.com/ansible/ansible-zuul-jobs
     nodeset: Trendmicro-DeepSecurity-20.0.344-python38

--- a/zuul.d/arista-eos-jobs.yaml
+++ b/zuul.d/arista-eos-jobs.yaml
@@ -8,9 +8,7 @@
     run: playbooks/ansible-network-eos-appliance/run.yaml
     host-vars:
       eos-4.20.10:
-        ansible_connection: network_cli
         ansible_network_os: eos
-        ansible_python_interpreter: python
     required-projects:
       - name: github.com/ansible/ansible-zuul-jobs
     nodeset: eos-4.20.10-python36

--- a/zuul.d/cisco-asa-jobs.yaml
+++ b/zuul.d/cisco-asa-jobs.yaml
@@ -8,9 +8,7 @@
     run: playbooks/ansible-network-asa-appliance/run.yaml
     host-vars:
       asav9-12-3:
-        ansible_connection: network_cli
         ansible_network_os: asa
-        ansible_python_interpreter: python
     required-projects:
       - name: github.com/ansible/ansible-zuul-jobs
     nodeset: asav9-12-3-python36

--- a/zuul.d/cisco-ios-jobs.yaml
+++ b/zuul.d/cisco-ios-jobs.yaml
@@ -8,9 +8,7 @@
     run: playbooks/ansible-network-ios-appliance/run.yaml
     host-vars:
       ios-15.6-2T:
-        ansible_connection: network_cli
         ansible_network_os: ios
-        ansible_python_interpreter: python
     required-projects:
       - name: github.com/ansible/ansible-zuul-jobs
     nodeset: ios-15.6-2T-python36

--- a/zuul.d/cisco-iosxr-jobs.yaml
+++ b/zuul.d/cisco-iosxr-jobs.yaml
@@ -8,9 +8,7 @@
     run: playbooks/ansible-network-iosxr-appliance/run.yaml
     host-vars:
       iosxr-7.0.2:
-        ansible_connection: network_cli
         ansible_network_os: iosxr
-        ansible_python_interpreter: python
     required-projects:
       - name: github.com/ansible/ansible-zuul-jobs
     nodeset: iosxr-7.0.2-python36

--- a/zuul.d/cisco-nxos-jobs.yaml
+++ b/zuul.d/cisco-nxos-jobs.yaml
@@ -8,9 +8,7 @@
     run: playbooks/ansible-network-nxos-appliance/run.yaml
     host-vars:
       nxos-7.0.3:
-        ansible_connection: network_cli
         ansible_network_os: nxos
-        ansible_python_interpreter: python
     required-projects:
       - name: github.com/ansible/ansible-zuul-jobs
     nodeset: nxos-7.0.3-python36

--- a/zuul.d/junipernetworks-junos-jobs.yaml
+++ b/zuul.d/junipernetworks-junos-jobs.yaml
@@ -14,9 +14,7 @@
     parent: ansible-network-junos-appliance
     host-vars:
       vsrx3-18.4R1:
-        ansible_connection: network_cli
         ansible_network_os: junos
-        ansible_python_interpreter: python
     nodeset: vsrx3-18.4R1-python36
 
 - job:
@@ -24,9 +22,7 @@
     parent: ansible-network-junos-appliance
     host-vars:
       vqfx-18.1R3:
-        ansible_connection: network_cli
         ansible_network_os: junos
-        ansible_python_interpreter: python
     nodeset: vqfx-18.1R3-python36
 
 - job:

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -17,6 +17,7 @@
               - playbooks/ansible-network-appliance-base/.*
               - playbooks/ansible-network-ios-appliance/.*
         - ansible-network-iosxr-appliance:
+            voting: false
             files:
               - playbooks/ansible-network-appliance-base/.*
               - playbooks/ansible-network-iosxr-appliance/.*
@@ -82,10 +83,6 @@
             files:
               - playbooks/ansible-network-appliance-base/.*
               - playbooks/ansible-network-ios-appliance/.*
-        - ansible-network-iosxr-appliance:
-            files:
-              - playbooks/ansible-network-appliance-base/.*
-              - playbooks/ansible-network-iosxr-appliance/.*
         - ansible-network-junos-vsrx-appliance:
             files:
               - playbooks/ansible-network-appliance-base/.*

--- a/zuul.d/vyos-vyos-jobs.yaml
+++ b/zuul.d/vyos-vyos-jobs.yaml
@@ -8,9 +8,7 @@
     run: playbooks/ansible-network-vyos-appliance/run.yaml
     host-vars:
       vyos-1.1.8:
-        ansible_connection: network_cli
         ansible_network_os: vyos
-        ansible_python_interpreter: python
     required-projects:
       - name: github.com/ansible/ansible-zuul-jobs
     nodeset: vyos-1.1.8-python36


### PR DESCRIPTION
We cannot use these variables in zuul any more. Jobs should find another
way to set them up.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>