### PR TITLE
a.aws: temp turn off the integration tests

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -76,17 +76,6 @@
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/community.aws
               - name: github.com/ansible-collections/community.general
-        - ansible-test-splitter
-        - ansible-test-cloud-integration-aws-py36_0
-        - ansible-test-cloud-integration-aws-py36_1
-        - ansible-test-cloud-integration-aws-py36_2
-        - ansible-test-cloud-integration-aws-py36_3
-        - ansible-test-cloud-integration-aws-py36_4
-        - ansible-test-cloud-integration-aws-py36_5
-        - ansible-test-cloud-integration-aws-py36_6
-        - ansible-test-cloud-integration-aws-py36_7
-        - ansible-test-cloud-integration-aws-py36_8
-        - ansible-test-cloud-integration-aws-py36_9
 
     gate:
       jobs:
@@ -103,17 +92,6 @@
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/community.aws
               - name: github.com/ansible-collections/community.general
-        - ansible-test-splitter
-        - ansible-test-cloud-integration-aws-py36_0
-        - ansible-test-cloud-integration-aws-py36_1
-        - ansible-test-cloud-integration-aws-py36_2
-        - ansible-test-cloud-integration-aws-py36_3
-        - ansible-test-cloud-integration-aws-py36_4
-        - ansible-test-cloud-integration-aws-py36_5
-        - ansible-test-cloud-integration-aws-py36_6
-        - ansible-test-cloud-integration-aws-py36_7
-        - ansible-test-cloud-integration-aws-py36_8
-        - ansible-test-cloud-integration-aws-py36_9
 
 - project-template:
     name: ansible-collections-community-aws


### PR DESCRIPTION
Turn off the integration tests the time we land some PR that aim
to improve the test reliability.