### PR TITLE
Add centos-8-stream-1vcpu nodeset

### DIFF
--- a/roles/configure-mirrors-fork/tasks/mirror.yaml
+++ b/roles/configure-mirrors-fork/tasks/mirror.yaml
@@ -12,6 +12,7 @@
   include: "{{ item }}"
   static: false
   with_first_found:
+    - "mirror/{{ ansible_lsb.id }}-{{ ansible_lsb.major_release }}.yaml"
     - "mirror/{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yaml"
     - "mirror/{{ ansible_distribution }}.yaml"
     - "mirror/{{ ansible_os_family }}.yaml"

--- a/roles/configure-mirrors-fork/tasks/mirror/CentOSStream-8.yaml
+++ b/roles/configure-mirrors-fork/tasks/mirror/CentOSStream-8.yaml
@@ -1,0 +1,32 @@
+---
+- name: Install CentOS 8 Stream repository files
+  become: true
+  template:
+    dest: "/{{ zj_repo }}"
+    group: root
+    mode: 0644
+    owner: root
+    src: "centos8-stream/{{ zj_repo }}.j2"
+  with_items:
+    - etc/yum.repos.d/CentOS-Stream-AppStream.repo
+    - etc/yum.repos.d/CentOS-Stream-BaseOS.repo
+    - etc/yum.repos.d/CentOS-Stream-HighAvailability.repo
+    - etc/yum.repos.d/CentOS-Stream-Extras.repo
+    - etc/yum.repos.d/CentOS-Stream-PowerTools.repo
+  loop_control:
+    loop_var: zj_repo
+  notify:
+    - Update yum/dnf cache
+
+# http://dnf.readthedocs.io/en/latest/conf_ref.html#options-for-both-main-and-repo
+# deltarpm is useful when the bottleneck is the network throughput.
+# It also requires additional drpm packages to be hosted by the mirrors which
+# is not done by default.
+- name: Disable deltrarpm
+  become: true
+  ini_file:
+    path: /etc/dnf.conf
+    section: main
+    option: deltarpm
+    value: "0"
+    mode: 0644

--- a/roles/configure-mirrors-fork/templates/centos8-stream/etc/yum.repos.d/CentOS-Stream-AppStream.repo.j2
+++ b/roles/configure-mirrors-fork/templates/centos8-stream/etc/yum.repos.d/CentOS-Stream-AppStream.repo.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+[appstream]
+name=CentOS Stream $releasever - AppStream
+baseurl={{ package_mirror }}/$stream/AppStream/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial

--- a/roles/configure-mirrors-fork/templates/centos8-stream/etc/yum.repos.d/CentOS-Stream-BaseOS.repo.j2
+++ b/roles/configure-mirrors-fork/templates/centos8-stream/etc/yum.repos.d/CentOS-Stream-BaseOS.repo.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+[baseos]
+name=CentOS Stream $releasever - BaseOS
+baseurl={{ package_mirror }}/$stream/BaseOS/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial

--- a/roles/configure-mirrors-fork/templates/centos8-stream/etc/yum.repos.d/CentOS-Stream-Extras.repo.j2
+++ b/roles/configure-mirrors-fork/templates/centos8-stream/etc/yum.repos.d/CentOS-Stream-Extras.repo.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+[extras]
+name=CentOS Stream $releasever - Extras
+baseurl={{ package_mirror }}/$stream/extras/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -18,6 +18,12 @@
         label: centos-8-1vcpu
 
 - nodeset:
+    name: centos-8-stream-1vcpu
+    nodes:
+      - name: centos-8-stream
+        label: centos-8-stream-1vcpu
+
+- nodeset:
     name: fedora-latest-1vcpu
     nodes:
       - name: fedora-34


### PR DESCRIPTION
This brings online centos-8-stream images. Which means we should work to
migrate all centos-8 jobs to this new image.  As this is now upstream
development of RHEL.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>