### PR TITLE
fix: correct computation for range end has been added

### DIFF
--- a/roles/ansible-test/tasks/split_targets.yaml
+++ b/roles/ansible-test/tasks/split_targets.yaml
@@ -9,12 +9,6 @@
   failed_when: ansible_test_targets.rc not in [0, 1]
 - set_fact:
     number_entries: "{{ ansible_test_targets.stdout_lines|length }}"
-- set_fact:
-    _iter_by: "{{ (number_entries|int / ansible_test_split_in)|round(0, 'ceil')|int }}"
-- set_fact:
-    _start_at: "{{ (_iter_by|int * ansible_test_do_number|int) - _iter_by|int }}"
-- set_fact:
-    _end_at: "{{ _start_at|int + _iter_by|int - 1 if ansible_test_do_number|int != ansible_test_split_in else number_entries|int - 1 }}"
 # Slow tests tend to be closely related.  Hash the names to produce a repeatable
 # list that avoids bringing those tests all into one group
 - set_fact:
@@ -22,7 +16,12 @@
   loop: '{{ ansible_test_targets.stdout_lines }}'
 - set_fact:
     sorted_test_targets: "{{ _hashed_targets | sort(attribute='hash') | map(attribute='name') | list }}"
+# Distribute test targets evenly between workers
 - set_fact:
-    _integration_targets: "{{ sorted_test_targets[_start_at|int:_end_at|int]|sort|join(' ') }}"
+    targets_to_test: "{{ targets_to_test | default([]) + [ sorted_test_targets[item] ] }}"
+  when: item % ansible_test_split_in == ansible_test_do_number|int - 1
+  loop: "{{ range(0,number_entries|int)|list }}"
+- set_fact:
+    _integration_targets: "{{ targets_to_test | join(' ') }}"
 - debug:
-    msg: "Do roles: {{ _integration_targets }}"
+    msg: "Do roles: '{{ _integration_targets }}'"

--- a/roles/ansible-test/tasks/split_targets.yaml
+++ b/roles/ansible-test/tasks/split_targets.yaml
@@ -14,7 +14,7 @@
 - set_fact:
     _start_at: "{{ (_iter_by|int * ansible_test_do_number|int) - _iter_by|int }}"
 - set_fact:
-    _end_at: "{{ _start_at|int + _iter_by|int }}"
+    _end_at: "{{ _start_at|int + _iter_by|int - 1 if ansible_test_do_number|int != ansible_test_split_in else number_entries - 1 }}"
 # Slow tests tend to be closely related.  Hash the names to produce a repeatable
 # list that avoids bringing those tests all into one group
 - set_fact:

--- a/roles/ansible-test/tasks/split_targets.yaml
+++ b/roles/ansible-test/tasks/split_targets.yaml
@@ -22,6 +22,6 @@
   when: item % ansible_test_split_in == ansible_test_do_number|int - 1
   loop: "{{ range(0,number_entries|int)|list }}"
 - set_fact:
-    _integration_targets: "{{ targets_to_test | join(' ') }}"
+    _integration_targets: "{{ targets_to_test | default([]) | join(' ') }}"
 - debug:
     msg: "Do roles: '{{ _integration_targets }}'"

--- a/roles/ansible-test/tasks/split_targets.yaml
+++ b/roles/ansible-test/tasks/split_targets.yaml
@@ -14,7 +14,7 @@
 - set_fact:
     _start_at: "{{ (_iter_by|int * ansible_test_do_number|int) - _iter_by|int }}"
 - set_fact:
-    _end_at: "{{ _start_at|int + _iter_by|int - 1 if ansible_test_do_number|int != ansible_test_split_in else number_entries - 1 }}"
+    _end_at: "{{ _start_at|int + _iter_by|int - 1 if ansible_test_do_number|int != ansible_test_split_in else number_entries|int - 1 }}"
 # Slow tests tend to be closely related.  Hash the names to produce a repeatable
 # list that avoids bringing those tests all into one group
 - set_fact:


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/977

playbook:
```
---
- hosts: localhost
  vars:
    ansible_test_split_in: 3
    number_entries: 10
  tasks:
    - set_fact:  
        _iter_by: "{{ (number_entries|int / ansible_test_split_in)|round(0, 'ceil')|int }}"
    - set_fact:
        _start_at: "{{ (_iter_by|int * ansible_test_do_number|int) - _iter_by|int }}"
    - set_fact:
        _end_at: "{{ _start_at|int + _iter_by|int }}"
    - debug:
        msg: "iter: {{ _iter_by }}, start: {{ _start_at }}, end: {{ _end_at }}"
```
produces:
```
➭ for i in {1..3}; do ansible-playbook a.yaml -e ansible_test_do_number=$i 2>&1; done | grep iter
iter: 4, start: 0, end: 4
iter: 4, start: 4, end: 8
iter: 4, start: 8, end: 12

```
and with the fix:
```
➭ for i in {1..3}; do ansible-playbook a.yaml -e ansible_test_do_number=$i 2>&1; done | grep iter
iter: 4, start: 0, end: 3
iter: 4, start: 4, end: 7
iter: 4, start: 8, end: 9
```