### PR TITLE
Only split the aws work over 6 jobs

### DIFF
--- a/roles/ansible-test-splitter/files/split_targets.py
+++ b/roles/ansible-test-splitter/files/split_targets.py
@@ -9,7 +9,8 @@ if len(sys.argv) == 3:
     targets_from_cli = sys.argv[2].split(" ")
 else:
     targets_from_cli = []
-jobs = [f"{job_prefix}{i}" for i in range(10)]
+# NOTE(pabelanger): Hardcode this to 6 because that is the semaphore in zuul.
+jobs = [f"{job_prefix}{i}" for i in range(6)]
 total_jobs = 10
 slow_targets = []
 regular_targets = []

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -336,29 +336,6 @@
     vars:
       ansible_test_integration_targets: "{{ child.targets_to_test[5]|join(' ') }}"
 
-- job:
-    name: ansible-test-cloud-integration-aws-py36_6
-    parent: ansible-test-cloud-integration-aws-py36
-    vars:
-      ansible_test_integration_targets: "{{ child.targets_to_test[6]|join(' ') }}"
-
-- job:
-    name: ansible-test-cloud-integration-aws-py36_7
-    parent: ansible-test-cloud-integration-aws-py36
-    vars:
-      ansible_test_integration_targets: "{{ child.targets_to_test[7]|join(' ') }}"
-
-- job:
-    name: ansible-test-cloud-integration-aws-py36_8
-    parent: ansible-test-cloud-integration-aws-py36
-    vars:
-      ansible_test_integration_targets: "{{ child.targets_to_test[8]|join(' ') }}"
-
-- job:
-    name: ansible-test-cloud-integration-aws-py36_9
-    parent: ansible-test-cloud-integration-aws-py36
-    vars:
-      ansible_test_integration_targets: "{{ child.targets_to_test[9]|join(' ') }}"
 #### units
 - job:
     name: ansible-test-units-community-aws-python38

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -84,10 +84,6 @@
         - ansible-test-cloud-integration-aws-py36_3
         - ansible-test-cloud-integration-aws-py36_4
         - ansible-test-cloud-integration-aws-py36_5
-        - ansible-test-cloud-integration-aws-py36_6
-        - ansible-test-cloud-integration-aws-py36_7
-        - ansible-test-cloud-integration-aws-py36_8
-        - ansible-test-cloud-integration-aws-py36_9
 
     gate:
       queue: integrated-aws
@@ -112,10 +108,6 @@
         - ansible-test-cloud-integration-aws-py36_3
         - ansible-test-cloud-integration-aws-py36_4
         - ansible-test-cloud-integration-aws-py36_5
-        - ansible-test-cloud-integration-aws-py36_6
-        - ansible-test-cloud-integration-aws-py36_7
-        - ansible-test-cloud-integration-aws-py36_8
-        - ansible-test-cloud-integration-aws-py36_9
 
 - project-template:
     name: ansible-collections-community-aws
@@ -140,10 +132,6 @@
         - ansible-test-cloud-integration-aws-py36_3
         - ansible-test-cloud-integration-aws-py36_4
         - ansible-test-cloud-integration-aws-py36_5
-        - ansible-test-cloud-integration-aws-py36_6
-        - ansible-test-cloud-integration-aws-py36_7
-        - ansible-test-cloud-integration-aws-py36_8
-        - ansible-test-cloud-integration-aws-py36_9
         - ansible-galaxy-importer:
             voting: false
     gate:
@@ -167,10 +155,6 @@
         - ansible-test-cloud-integration-aws-py36_3
         - ansible-test-cloud-integration-aws-py36_4
         - ansible-test-cloud-integration-aws-py36_5
-        - ansible-test-cloud-integration-aws-py36_6
-        - ansible-test-cloud-integration-aws-py36_7
-        - ansible-test-cloud-integration-aws-py36_8
-        - ansible-test-cloud-integration-aws-py36_9
         - ansible-galaxy-importer:
             voting: false
 


### PR DESCRIPTION
The aws semaphore is capped at 6, no need trying to use more resources
then that.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>