### PR TITLE
cloud.common/vmware_rest: periodic jobs need the artifacts

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -495,6 +495,7 @@
         - ansible-test-sanity-docker-stable-2.10
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-units-cloud-common-python38
+        - build-ansible-collection
 
 - project-template:
     name: ansible-collections-community-vmware
@@ -560,6 +561,7 @@
         - ansible-test-sanity-docker-stable-2.9
         - ansible-test-sanity-docker-stable-2.10
         - ansible-test-sanity-docker-stable-2.11
+        - build-ansible-collection
 
 - project-template:
     name: ansible-collections-community-vmware-rest-code-generator


### PR DESCRIPTION
The sanity jobs need the collection artifacts. This commit ensures we
call `build-ansible-collection` first.
