### PR TITLE
Remove merge-check pipeline jobs

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1603,9 +1603,6 @@
     lgtm:
       jobs:
         - noop
-    merge-check:
-      jobs:
-        - noop
     unlabel-on-push:
       jobs:
         - noop


### PR DESCRIPTION
We actually do not need this, as github does it for free.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>