### PR TITLE
Add irrelevant-files for network-ee-tests-base

### DIFF
--- a/zuul.d/ansible-test-jobs.yaml
+++ b/zuul.d/ansible-test-jobs.yaml
@@ -11,6 +11,8 @@
     required-projects:
       - name: github.com/ansible/ansible
     timeout: 3600
+    irrelevant-files:
+      - .pre-commit-config.yaml
     vars:
       ansible_test_collections: true
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -209,6 +209,8 @@
       - name: github.com/ansible/ansible
         override-checkout: stable-2.9
     timeout: 3600
+    irrelevant-files:
+      - .pre-commit-config.yaml
     vars:
       ansible_test_collections: true
       ansible_test_command: units

--- a/zuul.d/network-jobs.yaml
+++ b/zuul.d/network-jobs.yaml
@@ -3,6 +3,8 @@
     name: network-ee-tests-base
     parent: ansible-ee-tests-base
     abstract: true
+    irrelevant-files:
+      - .pre-commit-config.yaml
     vars:
       container_image_name: quay.io/ansible/network-ee
 


### PR DESCRIPTION
We don't need to run testing on pre-commit changes.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>