### PR TITLE
govcsim: run on python38

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -19,12 +19,11 @@
 # govcsim
 
 - job:
-    name: ansible-test-cloud-integration-govcsim-python36
-    nodeset: vmware-govcsim-python36
+    name: ansible-test-cloud-integration-govcsim-python38
+    nodeset: vmware-govcsim-python38
     dependencies:
       - name: build-ansible-collection
     pre-run:
-      - playbooks/ansible-cloud/py36/pre.yaml
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/govcsim-base/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
@@ -36,7 +35,7 @@
     timeout: 3600
     vars:
       ansible_collections_repo: github.com/ansible-collections/community.vmware
-      ansible_test_python: 3.6
+      ansible_test_python: 3.8
       ansible_test_integration_targets: zuul/vmware/govcsim/
       ansible_test_command: integration
       ansible_test_split_in: 3
@@ -45,20 +44,20 @@
         VMWARE_TEST_PLATFORM: static
 
 - job:
-    name: ansible-test-cloud-integration-govcsim-python36_1_of_3
-    parent: ansible-test-cloud-integration-govcsim-python36
+    name: ansible-test-cloud-integration-govcsim-python38_1_of_3
+    parent: ansible-test-cloud-integration-govcsim-python38
     vars:
       ansible_test_do_number: 1
 
 - job:
-    name: ansible-test-cloud-integration-govcsim-python36_2_of_3
-    parent: ansible-test-cloud-integration-govcsim-python36
+    name: ansible-test-cloud-integration-govcsim-python38_2_of_3
+    parent: ansible-test-cloud-integration-govcsim-python38
     vars:
       ansible_test_do_number: 2
 
 - job:
-    name: ansible-test-cloud-integration-govcsim-python36_3_of_3
-    parent: ansible-test-cloud-integration-govcsim-python36
+    name: ansible-test-cloud-integration-govcsim-python38_3_of_3
+    parent: ansible-test-cloud-integration-govcsim-python38
     vars:
       ansible_test_do_number: 3
 

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -55,7 +55,7 @@
 
 # Ansible cloud appliance nodesets
 - nodeset:
-    name: vmware-govcsim-python36
+    name: vmware-govcsim-python38
     nodes:
       - name: fedora-34
         label: fedora-34-1vcpu

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -500,11 +500,11 @@
     name: ansible-collections-community-vmware
     check:
       jobs:
-        - ansible-test-cloud-integration-govcsim-python36_1_of_3:
+        - ansible-test-cloud-integration-govcsim-python38_1_of_3:
             voting: false
-        - ansible-test-cloud-integration-govcsim-python36_2_of_3:
+        - ansible-test-cloud-integration-govcsim-python38_2_of_3:
             voting: false
-        - ansible-test-cloud-integration-govcsim-python36_3_of_3:
+        - ansible-test-cloud-integration-govcsim-python38_3_of_3:
             voting: false
         - ansible-tox-linters
         - build-ansible-collection
@@ -522,11 +522,11 @@
         - ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_2_of_2
     gate:
       jobs:
-        - ansible-test-cloud-integration-govcsim-python36_1_of_3:
+        - ansible-test-cloud-integration-govcsim-python38_1_of_3:
             voting: false
-        - ansible-test-cloud-integration-govcsim-python36_2_of_3:
+        - ansible-test-cloud-integration-govcsim-python38_2_of_3:
             voting: false
-        - ansible-test-cloud-integration-govcsim-python36_3_of_3:
+        - ansible-test-cloud-integration-govcsim-python38_3_of_3:
             voting: false
         - ansible-tox-linters
         - build-ansible-collection


### PR DESCRIPTION
Run the govcsim tests on python38 to avoid the following problem:

    This version of ansible-test cannot be executed with Python version 3.6.15. Supported Python versions are: 3.8, 3.9, 3.10

Introduced by https://github.com/ansible/ansible/pull/75605
