### PR TITLE
Move ansible-tox-py38 to centos-8-stream

### DIFF
--- a/playbooks/ansible-tox-py38/pre.yaml
+++ b/playbooks/ansible-tox-py38/pre.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  tasks:
+    - name: Ensure python3.8 is present
+      become: true
+      package:
+        name: python38-devel
+        state: present

--- a/zuul.d/ansible-navigator-jobs.yaml
+++ b/zuul.d/ansible-navigator-jobs.yaml
@@ -1,7 +1,7 @@
 ---
 - job:
     name: ansible-navigator-tox-py38
-    parent: ansible-tox-py38
+    parent: tox
     vars:
       tox_install_siblings: false
       tox_envlist: py38,type,report,clean
@@ -9,7 +9,6 @@
 
 - job:
     name: ansible-navigator-tox-smoke
-    parent: tox
+    parent: ansible-tox-py38
     vars:
       tox_envlist: smoke
-    nodeset: centos-8-1vcpu

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -74,8 +74,9 @@
 - job:
     name: ansible-tox-py38
     parent: tox-py38
+    pre-run: playbooks/ansible-tox-py38/pre.yaml
     timeout: 3600
-    nodeset: ubuntu-bionic-1vcpu
+    nodeset: centos-8-stream
 
 - job:
     name: ansible-build-python-tarball


### PR DESCRIPTION
This should cause jobs to run faster.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>