### PR TITLE
Remove ansible-test gate jobs

### DIFF
--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -57,18 +57,6 @@
               - playbooks/ansible-test-network-integration-base/files/bootstrap-trendmicro.deepsec.deepsec.yaml
               - playbooks/ansible-network-appliance-base/.*
               - roles/trendmicro.*
-        ## ansible-test* roles
-        - build-ansible-collection:
-            required-projects:
-              # - name: github.com/ansible-collections/openvswitch.openvswitch
-              - name: github.com/ansible-collections/amazon.aws
-              - name: github.com/ansible-collections/ansible.netcommon
-              # - name: github.com/ansible-collections/community.vmware
-            files:
-              # - roles/vmware.*
-              - roles/ansible-test*
-              - playbooks/ansible-cloud/.*
-
     gate:
       jobs:
         - ansible-network-asa-appliance:
@@ -106,28 +94,3 @@
         - ansible-security-trendmicro-deepsec-appliance:
             files:
               - playbooks/ansible-network-appliance-base/.*
-        ## ansible-test* roles
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/openvswitch.openvswitch
-              - name: github.com/ansible-collections/amazon.aws
-              - name: github.com/ansible-collections/ansible.netcommon
-              - name: github.com/ansible-collections/community.vmware
-            files:
-              - roles/vmware.*
-              - roles/ansible-test*
-              - playbooks/ansible-cloud/.*
-        - ansible-test-cloud-integration-vcenter7_only-python36:
-            match-on-config-updates: false
-            files:
-              - roles/vmware.*
-              - roles/ansible-test*
-              - playbooks/ansible-cloud/.*
-            vars:
-              ansible_test_integration_targets: vmware_vcenter_settings
-        - ansible-test-network-integration-openvswitch-python35:
-            match-on-config-updates: false
-            files:
-              - roles/ansible-test*
-            vars:
-              ansible_test_collections: true


### PR DESCRIPTION
For some reason these have been deleted in check but not gate. Some one
needs to dig more into this.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>