### PR TITLE
okd: use 3pci-check pipeline

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -416,7 +416,7 @@
 
 - project-template:
     name: ansible-collections-community-okd
-    third-party-check:
+    3pci-check:
       jobs:
         - build-ansible-collection:
             required-projects:


### PR DESCRIPTION
3pci-check is associated with the Ansible Zuul Third Party CI app.
https://github.com/apps/ansible-zuul-third-party-ci