### PR TITLE
kubernetes.core - add molecule tests per tags

### DIFF
--- a/playbooks/ansible-cloud/k8s/integration.yaml
+++ b/playbooks/ansible-cloud/k8s/integration.yaml
@@ -1,9 +1,0 @@
----
-- hosts: all
-  vars:
-    ansible_zuul_src_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"
-  tasks:
-    - name: Integration tests
-      shell: "source {{ ansible_test_venv_path }}/bin/activate; make test-integration"
-      args:
-        chdir: ~/.ansible/collections/ansible_collections/kubernetes/core

--- a/playbooks/ansible-cloud/k8s/molecule.yaml
+++ b/playbooks/ansible-cloud/k8s/molecule.yaml
@@ -1,10 +1,32 @@
 ---
 - hosts: all
-  vars:
-    ansible_zuul_src_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"
   tasks:
+    - set_fact:
+        collection_path: "{{ '~/.ansible/collections/ansible_collections/kubernetes/core' | expanduser }}"
+
     - name: Test using Molecule
       shell: "source {{ ansible_test_venv_path }}/bin/activate; molecule test"
       environment: "{{ ansible_test_environment | default({}) }}"
       args:
-        chdir: ~/.ansible/collections/ansible_collections/kubernetes/core
+        chdir: "{{ collection_path }}"
+      when: molecule_test___tag_id is not defined
+
+    - name: Run molecule tests for specific group
+      block:
+        - name: tags group file name
+          set_fact:
+            _tag_file: "{{ collection_path }}/molecule/default/tags_{{ molecule_test___tag_id }}.txt"
+
+        - debug: var=_tag_file
+
+        - name: Get list of tags to be executed
+          set_fact:
+            tags: "{{ lookup('file', _tag_file) | replace('\n', ',') }}"
+
+        - name: Test using Molecule
+          shell: "source {{ ansible_test_venv_path }}/bin/activate; molecule test -- -v --tags {{ tags }}"
+          environment: "{{ ansible_test_environment | default({}) }}"
+          args:
+            chdir: ~/.ansible/collections/ansible_collections/kubernetes/core
+          when: molecule_test___tag_id is not defined
+      when: molecule_test___tag_id is defined

--- a/playbooks/ansible-cloud/k8s/molecule.yaml
+++ b/playbooks/ansible-cloud/k8s/molecule.yaml
@@ -1,26 +1,14 @@
 ---
 - hosts: all
   tasks:
-    - set_fact:
-        collection_path: "{{ '~/.ansible/collections/ansible_collections/kubernetes/core' | expanduser }}"
+    - name: Ensure tox is present
+      include_role:
+        name: ensure-tox
 
-    - name: Test using Molecule
-      shell: "source {{ ansible_test_venv_path }}/bin/activate; molecule test"
-      environment: "{{ ansible_test_environment | default({}) }}"
-      args:
-        chdir: "{{ collection_path }}"
-      when: molecule_test___tag_id is not defined
-
-    - name: Run molecule tests for specific group
-      block:
-        - name: Read list of tags
-          set_fact:
-            tags: "{{ lookup('file', collection_path ~ '/molecule/default/tags_' ~ molecule_test___tag_id  ~ '.txt') | replace('\n', ',') }}"
-
-        - name: Test using Molecule
-          shell: "source {{ ansible_test_venv_path }}/bin/activate; molecule test -- -v --tags {{ tags }}"
-          environment: "{{ ansible_test_environment | default({}) }}"
-          args:
-            chdir: ~/.ansible/collections/ansible_collections/kubernetes/core
-          when: molecule_test___tag_id is not defined
-      when: molecule_test___tag_id is defined
+    - name: Run molecule tests on tox
+      include_role:
+        name: tox
+      vars:
+        tox_extra_args: "-vv -- {{ molecule_test___id | default(omit) }}"
+        zuul_work_dir: "~/.ansible/collections/ansible_collections/kubernetes/core"
+        tox_install_siblings: false

--- a/playbooks/ansible-cloud/k8s/molecule.yaml
+++ b/playbooks/ansible-cloud/k8s/molecule.yaml
@@ -13,15 +13,9 @@
 
     - name: Run molecule tests for specific group
       block:
-        - name: tags group file name
+        - name: Read list of tags
           set_fact:
-            _tag_file: "{{ collection_path }}/molecule/default/tags_{{ molecule_test___tag_id }}.txt"
-
-        - debug: var=_tag_file
-
-        - name: Get list of tags to be executed
-          set_fact:
-            tags: "{{ lookup('file', _tag_file) | replace('\n', ',') }}"
+            tags: "{{ lookup('file', collection_path ~ '/molecule/default/tags_' ~ molecule_test___tag_id  ~ '.txt') | replace('\n', ',') }}"
 
         - name: Test using Molecule
           shell: "source {{ ansible_test_venv_path }}/bin/activate; molecule test -- -v --tags {{ tags }}"

