### PR TITLE
Fix splitter to correctly format list of jobs

### DIFF
--- a/roles/ansible-test-splitter/files/split_targets.py
+++ b/roles/ansible-test-splitter/files/split_targets.py
@@ -59,7 +59,7 @@ def get_targets_to_run(collection_path, targets_from_cli):
         if to_skip_because_disabled(lines):
             continue
         if is_slow(lines):
-            slow_targets.append([target.name])
+            slow_targets.append(target.name)
         else:
             regular_targets.append(target.name)
     return slow_targets, regular_targets


### PR DESCRIPTION
The slow jobs get placed into separate lists later down in `build_up_batches()`.