### PR TITLE
Update ansible-tox-docs bindep_profile settings

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -20,6 +20,8 @@
 - job:
     name: ansible-tox-docs
     parent: tox-docs
+    vars:
+      bindep_profile: docs
     nodeset: centos-8-stream
 
 - job:


### PR DESCRIPTION
There is no need to install all the things in bindep.txt files, just the
docs entry point.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>