### PR TITLE
Slow targets should only be wrapped in a list once

### DIFF
--- a/roles/ansible-test-splitter/files/split_targets.py
+++ b/roles/ansible-test-splitter/files/split_targets.py
@@ -59,7 +59,7 @@ def get_targets_to_run(collection_path, targets_from_cli):
         if to_skip_because_disabled(lines):
             continue
         if is_slow(lines):
-            slow_targets.append([target.name])
+            slow_targets.append(target.name)
         else:
             regular_targets.append(target.name)
     return slow_targets, regular_targets
@@ -67,6 +67,8 @@ def get_targets_to_run(collection_path, targets_from_cli):
 
 def build_up_batches(slow_targets, regular_targets, total_jobs):
     remaining_jobs = max(total_jobs - len(slow_targets), 1)
+    # Slow targets is a list of slow targets so we need to wrap each entry in a
+    # list
     batches = [[i] for i in slow_targets]
     for x in range(remaining_jobs):
         batch = regular_targets[x::remaining_jobs]


### PR DESCRIPTION
We're currently seeing 'slow' tests double-wrapped in a list, this is breaking things:

```
  "for_zuul_return": {
    "data": {
      "child": {
        "targets_to_test": [
          [   
            [   
              "ec2_vpc_subnet"
            ]   
          ],  
          [   
            [   
              "ec2_vol"
            ]   
          ],  
          [   
            [   
              "ec2_ami"
            ]   
          ],  
          [   
            [   
              "ec2_eni"
            ]   
          ],  
          [   
            "aws_caller_info",
            "aws_s3",
            "lookup_aws_account_attribute",
            "ec2_elb_lb",
            "ec2_vpc_igw",
            "ec2",
            "inventory_aws_ec2",
            "module_utils_core",
            "ec2_key",
            "s3_bucket",
            "cloudformation",
            "ec2_vpc_dhcp_option",
            "module_utils_waiter"
          ],  
          [
            "ec2_metadata_facts",
            "ec2_spot_instance",
            "aws_az_info",
            "ec2_vpc_endpoint_service_info",
            "ec2_vpc_route_table",
            "inventory_aws_rds",
            "ec2_tag",
            "ec2_vpc_nat_gateway",
            "ec2_vpc_net",
            "lookup_aws_secret",
            "lookup_aws_service_ip_ranges",
            "module_utils_ec2"
          ]
        ]
      },
      "zuul": {
        "child_jobs": [
          "ansible-test-cloud-integration-aws-py36_0",
          "ansible-test-cloud-integration-aws-py36_1",
          "ansible-test-cloud-integration-aws-py36_2",
          "ansible-test-cloud-integration-aws-py36_3",
          "ansible-test-cloud-integration-aws-py36_4",
          "ansible-test-cloud-integration-aws-py36_5"
        ]
      }
    }
  }
}
```