### PR TITLE
aws/sanity switch back on centos8

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -376,7 +376,7 @@
 - job:
     name: ansible-test-sanity-aws-ansible
     parent: ansible-test-sanity-docker
-    nodeset: controller-python36-f34
+    nodeset: controller-python36
     dependencies:
       - name: build-ansible-collection
         soft: true


### PR DESCRIPTION
ansible-test fails to spawn the pytest container since the 2021-07-18.
This seems to be a Fedora-only problem.

e.g: https://72f8f0edfedb3b3ea8a3-8026faeb25346531e26ef4572169216e.ssl.cf2.rackcdn.com/411/05255539ddf938691dd3c511c4077b326138de65/check/ansible-test-sanity-aws-ansible-devel-python38/704abad/job-output.txt