### PR TITLE
amazon.aws/gate: temporarily disabled the integration job

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -85,15 +85,6 @@
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/community.aws
               - name: github.com/ansible-collections/community.general
-        - ansible-test-splitter:
-            vars:
-              ansible_test_splitter__test_changed: false
-        - ansible-test-cloud-integration-aws-py36_0
-        - ansible-test-cloud-integration-aws-py36_1
-        - ansible-test-cloud-integration-aws-py36_2
-        - ansible-test-cloud-integration-aws-py36_3
-        - ansible-test-cloud-integration-aws-py36_4
-        - ansible-test-cloud-integration-aws-py36_5
 
 - project-template:
     name: ansible-collections-community-aws


### PR DESCRIPTION
We've got a bunch of PR that we trust to land quickly. We will reverse
the PR once they are merged.
