### PR TITLE
When running AWS sanity tests limit which python versions we test against

### DIFF
--- a/roles/ansible-test/tasks/init_test_options.yaml
+++ b/roles/ansible-test/tasks/init_test_options.yaml
@@ -49,7 +49,6 @@
     ansible_test_options: "{{ ansible_test_options }} --python {{ ansible_test_python }}"
   when:
     - ansible_test_python
-    - not ansible_test_docker
 
 - name: Setup --docker option
   set_fact:

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -389,6 +389,9 @@
       ansible_test_command: sanity
       ansible_test_enable_ara: false
       ansible_test_python: 3.6
+      ansible_test_sanity_skiptests:
+        - 'future-import-boilerplate'
+        - 'metaclass-boilerplate'
 
 - job:
     name: ansible-test-sanity-aws-ansible-2.9-python36


### PR DESCRIPTION
AWS collections don't support Python<3.6, explicitly limit which versions of python we run our compilation tests against.