### PR TITLE
aws: increase the job timeout

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -315,7 +315,7 @@
     # post-run: playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
-    timeout: 3600
+    timeout: 10800
     vars:
       ansible_test_collections: true
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"


### PR DESCRIPTION
Bump from 3600 to 10800s. We've got some rather slow test targets that we
plan to split up. For now, we just increase the timeout to avoid the
situation where the CI starts to shoot jobs that are mostly done.