### PR TITLE
Migrate ansible-tox-* jobs to centos-8-stream

### DIFF
--- a/roles/configure-mirrors-fork/tasks/mirror/CentOSStream-8.yaml
+++ b/roles/configure-mirrors-fork/tasks/mirror/CentOSStream-8.yaml
@@ -11,6 +11,7 @@
     - etc/yum.repos.d/CentOS-Stream-AppStream.repo
     - etc/yum.repos.d/CentOS-Stream-BaseOS.repo
     - etc/yum.repos.d/CentOS-Stream-Extras.repo
+    - etc/yum.repos.d/CentOS-Stream-PowerTools.repo
   loop_control:
     loop_var: zj_repo
   notify:

--- a/roles/configure-mirrors-fork/templates/centos8-stream/etc/yum.repos.d/CentOS-Stream-PowerTools.repo.j2
+++ b/roles/configure-mirrors-fork/templates/centos8-stream/etc/yum.repos.d/CentOS-Stream-PowerTools.repo.j2
@@ -1,0 +1,8 @@
+# {{ ansible_managed }}
+[powertools]
+name=CentOS Stream $releasever - PowerTools
+baseurl={{ package_mirror }}/$stream/PowerTools/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -20,12 +20,12 @@
 - job:
     name: ansible-tox-docs
     parent: tox-docs
-    nodeset: centos-8-1vcpu
+    nodeset: centos-8-stream
 
 - job:
     name: ansible-tox-linters
     parent: tox-linters
-    nodeset: centos-8-1vcpu
+    nodeset: centos-8-stream
 
 - job: &ansible-tox-molecule-base
     name: ansible-tox-molecule-base
@@ -63,7 +63,7 @@
     name: ansible-tox-py36
     parent: tox-py36
     timeout: 3600
-    nodeset: centos-8-1vcpu
+    nodeset: centos-8-stream
 
 - job:
     name: ansible-tox-py37
@@ -86,7 +86,7 @@
     post-run: playbooks/ansible-build-python-tarball/post.yaml
     required-projects:
       - github.com/ansible-network/releases
-    nodeset: centos-8-1vcpu
+    nodeset: centos-8-stream
     vars:
       release_python: python3
 


### PR DESCRIPTION
This should result in some faster job runtimes on newer flavors.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>