### PR TITLE
kubernetes.core: Add turbo mode job

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -446,3 +446,12 @@
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.10
+
+- job:
+    name: ansible-test-molecule-kubernetes-core-with-turbo
+    parent: ansible-test-molecule-kubernetes-core
+    required-projects:
+      - name: github.com/ansible-collections/cloud.common
+    vars:
+      ansible_test_environment:
+        ENABLE_TURBO_MODE: true

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -674,6 +674,7 @@
         - ansible-test-molecule-kubernetes-core
         - ansible-test-molecule-kubernetes-core-2.9
         - ansible-test-molecule-kubernetes-core-2.10
+        - ansible-test-molecule-kubernetes-core-with-turbo
         - ansible-tox-linters
     gate:
       jobs: *ansible-collections-kubernetes-core-units-jobs


### PR DESCRIPTION
Added an additional voting molecule job to test ``ENABLE_TURBO_MODE=True``
and cloud.common.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>