### PR TITLE
rename the aws-sanity jobs

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -372,7 +372,7 @@
 
 #### sanity
 - job:
-    name: ansible-test-sanity-aws-ansible-python36
+    name: ansible-test-sanity-aws-ansible
     parent: ansible-test-sanity-docker
     vars:
       ansible_test_sanity_skiptests:
@@ -380,7 +380,7 @@
         - 'metaclass-boilerplate'
 
 - job:
-    name: ansible-test-sanity-aws-ansible-2.9-python36
+    name: ansible-test-sanity-aws-ansible-2.9
     parent: ansible-test-sanity-docker-stable-2.9
     vars:
       ansible_test_sanity_skiptests:
@@ -388,7 +388,7 @@
         - 'metaclass-boilerplate'
 
 - job:
-    name: ansible-test-sanity-aws-ansible-2.11-python36
+    name: ansible-test-sanity-aws-ansible-2.11
     parent: ansible-test-sanity-docker-stable-2.11
     vars:
       ansible_test_sanity_skiptests:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -54,9 +54,9 @@
     check:
       queue: integrated-aws
       jobs: &ansible-collections-amazon-aws-jobs
-        - ansible-test-sanity-aws-ansible-python36
-        - ansible-test-sanity-aws-ansible-2.9-python36
-        - ansible-test-sanity-aws-ansible-2.11-python36
+        - ansible-test-sanity-aws-ansible
+        - ansible-test-sanity-aws-ansible-2.9
+        - ansible-test-sanity-aws-ansible-2.11
         - ansible-test-units-amazon-aws-python38
         - build-ansible-collection:
             required-projects:


### PR DESCRIPTION
Drop the -python36 suffix, the version doesn't really matter and
is defined ansible-test-sanity-docker. It's py38 now.
