### PR TITLE
Only run AWS integration tests for ansible changes

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -262,6 +262,9 @@
 - job:
     name: ansible-test-splitter
     run: playbooks/ansible-test-splitter/run.yaml
+    files:
+      - ^plugins/.*$
+      - ^tests/integration/.*$
     nodeset: controller-python36-f34
     required-projects:
       - name: github.com/ansible/ansible
@@ -286,6 +289,9 @@
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
+    files:
+      - ^plugins/.*$
+      - ^tests/integration/.*$
     # TODO: disabled for now, required for Ara
     # post-run: playbooks/ansible-test-base/post.yaml
     required-projects:


### PR DESCRIPTION
If users change plugins / tests/integration files then run integration
testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>