### PR TITLE
okd: don't use k.core 1.2

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -431,7 +431,6 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/kubernetes.core
-                override-checkout: stable-1.2
         - ansible-galaxy-importer:
             voting: false
 


### PR DESCRIPTION
We don't need that anymore. Let's use the main branch by default.