### PR TITLE
Make the ansible-test-splitter job only run changed targets

### DIFF
--- a/playbooks/ansible-test-splitter/run.yaml
+++ b/playbooks/ansible-test-splitter/run.yaml
@@ -1,10 +1,6 @@
 ---
 - hosts: all
   tasks:
-    - name: You are here
-      debug:
-        msg: '{{ ansible_test_splitter__test_changed }}'
-
     - name: Run ansible-test-splitter
       include_role:
         name: ansible-test-splitter

--- a/playbooks/ansible-test-splitter/run.yaml
+++ b/playbooks/ansible-test-splitter/run.yaml
@@ -1,8 +1,12 @@
 ---
 - hosts: all
   tasks:
+    - name: You are here
+      debug:
+        msg: '{{ ansible_test_splitter__test_changed }}'
+
     - name: Run ansible-test-splitter
-      import_role:
+      include_role:
         name: ansible-test-splitter
       vars:
         ansible_test_test_command: "{{ ansible_test_command }}"

--- a/roles/ansible-test-splitter/defaults/main.yaml
+++ b/roles/ansible-test-splitter/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-ansible_test_splitter__test_changed: true
+ansible_test_splitter__test_changed: false
 ansible_test_splitter__children_prefix: please_adjust_this

--- a/roles/ansible-test-splitter/defaults/main.yaml
+++ b/roles/ansible-test-splitter/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-ansible_test_splitter__test_changed: false
+ansible_test_splitter__test_changed: true
 ansible_test_splitter__children_prefix: please_adjust_this

--- a/roles/ansible-test-splitter/files/split_targets.py
+++ b/roles/ansible-test-splitter/files/split_targets.py
@@ -3,15 +3,16 @@
 from pathlib import PosixPath
 import sys
 import json
+import subprocess
 
 job_prefix = sys.argv[1]
+print(sys.argv[2])
 if len(sys.argv) == 3:
     targets_from_cli = sys.argv[2].split(" ")
 else:
     targets_from_cli = []
 # NOTE(pabelanger): Hardcode this to 6 because that is the semaphore in zuul.
 jobs = [f"{job_prefix}{i}" for i in range(6)]
-total_jobs = 10
 slow_targets = []
 regular_targets = []
 
@@ -43,7 +44,6 @@ for x in range(remaining_jobs):
     batch = regular_targets[x::remaining_jobs]
     if batch:
         batches.append(batch)
