### PR TITLE
Move netcommon-specific test runs to python38

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -170,15 +170,15 @@
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
 
 - job:
-    name: ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python36
-    parent: ansible-test-network-integration-iosxr-python36
+    name: ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python38
+    parent: ansible-test-network-integration-iosxr-python38
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
-    name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python36
-    parent: ansible-test-network-integration-junos-vsrx-python36
+    name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python38
+    parent: ansible-test-network-integration-junos-vsrx-python38
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -411,7 +411,7 @@
     name: ansible-collections-cisco-iosxr-netconf
     check:
       jobs:
-        - ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python36:
+        - ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python38:
             vars:
               ansible_test_collections: true
             voting: false
@@ -689,7 +689,7 @@
     name: ansible-collections-juniper-junos-netconf
     check:
       jobs: &ansible-collections-juniper-junos-netconf-jobs
-        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python36:
+        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python38:
             vars:
               ansible_test_collections: true
         - build-ansible-collection:


### PR DESCRIPTION
The underlying jobs have moved, so this should work now

This is obsoleted by https://github.com/ansible/ansible-zuul-jobs/pull/1087 and https://github.com/ansible/ansible-zuul-jobs/pull/1129, but unblocks testing in the meantime