### PR TITLE
Revert "a.aws: temp turn off the integration tests"

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -76,6 +76,17 @@
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/community.aws
               - name: github.com/ansible-collections/community.general
+        - ansible-test-splitter
+        - ansible-test-cloud-integration-aws-py36_0
+        - ansible-test-cloud-integration-aws-py36_1
+        - ansible-test-cloud-integration-aws-py36_2
+        - ansible-test-cloud-integration-aws-py36_3
+        - ansible-test-cloud-integration-aws-py36_4
+        - ansible-test-cloud-integration-aws-py36_5
+        - ansible-test-cloud-integration-aws-py36_6
+        - ansible-test-cloud-integration-aws-py36_7
+        - ansible-test-cloud-integration-aws-py36_8
+        - ansible-test-cloud-integration-aws-py36_9
 
     gate:
       jobs:
@@ -92,6 +103,17 @@
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/community.aws
               - name: github.com/ansible-collections/community.general
+        - ansible-test-splitter
+        - ansible-test-cloud-integration-aws-py36_0
+        - ansible-test-cloud-integration-aws-py36_1
+        - ansible-test-cloud-integration-aws-py36_2
+        - ansible-test-cloud-integration-aws-py36_3
+        - ansible-test-cloud-integration-aws-py36_4
+        - ansible-test-cloud-integration-aws-py36_5
+        - ansible-test-cloud-integration-aws-py36_6
+        - ansible-test-cloud-integration-aws-py36_7
+        - ansible-test-cloud-integration-aws-py36_8
+        - ansible-test-cloud-integration-aws-py36_9
 
 - project-template:
     name: ansible-collections-community-aws


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/413
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/411
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/406

This reverts commit f605121aac62bf038e9b496f56fb71ea531e3d7e.