### PR TITLE
Move ansible-test-network-integration to silent pipeline

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1087,7 +1087,7 @@
         - ansible-test-network-integration-vyos-python37:
             branches:
               - stable-2.9
-    third-party-check:
+    third-party-check-silent:
       jobs:
         - ansible-test-network-integration-eos-python27:
             branches:


### PR DESCRIPTION
This should cut down on the merge failure messages.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>