### PR TITLE
Clean up network-ee integration tests

### DIFF
--- a/zuul.d/ansible-utils-jobs.yaml
+++ b/zuul.d/ansible-utils-jobs.yaml
@@ -2,50 +2,6 @@
 # ansible-collections/ansible.utils jobs
 # =============================================================================
 - job:
-    name: network-ee-integration-tests-ansible-utils
-    parent: ansible-network-openvswitch-appliance
-
-- job:
-    name: network-ee-integration-tests-ansible-utils
-    parent: network-ee-integration-tests
-    nodeset: openvswitch-2.9.0-python38
-    vars:
-      collection_name: utils
-      collection_namespace: ansible
-
-# =============================================================================
-
-- job:
-    name: network-ee-integration-tests-ansible-utils-stable-2.11
-    parent: ansible-network-openvswitch-appliance
-
-- job:
-    name: network-ee-integration-tests-ansible-utils-stable-2.11
-    parent: network-ee-integration-tests-stable-2.11
-    nodeset: openvswitch-2.9.0-python38
-    vars:
-      test_ansible_python_interpreter: /usr/bin/python3.6
-      collection_name: utils
-      collection_namespace: ansible
-
-# =============================================================================
-
-- job:
-    name: network-ee-integration-tests-ansible-utils-stable-2.9
-    parent: ansible-network-openvswitch-appliance
-
-- job:
-    name: network-ee-integration-tests-ansible-utils-stable-2.9
-    parent: network-ee-integration-tests-stable-2.9
-    nodeset: openvswitch-2.9.0-python38
-    vars:
-      test_ansible_python_interpreter: /usr/bin/python3.6
-      collection_name: utils
-      collection_namespace: ansible
-
-# =============================================================================
-
-- job:
     name: ansible-test-units-ansible-utils-python27
     parent: ansible-test-units-base-python27
     required-projects:
@@ -76,3 +32,43 @@
       - name: github.com/ansible-collections/ansible.utils
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.utils
+
+# =============================================================================
+- job:
+    name: network-ee-integration-tests-ansible-utils
+    parent: ansible-network-openvswitch-appliance
+
+- job:
+    name: network-ee-integration-tests-ansible-utils
+    parent: network-ee-integration-tests
+    nodeset: openvswitch-2.9.0-python38
+    vars:
+      collection_name: utils
+      collection_namespace: ansible
+
+# =============================================================================
+- job:
+    name: network-ee-integration-tests-ansible-utils-stable-2.11
+    parent: ansible-network-openvswitch-appliance
+
+- job:
+    name: network-ee-integration-tests-ansible-utils-stable-2.11
+    parent: network-ee-integration-tests-stable-2.11
+    nodeset: openvswitch-2.9.0-python38
+    vars:
+      collection_name: utils
+      collection_namespace: ansible
+
+# =============================================================================
+- job:
+    name: network-ee-integration-tests-ansible-utils-stable-2.9
+    parent: ansible-network-openvswitch-appliance
+
+- job:
+    name: network-ee-integration-tests-ansible-utils-stable-2.9
+    parent: network-ee-integration-tests-stable-2.9
+    nodeset: openvswitch-2.9.0-python38
+    vars:
+      test_ansible_python_interpreter: /usr/bin/python3
+      collection_name: utils
+      collection_namespace: ansible

--- a/zuul.d/openvswitch-openvswitch-jobs.yaml
+++ b/zuul.d/openvswitch-openvswitch-jobs.yaml
@@ -1,6 +1,6 @@
 ---
 # ansible-collections/openvswitch.openvswitch jobs
-
+# =============================================================================
 - job:
     name: ansible-network-openvswitch-appliance
     parent: ansible-network-appliance-base
@@ -47,6 +47,7 @@
     vars:
       ansible_collections_repo: github.com/ansible-collections/openvswitch.openvswitch
 
+# =============================================================================
 - job:
     name: network-ee-integration-tests-openvswitch-openvswitch
     parent: ansible-network-openvswitch-appliance
@@ -56,6 +57,7 @@
     parent: network-ee-integration-tests
     nodeset: openvswitch-2.9.0-python38
 
+# =============================================================================
 - job:
     name: network-ee-integration-tests-openvswitch-openvswitch-stable-2.11
     parent: ansible-network-openvswitch-appliance
@@ -64,9 +66,8 @@
     name: network-ee-integration-tests-openvswitch-openvswitch-stable-2.11
     parent: network-ee-integration-tests-stable-2.11
     nodeset: openvswitch-2.9.0-python38
-    vars:
-      test_ansible_python_interpreter: /usr/bin/python3.6
 
+# =============================================================================
 - job:
     name: network-ee-integration-tests-openvswitch-openvswitch-stable-2.9
     parent: ansible-network-openvswitch-appliance
@@ -76,4 +77,4 @@
     parent: network-ee-integration-tests-stable-2.9
     nodeset: openvswitch-2.9.0-python38
     vars:
-      test_ansible_python_interpreter: /usr/bin/python3.6
+      test_ansible_python_interpreter: /usr/bin/python3

--- a/zuul.d/vyos-vyos-jobs.yaml
+++ b/zuul.d/vyos-vyos-jobs.yaml
@@ -75,8 +75,6 @@
     name: network-ee-integration-tests-vyos-stable-2.11
     parent: network-ee-integration-tests-stable-2.11
     nodeset: vyos-1.1.8-python38
-    vars:
-      test_ansible_python_interpreter: /usr/bin/python3
 
 - job:
     name: network-ee-integration-tests-vyos-libssh-stable-2.11


### PR DESCRIPTION
Don't set python interpreter on stable-2.11 jobs. We should also use
/usr/bin/python3 which is what devel jobs use. Finally some
reformatting.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>