### PR TITLE
ansible-tox-py37: ensure py37 is installed

### DIFF
--- a/playbooks/ansible-tox-py37/pre.yaml
+++ b/playbooks/ansible-tox-py37/pre.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  tasks:
+    - name: Ensure python3.7 is present
+      become: true
+      package:
+        name: python3.7
+        state: present

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -68,6 +68,7 @@
 - job:
     name: ansible-tox-py37
     parent: tox-py37
+    pre-run: playbooks/ansible-tox-py37/pre.yaml
     timeout: 3600
     nodeset: fedora-latest-1vcpu
 


### PR DESCRIPTION
Ensure we've got the python3.7 package installed for the case where it's
not in the base system (AWS).