### PR TITLE
Make ansible-test-splitter configuration more flexible (use getopts)

### DIFF
--- a/roles/ansible-test-splitter/defaults/main.yaml
+++ b/roles/ansible-test-splitter/defaults/main.yaml
@@ -1,3 +1,4 @@
 ---
 ansible_test_splitter__test_changed: false
 ansible_test_splitter__children_prefix: please_adjust_this
+ansible_test_splitter__children_count: 5

--- a/roles/ansible-test-splitter/files/split_targets.py
+++ b/roles/ansible-test-splitter/files/split_targets.py
@@ -57,7 +57,7 @@ for target in targets.glob("*"):
     else:
         regular_targets.append(target.name)
 
-
+batches.sort()
 regular_targets.sort()
 slow_jobs = len(batches)
 remaining_jobs = total_jobs - slow_jobs
@@ -66,7 +66,6 @@ for x in range(remaining_jobs):
     batch = regular_targets[x::remaining_jobs]
     if batch:
         batches.append(batch)
-
 
 result = {
     "data": {

--- a/roles/ansible-test-splitter/files/split_targets.py
+++ b/roles/ansible-test-splitter/files/split_targets.py
@@ -1,16 +1,38 @@
 #!/usr/bin/env python3
 
 from pathlib import PosixPath
-import sys
+import getopt
 import json
+import sys
 
-job_prefix = sys.argv[1]
-if len(sys.argv) == 3:
-    targets_from_cli = sys.argv[2].split(" ")
+try:
+    opts, args = getopt.getopt(sys.argv[1:],"ht:j:p:")
+except getopt.GetoptError:
+    print('split_targets.py -t <targets> -j <total_jobs> -p <job_prefix>')
+    sys.exit(2)
+
+targets = ""
+job_prefix = "job"
+job_count = 10
+
+for opt, arg in opts:
+    if opt == '-h':
+        print('split_targets.py -t <targets> -j <total_jobs> -p <job_prefix>')
+        sys.exit(0)
+    if opt == '-p':
+        job_prefix = arg
+    if opt == '-t':
+        targets_from_cli = arg
+    if opt == '-j':
+        job_count = int(arg)
+
+if targets:
+    targets_from_cli = targets.split(" ")
 else:
     targets_from_cli = []
-jobs = [f"{job_prefix}{i}" for i in range(10)]
-total_jobs = 10
+
+jobs = [f"{job_prefix}{i}" for i in range(job_count)]
+total_jobs = job_count
 slow_targets = []
 regular_targets = []
 

--- a/roles/ansible-test-splitter/files/split_targets.py
+++ b/roles/ansible-test-splitter/files/split_targets.py
@@ -57,6 +57,8 @@ for target in targets.glob("*"):
     else:
         regular_targets.append(target.name)
 
+
+regular_targets.sort()
 slow_jobs = len(batches)
 remaining_jobs = total_jobs - slow_jobs
 

--- a/roles/ansible-test-splitter/tasks/split_targets.yaml
+++ b/roles/ansible-test-splitter/tasks/split_targets.yaml
@@ -9,7 +9,7 @@
     python3 /tmp/split_targets.py
     -p "{{ ansible_test_splitter__children_prefix }}"
     -t "{{ ansible_test_splitter__targets_to_test|default('') }}"
-    -j 10
+    -j "{{ ansible_test_splitter__children_count }}"
   args:
     chdir: "{{ ansible_test_location }}"
   register: _result

--- a/roles/ansible-test-splitter/tasks/split_targets.yaml
+++ b/roles/ansible-test-splitter/tasks/split_targets.yaml
@@ -5,7 +5,11 @@
     mode: '0700'
 
 - name: Split the workload
-  command: python3 /tmp/split_targets.py "{{ ansible_test_splitter__children_prefix }}" "{{ ansible_test_splitter__targets_to_test|default('') }}"
+  command: >-
+    python3 /tmp/split_targets.py
+    -p "{{ ansible_test_splitter__children_prefix }}"
+    -t "{{ ansible_test_splitter__targets_to_test|default('') }}"
+    -j 10
   args:
     chdir: "{{ ansible_test_location }}"
   register: _result

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -359,6 +359,7 @@
     parent: ansible-test-cloud-integration-aws-py36
     vars:
       ansible_test_integration_targets: "{{ child.targets_to_test[9]|join(' ') }}"
+
 #### units
 - job:
     name: ansible-test-units-community-aws-python38

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -76,7 +76,9 @@
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/community.aws
               - name: github.com/ansible-collections/community.general
-        - ansible-test-splitter
+        - ansible-test-splitter:
+            vars:
+              ansible_test_splitter__children_count: 10
         - ansible-test-cloud-integration-aws-py36_0
         - ansible-test-cloud-integration-aws-py36_1
         - ansible-test-cloud-integration-aws-py36_2
@@ -103,7 +105,9 @@
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/community.aws
               - name: github.com/ansible-collections/community.general
-        - ansible-test-splitter
+        - ansible-test-splitter:
+            vars:
+              ansible_test_splitter__children_count: 10
         - ansible-test-cloud-integration-aws-py36_0
         - ansible-test-cloud-integration-aws-py36_1
         - ansible-test-cloud-integration-aws-py36_2
@@ -130,7 +134,9 @@
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/community.general
-        - ansible-test-splitter
+        - ansible-test-splitter:
+            vars:
+              ansible_test_splitter__children_count: 10
         - ansible-test-cloud-integration-aws-py36_0
         - ansible-test-cloud-integration-aws-py36_1
         - ansible-test-cloud-integration-aws-py36_2
@@ -156,7 +162,9 @@
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/community.general
-        - ansible-test-splitter
+        - ansible-test-splitter:
+            vars:
+              ansible_test_splitter__children_count: 10
         - ansible-test-cloud-integration-aws-py36_0
         - ansible-test-cloud-integration-aws-py36_1
         - ansible-test-cloud-integration-aws-py36_2


### PR DESCRIPTION
Integration tests can be slow.  For the amazon.aws checks we only want to run the full integration tests as a part of gate.  "check" should run only on the tests for modules that changed.