### PR TITLE
Add test command specific pip requirements/constraints

### DIFF
--- a/roles/ansible-test/defaults/main.yaml
+++ b/roles/ansible-test/defaults/main.yaml
@@ -25,3 +25,5 @@ ansible_test_network_cli_ssh_type: paramiko
 ansible_test_changed: false
 ansible_test_base_branch: main
 ansible_test_verbosity: "-vvvv"
+ansible_test_requirement_files: ['requirements.txt', 'test-requirements.txt']
+ansible_test_constraint_files: []

--- a/roles/ansible-test/tasks/init_collection.yaml
+++ b/roles/ansible-test/tasks/init_collection.yaml
@@ -4,8 +4,36 @@
     _test_location: "{{ ansible_test_collection_dir }}/{{ ansible_test_collection_namespace }}/{{ ansible_test_collection_name }}"
     _test_cfg_location: "{{ ansible_test_collection_dir }}/{{ ansible_test_collection_namespace }}/{{ ansible_test_collection_name }}/tests/integration/{{ ansible_test_test_command }}.cfg"
 
+- name: Setup minimum test requirements
+  set_fact:
+    _test_requirements: '-r {{ _test_location }}/requirements.txt -r {{ _test_location }}/test-requirements.txt'
+
+- name: Check for existence of test command specific requirements/constraints
+  when: ansible_test_test_command in _file_locations
+  vars:
+    _file_locations:
+      integration: '{{ _test_location }}/tests/integration'
+      units: '{{ _test_location }}/tests/unit'
+  block:
+    - name: Check for test command constraints file
+      stat:
+        path: '{{ _file_locations[ansible_test_test_command] }}/constraints.txt'
+      register: _extra_constraints_stat
+    - name: Check for test command requirements file
+      stat:
+        path: '{{ _file_locations[ansible_test_test_command] }}/requirements.txt'
+      register: _extra_requirements_stat
+    - name: Add extra constraints.txt
+      when: _extra_constraints_stat.stat.exists
+      set_fact:
+        _test_requirements: '{{_test_requirements}} -c {{ _file_locations[ansible_test_test_command] }}/constraints.txt'
+    - name: Add extra requirements.txt
+      when: _extra_requirements_stat.stat.exists
+      set_fact:
+        _test_requirements: '{{_test_requirements}} -r {{ _file_locations[ansible_test_test_command] }}/requirements.txt'
+
 - name: Install python requirements
-  shell: "{{ ansible_test_venv_path }}/bin/pip install -r {{ _test_location }}/requirements.txt -r {{ _test_location }}/test-requirements.txt"
+  shell: "{{ ansible_test_venv_path }}/bin/pip install {{ _test_requirements }}"
 
 - name: Copy potential cloud provider configuration for ansible-test in the collection
   shell: "cp -v {{ ansible_test_ansible_path }}/test/integration/cloud-config-*.ini {{ _test_location }}/tests/integration/"

--- a/roles/ansible-test/tasks/init_collection.yaml
+++ b/roles/ansible-test/tasks/init_collection.yaml
@@ -6,34 +6,11 @@
 
 - name: Setup minimum test requirements
   set_fact:
-    _test_requirements: '-r {{ _test_location }}/requirements.txt -r {{ _test_location }}/test-requirements.txt'
-
-- name: Check for existence of test command specific requirements/constraints
-  when: ansible_test_test_command in _file_locations
-  vars:
-    _file_locations:
-      integration: '{{ _test_location }}/tests/integration'
-      units: '{{ _test_location }}/tests/unit'
-  block:
-    - name: Check for test command constraints file
-      stat:
-        path: '{{ _file_locations[ansible_test_test_command] }}/constraints.txt'
-      register: _extra_constraints_stat
-    - name: Check for test command requirements file
-      stat:
-        path: '{{ _file_locations[ansible_test_test_command] }}/requirements.txt'
-      register: _extra_requirements_stat
-    - name: Add extra constraints.txt
-      when: _extra_constraints_stat.stat.exists
-      set_fact:
-        _test_requirements: '{{_test_requirements}} -c {{ _file_locations[ansible_test_test_command] }}/constraints.txt'
-    - name: Add extra requirements.txt
-      when: _extra_requirements_stat.stat.exists
-      set_fact:
-        _test_requirements: '{{_test_requirements}} -r {{ _file_locations[ansible_test_test_command] }}/requirements.txt'
+    _test_requirements: '{% for requirement in ansible_test_requirement_files %} -r {{ _test_location }}/{{ requirement }}{% endfor %}'
+    _test_constraints: '{% for constraint in ansible_test_constraint_files %} -c {{ _test_location }}/{{ constraint }}{% endfor %}'
 
 - name: Install python requirements
-  shell: "{{ ansible_test_venv_path }}/bin/pip install {{ _test_requirements }}"
+  shell: "{{ ansible_test_venv_path }}/bin/pip install {{ _test_requirements }} {{ _test_constraints }}"
 
 - name: Copy potential cloud provider configuration for ansible-test in the collection
   shell: "cp -v {{ ansible_test_ansible_path }}/test/integration/cloud-config-*.ini {{ _test_location }}/tests/integration/"

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -305,6 +305,14 @@
       ansible_test_enable_ara: false
       ansible_test_python: 3.6
       ansible_test_retry_on_error: true
+      ansible_test_requirement_files:
+        - requirements.txt
+        - test-requirements.txt
+        # Ansible-test picks up requirements and constraints from
+        # tests/integration when running in docker, mirror this
+        - tests/integration/requirements.txt
+      ansible_test_constraint_files:
+        - tests/integration/constraints.txt
     semaphore: ansible-test-cloud-integration-aws
 
 - job:
@@ -344,17 +352,24 @@
       ansible_test_integration_targets: "{{ child.targets_to_test[5]|join(' ') }}"
 
 #### units
-- job:
-    name: ansible-test-units-community-aws-python38
-    parent: ansible-test-units-base-python38
-    vars:
-      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
 
 - job:
     name: ansible-test-units-amazon-aws-python38
     parent: ansible-test-units-base-python38
     vars:
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
+      ansible_test_requirement_files:
+        - requirements.txt
+        - test-requirements.txt
+        # Ansible-test picks up requirements and constraints from
+        # tests/unit when running in docker, mirror this
+        - tests/unit/requirements.txt
+      ansible_test_constraint_files:
+        - tests/unit/constraints.txt
+
+- job:
+    name: ansible-test-units-community-aws-python38
+    parent: ansible-test-units-amazon-aws-python38
 
 #### sanity
 - job:


### PR DESCRIPTION
Ansible-test normally pulls in test-command specific python requirements.  This means that we can do things like forcing an old version of boto3/botocore during tests to ensure unsupported API calls are tested for.

Depends-On: https://github.com/ansible-collections/amazon.aws/pull/404
Depends-On: https://github.com/ansible-collections/community.aws/pull/644