### PR TITLE
ansible-test-sanity-docker: bump to py38

### DIFF
--- a/zuul.d/ansible-test-jobs.yaml
+++ b/zuul.d/ansible-test-jobs.yaml
@@ -2,7 +2,7 @@
 - job:
     name: ansible-test-sanity-docker
     parent: unittests
-    nodeset: controller-python36
+    nodeset: controller-python38
     dependencies:
       - name: build-ansible-collection
         soft: true
@@ -19,7 +19,7 @@
       ansible_test_command: sanity
       ansible_test_docker: true
       ansible_test_enable_ara: false
-      ansible_test_python: 3.6
+      ansible_test_python: 3.8
       container_command: podman
 
 - job:


### PR DESCRIPTION
This to address the following error introduced by
https://github.com/ansible/ansible/pull/75605

    This version of ansible-test cannot be executed with Python version
    3.6.8. Supported Python versions are: 3.8, 3.9, 3.10
