### PR TITLE
ansible-test: address two corner cases

### DIFF
--- a/roles/ansible-test/tasks/ansible_test_changed.yaml
+++ b/roles/ansible-test/tasks/ansible_test_changed.yaml
@@ -10,4 +10,4 @@
     done
   register: _result
 - set_fact:
-    ansible_test_integration_targets: "{{ _result.stdout_lines|join(' ') }}"
+    ansible_test_integration_targets: "{{ _result.stdout_lines|unique|join(' ') }}"

--- a/roles/ansible-test/tasks/split_targets.yaml
+++ b/roles/ansible-test/tasks/split_targets.yaml
@@ -1,4 +1,6 @@
 ---
+- set_fact:
+    _hashed_targets: []
 - name: List the targets
   args:
     chdir: "{{ _test_location }}"
@@ -18,7 +20,7 @@
 # Slow tests tend to be closely related.  Hash the names to produce a repeatable
 # list that avoids bringing those tests all into one group
 - set_fact:
-    _hashed_targets: "{{ ( _hashed_targets | default([])) + [ { 'name': item, 'hash': (item | hash('md5')) } ] }}"
+    _hashed_targets: "{{ _hashed_targets + [ { 'name': item, 'hash': (item | hash('md5')) } ] }}"
   loop: '{{ ansible_test_targets.stdout_lines }}'
 - set_fact:
     sorted_test_targets: "{{ _hashed_targets | sort(attribute='hash') | map(attribute='name') | list }}"


### PR DESCRIPTION
- ansible_test_changed: ensure we don't get dup in the output
- split_targets: _hashed_targets should be define even if
  ansible_test_targets.stoud_lines is empty.