### PR TITLE
cloud.common add job to run molecule test on kubernetes.core

### DIFF
--- a/playbooks/ansible-cloud/k8s/molecule.yaml
+++ b/playbooks/ansible-cloud/k8s/molecule.yaml
@@ -5,5 +5,6 @@
   tasks:
     - name: Test using Molecule
       shell: "source {{ ansible_test_venv_path }}/bin/activate; molecule test"
+      environment: "{{ ansible_test_environment | default({}) }}"
       args:
         chdir: ~/.ansible/collections/ansible_collections/kubernetes/core

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -454,6 +454,10 @@
             required-projects:
               - name: github.com/ansible-collections/community.vmware
               - name: github.com/ansible-collections/vmware.vmware_rest
+        - ansible-test-molecule-kubernetes-core:
+            vars:
+              ansible_test_environment:
+                ENABLE_TURBO_MODE: true
     gate:
       jobs: *ansible-collections-cloud-common-jobs
 


### PR DESCRIPTION
Every pull requests on ``cloud.common`` should trigger the molecule test of the ``kubernetes.core`` collection with the turbo mode activated (env var ``ENABBLE_TURBO_MODE`` set to ``true``)