### PR TITLE
c.vmware: turns govcsim non-voting for now

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -513,9 +513,12 @@
     name: ansible-collections-community-vmware
     check:
       jobs:
-        - ansible-test-cloud-integration-govcsim-python36_1_of_3
-        - ansible-test-cloud-integration-govcsim-python36_2_of_3
-        - ansible-test-cloud-integration-govcsim-python36_3_of_3
+        - ansible-test-cloud-integration-govcsim-python36_1_of_3:
+            voting: false
+        - ansible-test-cloud-integration-govcsim-python36_2_of_3:
+            voting: false
+        - ansible-test-cloud-integration-govcsim-python36_3_of_3:
+            voting: false
         - ansible-tox-linters
         - build-ansible-collection
         - ansible-test-sanity-docker
@@ -531,9 +534,12 @@
         - ansible-test-cloud-integration-vcenter7_2esxi-python36-stable210
     gate:
       jobs:
-        - ansible-test-cloud-integration-govcsim-python36_1_of_3
-        - ansible-test-cloud-integration-govcsim-python36_2_of_3
-        - ansible-test-cloud-integration-govcsim-python36_3_of_3
+        - ansible-test-cloud-integration-govcsim-python36_1_of_3:
+            voting: false
+        - ansible-test-cloud-integration-govcsim-python36_2_of_3:
+            voting: false
+        - ansible-test-cloud-integration-govcsim-python36_3_of_3:
+            voting: false
         - ansible-tox-linters
         - build-ansible-collection
         - ansible-test-sanity-docker


### PR DESCRIPTION
We've got a race condition with the way we start `govcsim`. We often
hit the situation where the tests run before the service is listening.

For instance:

```
    "delta": "0:00:00.015379",
    "end": "2021-07-12 10:27:35.978867",
    "invocation": {
        "module_args": {
            "_raw_params": "systemd-run --unit=ansible-vmware-govcsim --remain-after-exit /usr/local/bin/vcsim -l 127.0.0.1:443 -app=0 -cluster=1 -dc=1 -ds=2 -folder=1 -host=3 -pg=1 -pod=1 -pool=1 -vm=2",
            "_uses_shell": false,
            "argv": null,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "stdin_add_newline": true,
            "strip_empty_ends": true,
            "warn": false
        }
    },
    "msg": "",
    "rc": 0,
    "start": "2021-07-12 10:27:35.963488",
    "stderr": "Running as unit: ansible-vmware-govcsim.service",
    "stderr_lines": [
        "Running as unit: ansible-vmware-govcsim.service"
    ],
    "stdout": "",
    "stdout_lines": []
}
2021-07-12 10:27:36.018559 | fedora-34 |
TASK [prepare_vmware_tests : set_fact] *****************************************
task path: /home/zuul/.ansible/collections/ansible_collections/community/vmware/tests/integration/targets/prepare_vmware_tests/tasks/init_vcsim_with_systemd.yml:20
ok: [testhost] => {
    "ansible_facts": {
        "vcenter_hostname": "localhost",
        "vcenter_password": "pass",
        "vcenter_port": 443,
        "vcenter_username": "user"
    },
    "changed": false
}
2021-07-12 10:27:36.038674 | fedora-34 |
TASK [prepare_vmware_tests : set state to poweroff on all VMs] *****************
task path: /home/zuul/.ansible/collections/ansible_collections/community/vmware/tests/integration/targets/prepare_vmware_tests/tasks/init_vcsim_with_systemd.yml:26
<testhost> ESTABLISH LOCAL CONNECTION FOR USER: zuul
<testhost> EXEC /bin/sh -c 'echo ~zuul && sleep 0'
<testhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/zuul/.ansible/tmp `"&& mkdir "` echo /home/zuul/.ansible/tmp/ansible-tmp-1626085656.076887-4085-95741640426473 `" && echo ansible-tmp-1626085656.076887-4085-95741640426473="` echo /home/zuul/.ansible/tmp/ansible-tmp-1626085656.076887-4085-95741640426473 `" ) && sleep 0'
Using module file /home/zuul/.ansible/collections/ansible_collections/community/vmware/plugins/modules/vmware_guest.py
<testhost> PUT /home/zuul/.ansible/tmp/ansible-local-39311a0bfy8w/tmpllo1sosw TO /home/zuul/.ansible/tmp/ansible-tmp-1626085656.076887-4085-95741640426473/AnsiballZ_vmware_guest.py
<testhost> EXEC /bin/sh -c 'chmod u+x /home/zuul/.ansible/tmp/ansible-tmp-1626085656.076887-4085-95741640426473/ /home/zuul/.ansible/tmp/ansible-tmp-1626085656.076887-4085-95741640426473/AnsiballZ_vmware_guest.py && sleep 0'
<testhost> EXEC /bin/sh -c '/home/zuul/venv/bin/python /home/zuul/.ansible/tmp/ansible-tmp-1626085656.076887-4085-95741640426473/AnsiballZ_vmware_guest.py && sleep 0'
<testhost> EXEC /bin/sh -c 'rm -f -r /home/zuul/.ansible/tmp/ansible-tmp-1626085656.076887-4085-95741640426473/ > /dev/null 2>&1 && sleep 0'
<testhost> EXEC /bin/sh -c 'echo ~zuul && sleep 0'
The full traceback is:
  File "/tmp/ansible_vmware_guest_payload_32h_w406/ansible_vmware_guest_payload.zip/ansible_collections/community/vmware/plugins/module_utils/vmware.py", line 748, in connect_to_api
    service_instance = connect.SmartConnect(**connect_args)
  File "/home/zuul/venv/lib/python3.6/site-packages/pyVim/connect.py", line 850, in SmartConnect
    sslContext)
  File "/home/zuul/venv/lib/python3.6/site-packages/pyVim/connect.py", line 724, in __FindSupportedVersion
    httpProxyPort)
  File "/home/zuul/venv/lib/python3.6/site-packages/pyVim/connect.py", line 641, in __GetServiceVersionDescription
    httpProxyHost, httpProxyPort)
  File "/home/zuul/venv/lib/python3.6/site-packages/pyVim/connect.py", line 606, in __GetElementTree
    conn.request("GET", path)
  File "/usr/lib64/python3.6/http/client.py", line 1291, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/lib64/python3.6/http/client.py", line 1337, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/lib64/python3.6/http/client.py", line 1286, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/lib64/python3.6/http/client.py", line 1046, in _send_output
    self.send(msg)
  File "/usr/lib64/python3.6/http/client.py", line 984, in send
    self.connect()
  File "/usr/lib64/python3.6/http/client.py", line 1444, in connect
    super().connect()
  File "/usr/lib64/python3.6/http/client.py", line 956, in connect
    (self.host,self.port), self.timeout, self.source_address)
  File "/usr/lib64/python3.6/socket.py", line 724, in create_connection
    raise err
  File "/usr/lib64/python3.6/socket.py", line 713, in create_connection
    sock.connect(sa)
