### PR TITLE
vcenter: install squid on the datastore

### DIFF
--- a/roles/vmware-ci-nfs-share/tasks/main.yaml
+++ b/roles/vmware-ci-nfs-share/tasks/main.yaml
@@ -41,3 +41,15 @@
   become: true
   notify:
     - Restart nfs-server
+
+- name: Install squid
+  package:
+    name: squid
+    state: present
+  become: true
+
+- name: Start squid
+  systemd:
+    state: started
+    name: squid
+  become: true


### PR DESCRIPTION
We need squid to validate the proxy support
