### PR TITLE
Allow aws jobs to use bindep.txt file

### DIFF
--- a/playbooks/ansible-cloud/aws/pre.yaml
+++ b/playbooks/ansible-cloud/aws/pre.yaml
@@ -1,11 +1,18 @@
 ---
 - hosts: controller
   tasks:
+    - name: Install binary dependencies
+      include_role:
+        name: bindep
+      vars:
+        bindep_dir: "{{ zuul.project.src_dir }}"
+
     - name: Fetch the aws_session file from the controller
       fetch:
         flat: true
         src: "/tmp/aws_session.json"
         dest: '{{ zuul.executor.work_root }}/'
+
     - import_role:
         name: ansible-test-provider
       vars:


### PR DESCRIPTION
This allows aws jobs to install binaries via the bindep.txt file.

NOTE: ansible-clouds jobs likely need to be refactored a little (to
look more like network jobs) to have a shared top-level playbook to
setup common things across all cloud collections.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>