--- a/playbooks/ansible-cloud/k8s/pre.yaml
+++ b/playbooks/ansible-cloud/k8s/pre.yaml
@@ -46,7 +46,7 @@
     - name: Install molecule and collection dependencies
       pip:
         name:
-          - molecule
+          - "molecule>=3.4.0"
           - yamllint
           - kubernetes
           - flake8

--- a/playbooks/ansible-cloud/k8s/pre.yaml
+++ b/playbooks/ansible-cloud/k8s/pre.yaml
@@ -43,17 +43,6 @@
       import_role:
         name: deploy-artifacts
 
-    - name: Install molecule and collection dependencies
-      pip:
-        name:
-          - "molecule>=3.4.0"
-          - yamllint
-          - kubernetes
-          - flake8
-          - jsonpatch
-        virtualenv: '{{ ansible_test_venv_path }}'
-        virtualenv_python: python3
-
     - name: Install Kubernetes cluster
       include_role:
         name: setup-kind

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -398,22 +398,6 @@
       ansible_collections_repo: github.com/ansible-collections/kubernetes.core
 
 - job:
-    name: ansible-test-integration-kubernetes-core
-    dependencies:
-      - name: build-ansible-collection
-    pre-run:
-      - playbooks/ansible-cloud/k8s/pre.yaml
-    run: playbooks/ansible-cloud/k8s/integration.yaml
-    required-projects:
-      - name: github.com/ansible/ansible
-      - name: github.com/ansible-collections/kubernetes.core
-    timeout: 5400
-    nodeset: centos-8-stream
-    vars:
-      ansible_test_python: 3.6
-      ansible_test_venv_path: "~/venv"
-
-- job:
     name: ansible-test-molecule-kubernetes-core
     dependencies:
       - name: build-ansible-collection

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -410,9 +410,7 @@
     timeout: 5400
     nodeset: centos-8-stream
     vars:
-      ansible_collections_repo: github.com/ansible-collections/kubernetes.core
       ansible_test_python: 3.6
-      ansible_test_collections: true
       ansible_test_venv_path: "~/venv"
 
 - job:
@@ -428,21 +426,83 @@
     timeout: 5400
     nodeset: centos-8-stream
     vars:
-      ansible_collections_repo: github.com/ansible-collections/kubernetes.core
-      ansible_test_collections: true
       ansible_test_python: 3.6
       ansible_test_venv_path: "~/venv"
 
 - job:
-    name: ansible-test-molecule-kubernetes-core-2.9
+    name: ansible-test-molecule-kubernetes-core-0
+    parent: ansible-test-molecule-kubernetes-core
+    vars:
+      molecule_test___tag_id: 0
+
+- job:
+    name: ansible-test-molecule-kubernetes-core-1
+    parent: ansible-test-molecule-kubernetes-core-0
+    vars:
+      molecule_test___tag_id: 1
+
+- job:
+    name: ansible-test-molecule-kubernetes-core-2
+    parent: ansible-test-molecule-kubernetes-core-0
+    vars:
+      molecule_test___tag_id: 2
+
+- job:
+    name: ansible-test-molecule-kubernetes-core-3
+    parent: ansible-test-molecule-kubernetes-core-0
+    vars:
+      molecule_test___tag_id: 3
+
+- job:
+    name: ansible-test-molecule-kubernetes-core-2.9-0
     parent: ansible-test-molecule-kubernetes-core
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.9
+    vars:
+      molecule_test___tag_id: 0
 
 - job:
-    name: ansible-test-molecule-kubernetes-core-2.10
+    name: ansible-test-molecule-kubernetes-core-2.9-1
+    parent: ansible-test-molecule-kubernetes-core-2.9-0
+    vars:
+      molecule_test___tag_id: 1
+
+- job:
+    name: ansible-test-molecule-kubernetes-core-2.9-2
+    parent: ansible-test-molecule-kubernetes-core-2.9-0
+    vars:
+      molecule_test___tag_id: 2
+
+- job:
+    name: ansible-test-molecule-kubernetes-core-2.9-3
+    parent: ansible-test-molecule-kubernetes-core-2.9-0
+    vars:
+      molecule_test___tag_id: 3
+
+- job:
+    name: ansible-test-molecule-kubernetes-core-2.10-0
     parent: ansible-test-molecule-kubernetes-core
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.10
+    vars:
+      molecule_test___tag_id: 0
+
+- job:
+    name: ansible-test-molecule-kubernetes-core-2.10-1
+    parent: ansible-test-molecule-kubernetes-core-2.10-0
+    vars:
+      molecule_test___tag_id: 1
+
+- job:
+    name: ansible-test-molecule-kubernetes-core-2.10-2
+    parent: ansible-test-molecule-kubernetes-core-2.10-0
+    vars:
+      molecule_test___tag_id: 2
+
+- job:
+    name: ansible-test-molecule-kubernetes-core-2.10-3
+    parent: ansible-test-molecule-kubernetes-core-2.10-0
+    vars:
+      molecule_test___tag_id: 3

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -412,30 +412,31 @@
     vars:
       ansible_test_python: 3.6
       ansible_test_venv_path: "~/venv"
