### PR TITLE
kubernetes.core job - molecule testing

### DIFF
--- a/playbooks/ansible-cloud/k8s/molecule.yaml
+++ b/playbooks/ansible-cloud/k8s/molecule.yaml
@@ -4,6 +4,6 @@
     ansible_zuul_src_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"
   tasks:
     - name: Test using Molecule
-      shell: "source {{ ansible_test_venv_path }}/bin/activate; make test-molecule"
+      shell: "source {{ ansible_test_venv_path }}/bin/activate; molecule test"
       args:
         chdir: ~/.ansible/collections/ansible_collections/kubernetes/core

--- a/playbooks/ansible-cloud/k8s/pre.yaml
+++ b/playbooks/ansible-cloud/k8s/pre.yaml
@@ -10,6 +10,14 @@
       include_role:
         name: ensure-docker
 
+    - name: Run ensure-virtualenv role
+      include_role:
+        name: ensure-virtualenv
+
+    - name: Run ensure-pip role
+      include_role:
+        name: ensure-pip
+
     - name: Setup base virtualenv_options
       set_fact:
         _virtualenv_options: "--python python{{ ansible_test_python }}"

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -405,11 +405,10 @@
       - name: github.com/ansible/ansible
       - name: github.com/ansible-collections/kubernetes.core
     timeout: 5400
-    nodeset: centos-7-4vcpu
+    nodeset: centos-8-stream
     vars:
       ansible_collections_repo: github.com/ansible-collections/kubernetes.core
       ansible_test_python: 3.6
-      ansible_test_command: integration
       ansible_test_collections: true
       ansible_test_venv_path: "~/venv"
 
@@ -424,10 +423,9 @@
       - name: github.com/ansible/ansible
       - name: github.com/ansible-collections/kubernetes.core
     timeout: 5400
-    nodeset: centos-7-4vcpu
+    nodeset: centos-8-stream
     vars:
       ansible_collections_repo: github.com/ansible-collections/kubernetes.core
-      ansible_test_python: 3.6
-      ansible_test_command: integration
       ansible_test_collections: true
+      ansible_test_python: 3.6
       ansible_test_venv_path: "~/venv"


### PR DESCRIPTION
kubernetes.core: use new node `centos-8-stream` as the process was failing in the previous one

amazon.aws: `check` should test only changed, all others targets will be tests on `gate`