### PR TITLE
Move ansible-test-splitter to centos-8-stream

### DIFF
--- a/playbooks/ansible-test-splitter/run.yaml
+++ b/playbooks/ansible-test-splitter/run.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: controller
+- hosts: all
   tasks:
     - name: Run ansible-test-splitter
       import_role:

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -265,9 +265,7 @@
     files:
       - ^plugins/.*$
       - ^tests/integration/.*$
-    nodeset: controller-python36-f34
-    required-projects:
-      - name: github.com/ansible/ansible
+    nodeset: centos-8-stream
     timeout: 1000
     vars:
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"


### PR DESCRIPTION
This is part of the effort to standardize on centos-8-stream

Signed-off-by: Paul Belanger <pabelanger@redhat.com>