### PR TITLE
Remove integration testsfor kubernetes.core

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -398,24 +398,6 @@
       ansible_collections_repo: github.com/ansible-collections/kubernetes.core
 
 - job:
-    name: ansible-test-integration-kubernetes-core
-    dependencies:
-      - name: build-ansible-collection
-    pre-run:
-      - playbooks/ansible-cloud/k8s/pre.yaml
-    run: playbooks/ansible-cloud/k8s/integration.yaml
-    required-projects:
-      - name: github.com/ansible/ansible
-      - name: github.com/ansible-collections/kubernetes.core
-    timeout: 5400
-    nodeset: centos-8-stream
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/kubernetes.core
-      ansible_test_python: 3.6
-      ansible_test_collections: true
-      ansible_test_venv_path: "~/venv"
-
-- job:
     name: ansible-test-molecule-kubernetes-core
     dependencies:
       - name: build-ansible-collection

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -670,7 +670,6 @@
         - ansible-test-sanity-docker-stable-2.10
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-units-kubernetes-core-python37
-        - ansible-test-integration-kubernetes-core
         - ansible-test-molecule-kubernetes-core
         - ansible-test-molecule-kubernetes-core-2.9
         - ansible-test-molecule-kubernetes-core-2.10


### PR DESCRIPTION
``kubernetes.core`` integration tests have been migrated to molecule tests, this job is not needed anymore.