### PR TITLE
Make eos jobs as non voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -191,37 +191,37 @@
     name: ansible-collections-arista-eos
     check:
       jobs: &ansible-collections-arista-eos-jobs
-        - ansible-test-network-integration-eos-httpapi-python27-stable211
+        - ansible-test-network-integration-eos-httpapi-python27-stable211:
             voting: false 
-        - ansible-test-network-integration-eos-httpapi-python27-stable29
+        - ansible-test-network-integration-eos-httpapi-python27-stable29:
             voting: false
-        - ansible-test-network-integration-eos-network_cli-python27-stable211-scenario01
+        - ansible-test-network-integration-eos-network_cli-python27-stable211-scenario01:
             voting: false
-        - ansible-test-network-integration-eos-network_cli-python27-stable211-scenario02
+        - ansible-test-network-integration-eos-network_cli-python27-stable211-scenario02:
             voting: false
-        - ansible-test-network-integration-eos-network_cli-python27-stable29
+        - ansible-test-network-integration-eos-network_cli-python27-stable29:
             voting: false
-        - ansible-test-network-integration-eos-httpapi-python36
+        - ansible-test-network-integration-eos-httpapi-python36:
             voting: false
-        - ansible-test-network-integration-eos-httpapi-python36-stable211
+        - ansible-test-network-integration-eos-httpapi-python36-stable211:
             voting: false
-        - ansible-test-network-integration-eos-httpapi-python36-stable29
+        - ansible-test-network-integration-eos-httpapi-python36-stable29:
             voting: false
-        - ansible-test-network-integration-eos-network_cli-python36
+        - ansible-test-network-integration-eos-network_cli-python36:
             voting: false
-        - ansible-test-network-integration-eos-network_cli-python36-stable211-scenario01
+        - ansible-test-network-integration-eos-network_cli-python36-stable211-scenario01:
             voting: false
-        - ansible-test-network-integration-eos-network_cli-python36-stable211-scenario02
+        - ansible-test-network-integration-eos-network_cli-python36-stable211-scenario02:
             voting: false
-        - ansible-test-network-integration-eos-network_cli-python36-stable29
+        - ansible-test-network-integration-eos-network_cli-python36-stable29:
             voting: false
-        - ansible-test-network-integration-eos-network_cli-libssh-python36
+        - ansible-test-network-integration-eos-network_cli-libssh-python36:
             voting: false
-        - ansible-test-network-integration-eos-network_cli-libssh-python36-stable211-scenario01
+        - ansible-test-network-integration-eos-network_cli-libssh-python36-stable211-scenario01:
             voting: false
-        - ansible-test-network-integration-eos-network_cli-libssh-python36-stable211-scenario02
+        - ansible-test-network-integration-eos-network_cli-libssh-python36-stable211-scenario02:
             voting: false
-        - ansible-test-network-integration-eos-network_cli-libssh-python36-stable29
+        - ansible-test-network-integration-eos-network_cli-libssh-python36-stable29:
             voting: false
         - build-ansible-collection:
             required-projects:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -192,28 +192,48 @@
     check:
       jobs: &ansible-collections-arista-eos-jobs
         - ansible-test-network-integration-eos-httpapi-python27-stable211
+            voting: false 
         - ansible-test-network-integration-eos-httpapi-python27-stable29
+            voting: false
         - ansible-test-network-integration-eos-network_cli-python27-stable211-scenario01
+            voting: false
         - ansible-test-network-integration-eos-network_cli-python27-stable211-scenario02
+            voting: false
         - ansible-test-network-integration-eos-network_cli-python27-stable29
+            voting: false
         - ansible-test-network-integration-eos-httpapi-python36
+            voting: false
         - ansible-test-network-integration-eos-httpapi-python36-stable211
+            voting: false
         - ansible-test-network-integration-eos-httpapi-python36-stable29
+            voting: false
         - ansible-test-network-integration-eos-network_cli-python36
+            voting: false
         - ansible-test-network-integration-eos-network_cli-python36-stable211-scenario01
+            voting: false
         - ansible-test-network-integration-eos-network_cli-python36-stable211-scenario02
+            voting: false
         - ansible-test-network-integration-eos-network_cli-python36-stable29
+            voting: false
         - ansible-test-network-integration-eos-network_cli-libssh-python36
+            voting: false
         - ansible-test-network-integration-eos-network_cli-libssh-python36-stable211-scenario01
+            voting: false
         - ansible-test-network-integration-eos-network_cli-libssh-python36-stable211-scenario02
+            voting: false
         - ansible-test-network-integration-eos-network_cli-libssh-python36-stable29
+            voting: false
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
     gate:
       queue: integrated
-      jobs: *ansible-collections-arista-eos-jobs
+      jobs:
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-collections/ansible.netcommon
+              - name: github.com/ansible-collections/ansible.utils
 
 - project-template:
     name: ansible-collections-ansible-utils

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -192,7 +192,7 @@
     check:
       jobs: &ansible-collections-arista-eos-jobs
         - ansible-test-network-integration-eos-httpapi-python27-stable211:
-            voting: false 
+            voting: false
         - ansible-test-network-integration-eos-httpapi-python27-stable29:
             voting: false
         - ansible-test-network-integration-eos-network_cli-python27-stable211-scenario01:


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gosriniv@redhat.com>

With the upgrade of eos image in CI , we are fixing the failures seen due to changes in cli syntax. Until the fixes are merged, the eos jobs will remain non-voting.