### PR TITLE
Place amazon.aws / community.aws in same shared queue

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -62,6 +62,7 @@
 - project-template:
     name: ansible-collections-amazon-aws
     check:
+      queue: integrated-aws
       jobs:
         - ansible-test-sanity-aws-ansible-2.9-python36
         - ansible-test-sanity-aws-ansible-2.9-python38
@@ -89,6 +90,7 @@
         - ansible-test-cloud-integration-aws-py36_9
 
     gate:
+      queue: integrated-aws
       jobs:
         - ansible-test-sanity-aws-ansible-2.9-python36
         - ansible-test-sanity-aws-ansible-2.9-python38
@@ -118,6 +120,7 @@
 - project-template:
     name: ansible-collections-community-aws
     check:
+      queue: integrated-aws
       jobs:
         - ansible-test-sanity-docker
         - ansible-test-sanity-docker-stable-2.9
@@ -144,6 +147,7 @@
         - ansible-galaxy-importer:
             voting: false
     gate:
+      queue: integrated-aws
       jobs:
         - ansible-test-sanity-docker
         - ansible-test-sanity-docker-stable-2.9


### PR DESCRIPTION
Because these jobs are ratelimited by AWS capacity, it makes sense to
also group them via a shared queue. This should help them from fighing
over resources between check / gate pipelines.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>