### PR TITLE
Evenly distributed targets to remaining jobs

### DIFF
--- a/roles/ansible-test-splitter/files/split_targets.py
+++ b/roles/ansible-test-splitter/files/split_targets.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from pathlib import PosixPath
-import random
 import sys
 import json
 
@@ -35,8 +34,6 @@ for target in targets.glob("*"):
         batches.append([target.name])
     else:
         regular_targets.append(target.name)
-
-random.shuffle(regular_targets)
 
 slow_jobs = len(batches)
 remaining_jobs = total_jobs - slow_jobs

--- a/roles/ansible-test-splitter/files/split_targets.py
+++ b/roles/ansible-test-splitter/files/split_targets.py
@@ -11,7 +11,7 @@ if len(sys.argv) == 3:
 else:
     targets_from_cli = []
 jobs = [f"{job_prefix}{i}" for i in range(10)]
-targets_per_job = 20
+total_jobs = 10
 slow_targets = []
 regular_targets = []
 
@@ -38,13 +38,13 @@ for target in targets.glob("*"):
 
 random.shuffle(regular_targets)
 
-splitted_targets = len(regular_targets) % targets_per_job
+slow_jobs = len(batches)
+remaining_jobs = total_jobs - slow_jobs
 
-splitted_targets = []
-while regular_targets:
-    batches.append(
-        [regular_targets.pop() for i in range(targets_per_job) if regular_targets]
-    )
+for x in range(remaining_jobs):
+    batch = regular_targets[x::remaining_jobs]
+    if batch:
+        batches.append(batch)
 
 
 result = {


### PR DESCRIPTION
This will take all the remaining jobs (after the slow ones have been assigned) and evenly distribute them across the remaining jobs. I'm assuming a hard coded number of 10 available jobs, but I don't know how correct that assumption is. The intent here is to avoid the timeouts we've been seeing with the AWS collections.