### PR TITLE
kubernetes.core - add job to run molecule test on ansible release 2.9 and 2.10

### DIFF
--- a/playbooks/ansible-cloud/k8s/pre.yaml
+++ b/playbooks/ansible-cloud/k8s/pre.yaml
@@ -46,7 +46,7 @@
     - name: Install molecule and collection dependencies
       pip:
         name:
-          - "molecule<3.3.0"
+          - molecule
           - yamllint
           - kubernetes
           - flake8

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -432,3 +432,17 @@
       ansible_test_collections: true
       ansible_test_python: 3.6
       ansible_test_venv_path: "~/venv"
+
+- job:
+    name: ansible-test-molecule-kubernetes-core-2.9
+    parent: ansible-test-molecule-kubernetes-core
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
+
+- job:
+    name: ansible-test-molecule-kubernetes-core-2.10
+    parent: ansible-test-molecule-kubernetes-core
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.10

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -672,6 +672,8 @@
         - ansible-test-units-kubernetes-core-python37
         - ansible-test-integration-kubernetes-core
         - ansible-test-molecule-kubernetes-core
+        - ansible-test-molecule-kubernetes-core-2.9
+        - ansible-test-molecule-kubernetes-core-2.10
         - ansible-tox-linters
     gate:
       jobs: *ansible-collections-kubernetes-core-units-jobs


### PR DESCRIPTION
kubernetes.core molecule test should run on ansible 2.9 and 2.10