### PR TITLE
c.vmware: functional test on ansible 2.11

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -123,84 +123,48 @@
       esxi2:
         ansible_network_os: vmware_rest
 
-# stable29
+# stable211
 - job:
-    name: ansible-test-cloud-integration-vcenter7_only-python36-stable29
+    name: ansible-test-cloud-integration-vcenter7_only-python36-stable211
     parent: ansible-test-cloud-integration-vcenter7_only-python36
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
+        override-checkout: stable-2.11
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable29
+    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211
     parent: ansible-test-cloud-integration-vcenter7_1esxi-python36
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
+        override-checkout: stable-2.11
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable29
+    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_1_of_2
     parent: ansible-test-cloud-integration-vcenter7_1esxi-python36
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-
-- job:
-    name: ansible-test-cloud-integration-vcenter7_2esxi-python36-stable29
-    parent: ansible-test-cloud-integration-vcenter7_2esxi-python36
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-
-# stable210
-- job:
-    name: ansible-test-cloud-integration-vcenter7_only-python36-stable210
-    parent: ansible-test-cloud-integration-vcenter7_only-python36
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-
-- job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable210
-    parent: ansible-test-cloud-integration-vcenter7_1esxi-python36
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-
-- job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable210
-    parent: ansible-test-cloud-integration-vcenter7_1esxi-python36
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-
-- job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable210_1_of_2
-    parent: ansible-test-cloud-integration-vcenter7_1esxi-python36
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
+        override-checkout: stable-2.11
     vars:
       ansible_test_split_in: 2
       ansible_test_do_number: 1
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable210_2_of_2
+    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_2_of_2
     parent: ansible-test-cloud-integration-vcenter7_1esxi-python36
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
+        override-checkout: stable-2.11
     vars:
       ansible_test_split_in: 2
       ansible_test_do_number: 2
 
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_2esxi-python36-stable210
+    name: ansible-test-cloud-integration-vcenter7_2esxi-python36-stable211
     parent: ansible-test-cloud-integration-vcenter7_2esxi-python36
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
+        override-checkout: stable-2.11
 
 
 ####################### vmware.vmware-rest #####################

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -529,10 +529,10 @@
         - ansible-test-units-community-vmware-python36
         - ansible-test-units-community-vmware-python37
         - ansible-test-units-community-vmware-python38
-        - ansible-test-cloud-integration-vcenter7_only-python36-stable210
-        - ansible-test-cloud-integration-vcenter7_2esxi-python36-stable210
-        - ansible-test-cloud-integration-vcenter7_1esxi-python36-stable210_1_of_2
-        - ansible-test-cloud-integration-vcenter7_1esxi-python36-stable210_2_of_2
+        - ansible-test-cloud-integration-vcenter7_only-python36-stable211
+        - ansible-test-cloud-integration-vcenter7_2esxi-python36-stable211
+        - ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_1_of_2
+        - ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_2_of_2
     gate:
       jobs:
         - ansible-test-cloud-integration-govcsim-python36_1_of_3:


### PR DESCRIPTION
Moving to ansible 2.11 by default. This is the current stable release.