-
 
 result = {
     "data": {

--- a/roles/ansible-test-splitter/files/split_targets.py
+++ b/roles/ansible-test-splitter/files/split_targets.py
@@ -3,22 +3,25 @@
 from pathlib import PosixPath
 import sys
 import json
-import subprocess
+import argparse
+import os
 
-job_prefix = sys.argv[1]
-print(sys.argv[2])
-if len(sys.argv) == 3:
-    targets_from_cli = sys.argv[2].split(" ")
-else:
-    targets_from_cli = []
+parser = argparse.ArgumentParser()
+parser.add_argument('-t', '--targets', help="list of targets for integration testing. example: 'ec2_tag ami_info ec2_instance'",default="")
+parser.add_argument('-p', '--prefix', help='list of targets for integration testing', default="job_")
+parser.add_argument('-c', '--collection_path', help='path to the collection.', default=os.getcwd())
+
+args = parser.parse_args()
+batches = []
 # NOTE(pabelanger): Hardcode this to 6 because that is the semaphore in zuul.
-jobs = [f"{job_prefix}{i}" for i in range(6)]
+total_jobs = 6
 slow_targets = []
 regular_targets = []
 
-batches = []
+jobs = [f"{args.prefix}{i}" for i in range(total_jobs)]
 
-targets = PosixPath("tests/integration/targets/")
+targets = PosixPath(os.path.join(args.collection_path,"tests/integration/targets/"))
+targets_from_cli = [ x for x in args.targets.split(" ") if x != "" ]
 for target in targets.glob("*"):
     aliases = target / "aliases"
     if not target.is_dir():

--- a/roles/ansible-test-splitter/tasks/ansible_test_changed.yaml
+++ b/roles/ansible-test-splitter/tasks/ansible_test_changed.yaml
@@ -9,5 +9,10 @@
   args:
     chdir: "{{ ansible_test_location }}"
   register: _result
+
 - set_fact:
     ansible_test_splitter__changed_targets_to_test: "{{ _result.stdout }}"
+
+- name: DEBUGGIER
+  debug:
+    msg: '{{ ansible_test_splitter__changed_targets_to_test }}'

--- a/roles/ansible-test-splitter/tasks/ansible_test_changed.yaml
+++ b/roles/ansible-test-splitter/tasks/ansible_test_changed.yaml
@@ -11,8 +11,4 @@
   register: _result
 
 - set_fact:
-    ansible_test_splitter__changed_targets_to_test: "{{ _result.stdout }}"
-
-- name: DEBUGGIER
-  debug:
-    msg: '{{ ansible_test_splitter__changed_targets_to_test }}'
+    ansible_test_splitter__targets_to_test: "{{ _result.stdout }}"

--- a/roles/ansible-test-splitter/tasks/main.yaml
+++ b/roles/ansible-test-splitter/tasks/main.yaml
@@ -1,6 +1,4 @@
 ---
-- debug:
-    msg: "Identify the targets associated with the changed files"
 - name: Identify the targets associated with the changed files
   include_tasks: ansible_test_changed.yaml
   when: ansible_test_splitter__test_changed|bool

--- a/roles/ansible-test-splitter/tasks/main.yaml
+++ b/roles/ansible-test-splitter/tasks/main.yaml
@@ -1,11 +1,19 @@
 ---
+- debug:
+    msg: "Identify the targets associated with the changed files"
 - name: Identify the targets associated with the changed files
-  import_tasks: ansible_test_changed.yaml
+  include_tasks: ansible_test_changed.yaml
   when: ansible_test_splitter__test_changed|bool
 
+- debug:
+    msg: "Build a list of all the targets"
 - name: Build a list of all the targets
-  import_tasks: list_all.yaml
+  include_tasks: list_all.yaml
   when: not(ansible_test_splitter__test_changed|bool)
 
+- name: Print all available facts
+  debug:
+    var: ansible_facts
+
 - name: Split targets
-  import_tasks: split_targets.yaml
+  include_tasks: split_targets.yaml

--- a/roles/ansible-test-splitter/tasks/split_targets.yaml
+++ b/roles/ansible-test-splitter/tasks/split_targets.yaml
@@ -4,6 +4,10 @@
     dest: /tmp/split_targets.py
     mode: '0700'
 
+- name: sigh
+  debug:
+    msg: "{{ _result|default('') }}"
+
 - name: Split the workload
   command: python3 /tmp/split_targets.py "{{ ansible_test_splitter__children_prefix }}" "{{ ansible_test_splitter__targets_to_test|default('') }}"
   args:

--- a/roles/ansible-test-splitter/tasks/split_targets.yaml
+++ b/roles/ansible-test-splitter/tasks/split_targets.yaml
@@ -4,14 +4,8 @@
     dest: /tmp/split_targets.py
     mode: '0700'
 
-- name: sigh
-  debug:
-    msg: "{{ _result|default('') }}"
-
 - name: Split the workload
-  command: python3 /tmp/split_targets.py "{{ ansible_test_splitter__children_prefix }}" "{{ ansible_test_splitter__targets_to_test|default('') }}"
-  args:
-    chdir: "{{ ansible_test_location }}"
+  command: python3 /tmp/split_targets.py -c "{{ ansible_test_location }}" -p "{{ ansible_test_splitter__children_prefix }}" -t "{{ ansible_test_splitter__targets_to_test|default('') }}"
   register: _result
 - debug: var=_result
 - set_fact:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -121,7 +121,7 @@
 - project-template:
     name: ansible-collections-arista-eos-units
     check:
-      jobs: &ansile-collections-arista-eos-units-jobs
+      jobs: &ansible-collections-arista-eos-units-jobs
         - ansible-changelog-fragment
         - ansible-test-sanity-docker
         - ansible-test-sanity-docker-stable-2.9
@@ -133,7 +133,7 @@
         - ansible-test-units-eos-python37
     gate:
       queue: integrated
-      jobs: *ansile-collections-arista-eos-units-jobs
+      jobs: *ansible-collections-arista-eos-units-jobs
 
 - project-template:
     name: ansible-collections-arista-eos
@@ -181,7 +181,7 @@
 - project-template:
     name: ansible-collections-ansible-utils-units
     check:
-      jobs: &ansile-collections-ansible-utils-units-jobs
+      jobs: &ansible-collections-ansible-utils-units-jobs
         - ansible-changelog-fragment
         - ansible-test-sanity-docker
         - ansible-test-sanity-docker-stable-2.9
@@ -193,7 +193,7 @@
         - ansible-test-units-ansible-utils-python37
     gate:
       queue: integrated
-      jobs: *ansile-collections-ansible-utils-units-jobs
+      jobs: *ansible-collections-ansible-utils-units-jobs
 
 - project-template:
     name: ansible-collections-cisco-asa-units

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -63,7 +63,7 @@
     name: ansible-collections-amazon-aws
     check:
       queue: integrated-aws
-      jobs: &ansile-collections-amazon-aws-jobs
+      jobs: &ansible-collections-amazon-aws-jobs
         - ansible-test-sanity-aws-ansible-python36
         - ansible-test-sanity-aws-ansible-2.9-python36
         - ansible-test-sanity-aws-ansible-2.11-python36
@@ -74,7 +74,9 @@
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/community.aws
               - name: github.com/ansible-collections/community.general
-        - ansible-test-splitter
+        - ansible-test-splitter:
+            vars:
+              ansible_test_splitter__test_changed: true
         - ansible-test-cloud-integration-aws-py36_0
         - ansible-test-cloud-integration-aws-py36_1
         - ansible-test-cloud-integration-aws-py36_2
@@ -83,13 +85,13 @@
         - ansible-test-cloud-integration-aws-py36_5
     gate:
       queue: integrated-aws
-      jobs: *ansile-collections-amazon-aws-jobs
+      jobs: *ansible-collections-amazon-aws-jobs
 
 - project-template:
     name: ansible-collections-community-aws
     check:
       queue: integrated-aws
-      jobs: &ansile-collections-community-aws-jobs
+      jobs: &ansible-collections-community-aws-jobs
         - ansible-test-sanity-docker
         - ansible-test-sanity-docker-stable-2.9
         - ansible-test-sanity-docker-stable-2.10
@@ -101,7 +103,9 @@
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/community.general
-        - ansible-test-splitter
+        - ansible-test-splitter:
+            vars:
+              ansible_test_splitter__test_changed: true
         - ansible-test-cloud-integration-aws-py36_0
         - ansible-test-cloud-integration-aws-py36_1
         - ansible-test-cloud-integration-aws-py36_2
@@ -112,7 +116,7 @@
             voting: false
     gate:
       queue: integrated-aws
-      jobs: *ansile-collections-community-aws-jobs
+      jobs: *ansible-collections-community-aws-jobs
 
 - project-template:
     name: ansible-collections-arista-eos-units


### PR DESCRIPTION
We're getting timeouts on some jobs again.  --diff doesn't seem to actually be doing anything, all jobs are running on small changes, but that will take more time to figure out and this is blocking everything.