### PR TITLE
cloud: ensure we've got py36 when required

### DIFF
--- a/playbooks/ansible-cloud/py36/pre.yaml
+++ b/playbooks/ansible-cloud/py36/pre.yaml
@@ -1,0 +1,10 @@
+---
+- hosts: controller
+  tasks:
+    - name: Ensure we've got python3.6 on the host for py36 jobs
+      become: true
+      package:
+        name: python3.6
+        state: present
+      when:
+        - ansible_test_python is version('3.6', '==')

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -24,6 +24,7 @@
     dependencies:
       - name: build-ansible-collection
     pre-run:
+      - playbooks/ansible-cloud/py36/pre.yaml
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/govcsim-base/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
@@ -70,6 +71,7 @@
     dependencies:
       - name: build-ansible-collection
     pre-run:
+      - playbooks/ansible-cloud/py36/pre.yaml
       - playbooks/ansible-test-base/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
     post-run: playbooks/ansible-test-base/post.yaml
@@ -284,6 +286,7 @@
       - name: build-ansible-collection
       - name: ansible-test-splitter
     pre-run:
+      - playbooks/ansible-cloud/py36/pre.yaml
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
     run: playbooks/ansible-test-base/run.yaml


### PR DESCRIPTION
On AWS, python-3.6 is not installed by default.

See: https://dashboard.zuul.ansible.com/t/ansible/build/6cdc48175fcc4213a3bbdf32562b158b/console