### PR TITLE
Remove release-ansible-collection-announcement job

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1629,11 +1629,6 @@
     release:
       jobs:
         - release-ansible-collection-automation-hub
-        - release-ansible-collection-announcement:
-            dependencies:
-              - name: release-ansible-collection-automation-hub
-              - name: release-ansible-collection-galaxy
-                soft: true
 
 - project-template:
     name: publish-to-galaxy


### PR DESCRIPTION
The job is currently broken because of a twitter API change upstream:

  https://github.com/bear/python-twitter/issues/695

Signed-off-by: Paul Belanger <pabelanger@redhat.com>