+      tox_envlist: molecule-devel
 
 - job:
     name: ansible-test-molecule-kubernetes-core-0
     parent: ansible-test-molecule-kubernetes-core
     vars:
-      molecule_test___tag_id: 0
+      molecule_test___id: 0
 
 - job:
     name: ansible-test-molecule-kubernetes-core-1
     parent: ansible-test-molecule-kubernetes-core-0
     vars:
-      molecule_test___tag_id: 1
+      molecule_test___id: 1
 
 - job:
     name: ansible-test-molecule-kubernetes-core-2
     parent: ansible-test-molecule-kubernetes-core-0
     vars:
-      molecule_test___tag_id: 2
+      molecule_test___id: 2
 
 - job:
     name: ansible-test-molecule-kubernetes-core-3
     parent: ansible-test-molecule-kubernetes-core-0
     vars:
-      molecule_test___tag_id: 3
+      molecule_test___id: 3
 
 - job:
     name: ansible-test-molecule-kubernetes-core-2.9-0
@@ -444,25 +445,26 @@
       - name: github.com/ansible/ansible
         override-checkout: stable-2.9
     vars:
-      molecule_test___tag_id: 0
+      molecule_test___id: 0
+      tox_envlist: molecule-29
 
 - job:
     name: ansible-test-molecule-kubernetes-core-2.9-1
     parent: ansible-test-molecule-kubernetes-core-2.9-0
     vars:
-      molecule_test___tag_id: 1
+      molecule_test___id: 1
 
 - job:
     name: ansible-test-molecule-kubernetes-core-2.9-2
     parent: ansible-test-molecule-kubernetes-core-2.9-0
     vars:
-      molecule_test___tag_id: 2
+      molecule_test___id: 2
 
 - job:
     name: ansible-test-molecule-kubernetes-core-2.9-3
     parent: ansible-test-molecule-kubernetes-core-2.9-0
     vars:
-      molecule_test___tag_id: 3
+      molecule_test___id: 3
 
 - job:
     name: ansible-test-molecule-kubernetes-core-2.10-0
@@ -471,22 +473,23 @@
       - name: github.com/ansible/ansible
         override-checkout: stable-2.10
     vars:
-      molecule_test___tag_id: 0
+      molecule_test___id: 0
+      tox_envlist: molecule-210
 
 - job:
     name: ansible-test-molecule-kubernetes-core-2.10-1
     parent: ansible-test-molecule-kubernetes-core-2.10-0
     vars:
-      molecule_test___tag_id: 1
+      molecule_test___id: 1
 
 - job:
     name: ansible-test-molecule-kubernetes-core-2.10-2
     parent: ansible-test-molecule-kubernetes-core-2.10-0
     vars:
-      molecule_test___tag_id: 2
+      molecule_test___id: 2
 
 - job:
     name: ansible-test-molecule-kubernetes-core-2.10-3
     parent: ansible-test-molecule-kubernetes-core-2.10-0
     vars:
-      molecule_test___tag_id: 3
+      molecule_test___id: 3

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -670,10 +670,18 @@
         - ansible-test-sanity-docker-stable-2.10
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-units-kubernetes-core-python37
-        - ansible-test-integration-kubernetes-core
-        - ansible-test-molecule-kubernetes-core
-        - ansible-test-molecule-kubernetes-core-2.9
-        - ansible-test-molecule-kubernetes-core-2.10
+        - ansible-test-molecule-kubernetes-core-0
+        - ansible-test-molecule-kubernetes-core-1
+        - ansible-test-molecule-kubernetes-core-2
+        - ansible-test-molecule-kubernetes-core-3
+        - ansible-test-molecule-kubernetes-core-2.9-0
+        - ansible-test-molecule-kubernetes-core-2.9-1
+        - ansible-test-molecule-kubernetes-core-2.9-2
+        - ansible-test-molecule-kubernetes-core-2.9-3
+        - ansible-test-molecule-kubernetes-core-2.10-0
+        - ansible-test-molecule-kubernetes-core-2.10-1
+        - ansible-test-molecule-kubernetes-core-2.10-2
+        - ansible-test-molecule-kubernetes-core-2.10-3
         - ansible-tox-linters
     gate:
       jobs: *ansible-collections-kubernetes-core-units-jobs


### PR DESCRIPTION
``kubernetes.core`` molecule testing will be executed on ansible releases ``2.9`` and ``2.10`` in addition to the ``devel`` branch