### PR TITLE
ansible-test/split_targets: improve the start/end computation

### DIFF
--- a/roles/ansible-test/tasks/split_targets.yaml
+++ b/roles/ansible-test/tasks/split_targets.yaml
@@ -10,8 +10,11 @@
 - set_fact:
     number_entries: "{{ ansible_test_targets.stdout_lines|length }}"
 - set_fact:
-    _start_at: "{{ number_entries|int // ansible_test_split_in * (ansible_test_do_number -1)|int }}"
-    _end_at: "{{ (number_entries|int // ansible_test_split_in * (ansible_test_do_number |int)) }}"
+    _iter_by: "{{ (number_entries|int / ansible_test_split_in)|round(0, 'ceil')|int }}"
+- set_fact:
+    _start_at: "{{ (_iter_by|int * ansible_test_do_number|int) - _iter_by|int }}"
+- set_fact:
+    _end_at: "{{ _start_at|int + _iter_by|int }}"
 # Slow tests tend to be closely related.  Hash the names to produce a repeatable
 # list that avoids bringing those tests all into one group
 - set_fact:


### PR DESCRIPTION
Simplify the logic and correctly compute the end of the first job
in case the number of targets is lower than `ansible_test_split_in`.