failed: [testhost] (item={'name': 'DC0_H0_VM0', 'folder': '/F0/DC0/vm/F0'}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "invocation": {
        "module_args": {
            "advanced_settings": [],
            "annotation": null,
            "cdrom": [],
            "cluster": null,
            "convert": null,
            "customization": {
                "autologon": null,
                "autologoncount": null,
                "dns_servers": null,
                "dns_suffix": null,
                "domain": null,
                "domainadmin": null,
                "domainadminpassword": null,
                "existing_vm": null,
                "fullname": null,
                "hostname": null,
                "hwclockUTC": null,
                "joindomain": null,
                "joinworkgroup": null,
                "orgname": null,
                "password": null,
                "productid": null,
                "runonce": null,
                "timezone": null
            },
            "customization_spec": null,
            "customvalues": [],
            "datacenter": "ha-datacenter",
            "datastore": null,
            "delete_from_inventory": false,
            "disk": [],
            "esxi_hostname": null,
            "folder": null,
            "force": false,
            "guest_id": null,
            "hardware": {
                "boot_firmware": null,
                "cpu_limit": null,
                "cpu_reservation": null,
                "hotadd_cpu": null,
                "hotadd_memory": null,
                "hotremove_cpu": null,
                "iommu": null,
                "max_connections": null,
                "mem_limit": null,
                "mem_reservation": null,
                "memory_mb": null,
                "memory_reservation_lock": null,
                "nested_virt": null,
                "num_cpu_cores_per_socket": null,
                "num_cpus": null,
                "scsi": null,
                "secure_boot": null,
                "version": null,
                "virt_based_security": null
            },
            "hostname": "localhost",
            "is_template": false,
            "linked_clone": false,
            "name": "DC0_H0_VM0",
            "name_match": "first",
            "networks": [],
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 443,
            "proxy_host": null,
            "proxy_port": null,
            "resource_pool": null,
            "snapshot_src": null,
            "state": "poweredoff",
            "state_change_timeout": 0,
            "template": null,
            "use_instance_uuid": false,
            "username": "user",
            "uuid": null,
            "validate_certs": false,
            "vapp_properties": [],
            "wait_for_customization": false,
            "wait_for_customization_timeout": 3600,
            "wait_for_ip_address": false,
            "wait_for_ip_address_timeout": 300
        }
    },
    "item": {
        "folder": "/F0/DC0/vm/F0",
        "name": "DC0_H0_VM0"
    },
    "msg": "Unknown error while connecting to vCenter or ESXi API at localhost:443 : [Errno 111] Connection refused"
}
```