### PR TITLE
vmware: partial rollback to esxi 6.7.0

### DIFF
--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -82,7 +82,7 @@
       - name: vcenter
         label: vmware-vcsa-7.0.2
       - name: esxi1
-        label: esxi-7.0.2
+        label: esxi-6.7.0
     groups:
       - name: appliance-ssh
         nodes:


### PR DESCRIPTION
Rollback to ESXi 6.7.0 until we figure out how to address the stability problem with 7.0.2.

See: https://github.com/ansible-collections/community.vmware/pull/969