### PR TITLE
Remove ansible-test-sanity-aws python38 jobs

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -378,27 +378,6 @@
         - 'future-import-boilerplate'
         - 'metaclass-boilerplate'
 
-- job:
-    name: ansible-test-sanity-aws-ansible-python38
-    parent: ansible-test-sanity-aws-ansible-python36
-    nodeset: controller-python38
-    vars:
-      ansible_test_python: 3.8
-
-- job:
-    name: ansible-test-sanity-aws-ansible-2.9-python38
-    parent: ansible-test-sanity-aws-ansible-2.9-python36
-    nodeset: controller-python38
-    vars:
-      ansible_test_python: 3.8
-
-- job:
-    name: ansible-test-sanity-aws-ansible-2.11-python38
-    parent: ansible-test-sanity-aws-ansible-2.11-python36
-    nodeset: controller-python38
-    vars:
-      ansible_test_python: 3.8
-
 ### Cloud Common
 - job:
     name: ansible-test-units-cloud-common-python38

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -67,9 +67,6 @@
         - ansible-test-sanity-aws-ansible-python36
         - ansible-test-sanity-aws-ansible-2.9-python36
         - ansible-test-sanity-aws-ansible-2.11-python36
-        - ansible-test-sanity-aws-ansible-python38
-        - ansible-test-sanity-aws-ansible-2.9-python38
-        - ansible-test-sanity-aws-ansible-2.11-python38
         - ansible-test-units-amazon-aws-python38
         - build-ansible-collection:
             required-projects:


### PR DESCRIPTION
Now that amazon.aws is running network-ee sanity jobs, they are already
on python38.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>