### PR TITLE
Drop py37 in favor for py38

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -43,11 +43,11 @@
     check:
       jobs:
         - ansible-tox-py36
-        - ansible-tox-py37
+        - ansible-tox-py38
     gate:
       jobs:
         - ansible-tox-py36
-        - ansible-tox-py37
+        - ansible-tox-py38
 
 - project-template:
     name: ansible-collections-amazon-aws


### PR DESCRIPTION
Currently py37 is only run on fedora, given nothing else really uses it
lets bump this to py38. We do support py38 for downstream products.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>