### PR TITLE
cloud: replace CentOS8 with Fedora34

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -301,7 +301,7 @@
 - job:
     name: ansible-test-splitter
     run: playbooks/ansible-test-splitter/run.yaml
-    nodeset: controller-python36
+    nodeset: controller-python36-f34
     required-projects:
       - name: github.com/ansible/ansible
     timeout: 1000
@@ -318,7 +318,7 @@
 - job:
     name: ansible-test-cloud-integration-aws-py36
     parent: ansible-core-ci-aws-session
-    nodeset: controller-python36
+    nodeset: controller-python36-f34
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
@@ -416,7 +416,7 @@
 - job:
     name: ansible-test-sanity-aws-ansible
     parent: ansible-test-sanity-docker
-    nodeset: controller-python36
+    nodeset: controller-python36-f34
     dependencies:
       - name: build-ansible-collection
         soft: true

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -20,8 +20,8 @@
 - nodeset:
     name: fedora-latest-1vcpu
     nodes:
-      - name: fedora-32
-        label: fedora-32-1vcpu
+      - name: fedora-34
+        label: fedora-34-1vcpu
 
 - nodeset:
     name: ubuntu-bionic-1vcpu
@@ -51,19 +51,19 @@
 - nodeset:
     name: vmware-govcsim-python36
     nodes:
-      - name: centos-8
-        label: centos-8-1vcpu
+      - name: fedora-34
+        label: fedora-34-1vcpu
     groups:
       - name: controller
         nodes:
-          - centos-8
+          - fedora-34
 
 # vcenter 7.0.2
 - nodeset:
     name: vmware-vcsa-7.0.2-python36
     nodes:
-      - name: centos-8
-        label: centos-8-1vcpu
+      - name: fedora-34
+        label: fedora-34-1vcpu
       - name: vcenter
         label: vmware-vcsa-7.0.2
     groups:
@@ -72,13 +72,13 @@
           - vcenter
       - name: controller
         nodes:
-          - centos-8
+          - fedora-34
 
 - nodeset:
     name: vmware-vcsa_1esxi-7.0.2-python36
     nodes:
-      - name: centos-8
-        label: centos-8-1vcpu
+      - name: fedora-34
+        label: fedora-34-1vcpu
       - name: vcenter
         label: vmware-vcsa-7.0.2
       - name: esxi1
@@ -95,13 +95,13 @@
           - esxi1
       - name: controller
         nodes:
-          - centos-8
+          - fedora-34
 
 - nodeset:
     name: vmware-vcsa_2esxi-7.0.2-python36
     nodes:
-      - name: centos-8
-        label: centos-8-1vcpu
+      - name: fedora-34
+        label: fedora-34-1vcpu
       - name: vcenter
         label: vmware-vcsa-7.0.2
       - name: esxi1
@@ -122,7 +122,7 @@
           - esxi2
       - name: controller
         nodes:
-          - centos-8
+          - fedora-34
 
 # Ansible network appliance nodesets
 - nodeset:
@@ -862,6 +862,16 @@
       - name: controller
         nodes:
           - ubuntu-bionic
+
+- nodeset:
+    name: controller-python36-f34
+    nodes:
+      - name: fedora-34
+        label: fedora-34-1vcpu
+    groups:
+      - name: controller
+        nodes:
+          - fedora-34
 
 # Ansible Security appliance nodesets
 - nodeset:


### PR DESCRIPTION
The initial goal was  to speed up the update of the controller node during the
deployment. We can also benefit from the large collection of Python
releases that come by default with Fedora 34.