### PR TITLE
Migrate Security platforms integration test jobs to use network-ee and update from py36 to py38

### DIFF
--- a/zuul.d/ansible-security-jobs.yaml
+++ b/zuul.d/ansible-security-jobs.yaml
@@ -3,7 +3,9 @@
 - job:
     name: ansible-security-splunk-appliance
     parent: ansible-network-appliance-base
-    pre-run: playbooks/ansible-security-splunk-appliance/pre.yaml
+    pre-run:
+      - playbooks/ansible-security-splunk-appliance/pre.yaml
+      - playbooks/network-ee-integration-tests/pre.yaml
     run: playbooks/ansible-security-splunk-appliance/run.yaml
     host-vars:
       SplunkEnterprise-SES-8.0.0:
@@ -21,7 +23,7 @@
     parent: ansible-security-splunk-appliance
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
-      - playbooks/ansible-test-network-integration-base/pre.yaml
+      - playbooks/network-ee-integration-tests/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
     post-run:
       - playbooks/ansible-test-network-integration-base/post.yaml
@@ -36,13 +38,23 @@
       ansible_test_collections: true
 
 - job:
-    name: ansible-security-integration-splunk-es-python27
+    name: network-ee-integration-splunk-es-python27
     parent: ansible-security-integration-splunk
     vars:
       ansible_test_python: 2.7
 
 - job:
+<<<<<<< HEAD
     name: ansible-security-integration-splunk-es-python38
+=======
+    name: network-ee-integration-splunk-es-python36
+    parent: ansible-security-integration-splunk
+    vars:
+      ansible_test_python: 3.6
+
+- job:
+    name: network-ee-integration-splunk-es-python38
+>>>>>>> 8d3b9ef (to support network-ee)
     parent: ansible-security-integration-splunk
     vars:
       ansible_test_python: 3.8
@@ -51,7 +63,9 @@
 - job:
     name: ansible-security-qradar-appliance
     parent: ansible-network-appliance-base
-    pre-run: playbooks/ansible-security-qradar-appliance/pre.yaml
+    pre-run:
+      - playbooks/ansible-security-qradar-appliance/pre.yaml
+      - playbooks/network-ee-integration-tests/pre.yaml
     run: playbooks/ansible-security-qradar-appliance/run.yaml
     host-vars:
       QRadarCE-7.3.1:
@@ -69,7 +83,7 @@
     parent: ansible-security-qradar-appliance
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
-      - playbooks/ansible-test-network-integration-base/pre.yaml
+      - playbooks/network-ee-integration-tests/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
     post-run:
       - playbooks/ansible-test-network-integration-base/post.yaml
@@ -84,13 +98,23 @@
       ansible_test_collections: true
 
 - job:
-    name: ansible-test-security-integration-qradar-python27
+    name: network-ee-integration-integration-qradar-python27
     parent: ansible-test-security-integration-qradar
     vars:
       ansible_test_python: 2.7
 
 - job:
+<<<<<<< HEAD
     name: ansible-test-security-integration-qradar-python38
+=======
+    name: network-ee-integration-integration-qradar-python36
+    parent: ansible-test-security-integration-qradar
+    vars:
+      ansible_test_python: 3.6
+
+- job:
+    name: network-ee-integration-integration-qradar-python38
+>>>>>>> 8d3b9ef (to support network-ee)
     parent: ansible-test-security-integration-qradar
     vars:
       ansible_test_python: 3.8
@@ -99,7 +123,9 @@
 - job:
     name: ansible-security-trendmicro-deepsec-appliance
     parent: ansible-network-appliance-base
-    pre-run: playbooks/ansible-security-trendmicro-deepsec-appliance/pre.yaml
+    pre-run:
+      - playbooks/ansible-security-trendmicro-deepsec-appliance/pre.yaml
+      - playbooks/network-ee-integration-tests/pre.yaml
     run: playbooks/ansible-security-trendmicro-deepsec-appliance/run.yaml
     host-vars:
       Trendmicro-DeepSecurity-20.0.344:
@@ -117,7 +143,7 @@
     parent: ansible-security-trendmicro-deepsec-appliance
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
-      - playbooks/ansible-test-network-integration-base/pre.yaml
+      - playbooks/network-ee-integration-tests/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
     post-run:
       - playbooks/ansible-test-network-integration-base/post.yaml
@@ -132,7 +158,7 @@
       ansible_test_collections: true
 
 - job:
-    name: ansible-security-integration-trendmicro-deepsec-python27
+    name: network-ee-integration-trendmicro-deepsec-python27
     parent: ansible-security-integration-trendmicro-deepsec
     nodeset: Trendmicro-DeepSecurity-20.0.344-python27
     required-projects:
@@ -142,7 +168,7 @@
       ansible_test_python: 2.7
 
 - job:
-    name: ansible-security-integration-trendmicro-deepsec-python36
+    name: network-ee-integration-trendmicro-deepsec-python36
     parent: ansible-security-integration-trendmicro-deepsec
     nodeset: Trendmicro-DeepSecurity-20.0.344-python36
     required-projects:
@@ -152,7 +178,7 @@
       ansible_test_python: 3.6
 
 - job:
-    name: ansible-security-integration-trendmicro-deepsec-python38
+    name: network-ee-integration-trendmicro-deepsec-python38
     parent: ansible-security-integration-trendmicro-deepsec
     nodeset: Trendmicro-DeepSecurity-20.0.344-python38
     vars:
@@ -161,66 +187,88 @@
 # stable29
 
 - job:
-    name: ansible-security-integration-splunk-es-python38-stable29
-    parent: ansible-security-integration-splunk-es-python38
+    name: network-ee-integration-splunk-es-python38-stable29
+    parent: network-ee-integration-splunk-es-python38
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.9
 
 - job:
-    name: ansible-test-security-integration-qradar-python38-stable29
-    parent: ansible-test-security-integration-qradar-python38
+    name: network-ee-integration-qradar-python38-stable29
+    parent: network-ee-integration-qradar-python38
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.9
 
 - job:
-    name: ansible-security-integration-trendmicro-deepsec-python38-stable29
-    parent: ansible-security-integration-trendmicro-deepsec-python38
+    name: network-ee-integration-trendmicro-deepsec-python38-stable29
+    parent: network-ee-integration-trendmicro-deepsec-python38
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.9
 
 # stable211
 - job:
-    name: ansible-security-integration-splunk-es-python38-stable211
-    parent: ansible-security-integration-splunk-es-python38
+    name: network-ee-integration-splunk-es-python38-stable210
+    parent: network-ee-integration-splunk-es-python38
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.11
 
 - job:
-    name: ansible-test-security-integration-qradar-python38-stable211
-    parent: ansible-test-security-integration-qradar-python38
+    name: network-ee-integration-qradar-python38-stable210
+    parent: network-ee-integration-qradar-python38
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.11
 
 - job:
-    name: ansible-security-integration-trendmicro-deepsec-python38-stable211
-    parent: ansible-security-integration-trendmicro-deepsec-python38
+    name: network-ee-integration-trendmicro-deepsec-python38-stable210
+    parent: network-ee-integration-trendmicro-deepsec-python38
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.11
 
 # stable212
 - job:
-    name: ansible-security-integration-splunk-es-python38-stable212
-    parent: ansible-security-integration-splunk-es-python38
+    name: network-ee-integration-splunk-es-python38-stable211
+    parent: network-ee-integration-splunk-es-python38
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.12
 
 - job:
-    name: ansible-test-security-integration-qradar-python38-stable212
-    parent: ansible-test-security-integration-qradar-python38
+    name: network-ee-integration-qradar-python38-stable211
+    parent: network-ee-integration-qradar-python38
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.12
 
 - job:
-    name: ansible-security-integration-trendmicro-deepsec-python38-stable212
-    parent: ansible-security-integration-trendmicro-deepsec-python38
+    name: network-ee-integration-trendmicro-deepsec-python38-stable211
+    parent: network-ee-integration-trendmicro-deepsec-python38
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
+
+# stable212
+- job:
+    name: network-ee-integration-splunk-es-python38-stable212
+    parent: network-ee-integration-splunk-es-python38
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.12
+
+- job:
+    name: network-ee-integration-qradar-python38-stable212
+    parent: network-ee-integration-qradar-python38
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.12
+
+- job:
+    name: network-ee-integration-trendmicro-deepsec-python38-stable212
+    parent: network-ee-integration-trendmicro-deepsec-python38
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.12

--- a/zuul.d/ansible-security-jobs.yaml
+++ b/zuul.d/ansible-security-jobs.yaml
@@ -38,7 +38,6 @@
       ansible_test_collections: true
 
 - job:
-    name: ansible-security-integration-splunk-es-python38
     name: network-ee-integration-splunk-es-python36
     parent: ansible-security-integration-splunk
     vars:
@@ -89,14 +88,12 @@
       ansible_test_collections: true
 
 - job:
-    name: network-ee-integration-integration-qradar-python36
     name: network-ee-integration-qradar-python36
     parent: ansible-test-security-integration-qradar
     vars:
       ansible_test_python: 3.6
 
 - job:
-    name: network-ee-integration-integration-qradar-python38
     name: network-ee-integration-qradar-python38
     parent: ansible-test-security-integration-qradar
     vars:

--- a/zuul.d/ansible-security-jobs.yaml
+++ b/zuul.d/ansible-security-jobs.yaml
@@ -38,15 +38,7 @@
       ansible_test_collections: true
 
 - job:
-    name: network-ee-integration-splunk-es-python27
-    parent: ansible-security-integration-splunk
-    vars:
-      ansible_test_python: 2.7
-
-- job:
-<<<<<<< HEAD
     name: ansible-security-integration-splunk-es-python38
-=======
     name: network-ee-integration-splunk-es-python36
     parent: ansible-security-integration-splunk
     vars:
@@ -54,7 +46,6 @@
 
 - job:
     name: network-ee-integration-splunk-es-python38
->>>>>>> 8d3b9ef (to support network-ee)
     parent: ansible-security-integration-splunk
     vars:
       ansible_test_python: 3.8
@@ -98,23 +89,15 @@
       ansible_test_collections: true
 
 - job:
-    name: network-ee-integration-integration-qradar-python27
-    parent: ansible-test-security-integration-qradar
-    vars:
-      ansible_test_python: 2.7
-
-- job:
-<<<<<<< HEAD
-    name: ansible-test-security-integration-qradar-python38
-=======
     name: network-ee-integration-integration-qradar-python36
+    name: network-ee-integration-qradar-python36
     parent: ansible-test-security-integration-qradar
     vars:
       ansible_test_python: 3.6
 
 - job:
     name: network-ee-integration-integration-qradar-python38
->>>>>>> 8d3b9ef (to support network-ee)
+    name: network-ee-integration-qradar-python38
     parent: ansible-test-security-integration-qradar
     vars:
       ansible_test_python: 3.8
@@ -156,16 +139,6 @@
       ansible_test_command: network-integration
       ansible_test_integration_targets: "deepsec_.*"
       ansible_test_collections: true
-
-- job:
-    name: network-ee-integration-trendmicro-deepsec-python27
-    parent: ansible-security-integration-trendmicro-deepsec
-    nodeset: Trendmicro-DeepSecurity-20.0.344-python27
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.11
-    vars:
-      ansible_test_python: 2.7
 
 - job:
     name: network-ee-integration-trendmicro-deepsec-python36

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -360,3 +360,22 @@
     nodes:
       - name: controller
         label: ansible-fedora-35-1vcpu
+
+- nodeset:
+    name: ansible-tox-py38
+    nodes:
+      - name: controller
+        label: ansible-fedora-35-1vcpu
+
+- nodeset:
+    name: ansible-tox-py39
+    nodes:
+      - name: controller
+        label: ansible-fedora-35-1vcpu
+
+
+- nodeset:
+    name: ansible-tox-py310
+    nodes:
+      - name: controller
+        label: ansible-fedora-35-1vcpu

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -169,6 +169,8 @@
         nodes:
           - controller
 
+# Ansible Security appliance nodesets
+
 - nodeset:
     name: QRadarCE-7.3.1-python38
     nodes:
@@ -177,12 +179,6 @@
 
 - nodeset:
     name: SplunkEnterprise-SES-8.0.0-python38
-    nodes:
-      - name: fedora-35
-        label: ansible-fedora-35-1vcpu
-
-- nodeset:
-    name: Trendmicro-DeepSecurity-20.0.344-python27
     nodes:
       - name: fedora-35
         label: ansible-fedora-35-1vcpu
@@ -364,61 +360,3 @@
     nodes:
       - name: controller
         label: ansible-fedora-35-1vcpu
-
-# Ansible Security appliance nodesets
-- nodeset:
-    name: QRadarCE-7.3.1-python38
-    nodes:
-      - name: fedora-35
-        label: ansible-fedora-35-1vcpu
-      - name: QRadarCE-7.3.1
-        label: QRadarCE-7.3.1
-    groups:
-      - name: appliance
-        nodes:
-          - QRadarCE-7.3.1
-      - name: controller
-        nodes:
-          - fedora-35
-      - name: aws
-        nodes:
-          - QRadarCE-7.3.1
-          - fedora-35
-
-- nodeset:
-    name: SplunkEnterprise-SES-8.0.0-python38
-    nodes:
-      - name: fedora-35
-        label: ansible-fedora-35-1vcpu
-      - name: SplunkEnterprise-SES-8.0.0
-        label: SplunkEnterprise-SES-8.0.0
-    groups:
-      - name: appliance-ssh
-        nodes:
-          - SplunkEnterprise-SES-8.0.0
-      - name: controller
-        nodes:
-          - fedora-35
-      - name: aws
-        nodes:
-          - SplunkEnterprise-SES-8.0.0
-          - fedora-35
-
-- nodeset:
-    name: Trendmicro-DeepSecurity-20.0.344-python38
-    nodes:
-      - name: fedora-35
-        label: ansible-fedora-35-1vcpu
-      - name: Trendmicro-DeepSecurity-20.0.344
-        label: Trendmicro-DeepSecurity-20.0.344
-    groups:
-      - name: appliance-ssh
-        nodes:
-          - Trendmicro-DeepSecurity-20.0.344
-      - name: controller
-        nodes:
-          - fedora-35
-      - name: aws
-        nodes:
-          - Trendmicro-DeepSecurity-20.0.344
-          - fedora-35

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -365,21 +365,60 @@
       - name: controller
         label: ansible-fedora-35-1vcpu
 
+# Ansible Security appliance nodesets
 - nodeset:
-    name: ansible-tox-py38
+    name: QRadarCE-7.3.1-python38
     nodes:
-      - name: controller
+      - name: fedora-35
         label: ansible-fedora-35-1vcpu
+      - name: QRadarCE-7.3.1
+        label: QRadarCE-7.3.1
+    groups:
+      - name: appliance
+        nodes:
+          - QRadarCE-7.3.1
+      - name: controller
+        nodes:
+          - fedora-35
+      - name: aws
+        nodes:
+          - QRadarCE-7.3.1
+          - fedora-35
 
 - nodeset:
-    name: ansible-tox-py39
+    name: SplunkEnterprise-SES-8.0.0-python38
     nodes:
-      - name: controller
+      - name: fedora-35
         label: ansible-fedora-35-1vcpu
-
+      - name: SplunkEnterprise-SES-8.0.0
+        label: SplunkEnterprise-SES-8.0.0
+    groups:
+      - name: appliance-ssh
+        nodes:
+          - SplunkEnterprise-SES-8.0.0
+      - name: controller
+        nodes:
+          - fedora-35
+      - name: aws
+        nodes:
+          - SplunkEnterprise-SES-8.0.0
+          - fedora-35
 
 - nodeset:
-    name: ansible-tox-py310
+    name: Trendmicro-DeepSecurity-20.0.344-python38
     nodes:
-      - name: controller
+      - name: fedora-35
         label: ansible-fedora-35-1vcpu
+      - name: Trendmicro-DeepSecurity-20.0.344
+        label: Trendmicro-DeepSecurity-20.0.344
+    groups:
+      - name: appliance-ssh
+        nodes:
+          - Trendmicro-DeepSecurity-20.0.344
+      - name: controller
+        nodes:
+          - fedora-35
+      - name: aws
+        nodes:
+          - Trendmicro-DeepSecurity-20.0.344
+          - fedora-35

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1323,13 +1323,14 @@
       jobs: &ansible-collections-security-ibm-qradar-jobs
         - build-ansible-collection
         - ansible-changelog-fragment
-        - ansible-test-security-integration-qradar-python27
-        - ansible-test-security-integration-qradar-python38
-        - ansible-test-security-integration-qradar-python38-stable29
-        - ansible-test-security-integration-qradar-python38-stable211
-        - ansible-test-security-integration-qradar-python38-stable212
-        - ansible-test-sanity-docker-devel
-        - ansible-test-sanity-docker-milestone
+        - network-ee-integration-qradar-python27
+        - network-ee-integration-qradar-python36
+        - network-ee-integration-qradar-python38
+        - network-ee-integration-qradar-python38-stable29
+        - network-ee-integration-qradar-python38-stable210
+        - network-ee-integration-qradar-python38-stable211
+        - network-ee-integration-qradar-python38-stable212
+        - ansible-test-sanity-docker
         - ansible-test-sanity-docker-stable-2.9
         - ansible-test-sanity-docker-stable-2.10
         - ansible-test-sanity-docker-stable-2.11
@@ -1343,13 +1344,14 @@
       jobs: &ansible-collections-security-splunk-es-jobs
         - build-ansible-collection
         - ansible-changelog-fragment
-        - ansible-security-integration-splunk-es-python27
-        - ansible-security-integration-splunk-es-python38
-        - ansible-security-integration-splunk-es-python38-stable29
-        - ansible-security-integration-splunk-es-python38-stable211
-        - ansible-security-integration-splunk-es-python38-stable212
-        - ansible-test-sanity-docker-devel
-        - ansible-test-sanity-docker-milestone
+        - network-ee-integration-splunk-es-python27
+        - network-ee-integration-splunk-es-python36
+        - network-ee-integration-splunk-es-python38
+        - network-ee-integration-splunk-es-python38-stable29
+        - network-ee-integration-splunk-es-python38-stable210
+        - network-ee-integration-splunk-es-python38-stable211
+        - network-ee-integration-splunk-es-python38-stable212
+        - ansible-test-sanity-docker
         - ansible-test-sanity-docker-stable-2.9
         - ansible-test-sanity-docker-stable-2.10
         - ansible-test-sanity-docker-stable-2.11
@@ -1363,15 +1365,14 @@
       jobs: &ansible-collections-security-trendmicro-deepsec-jobs
         - build-ansible-collection
         - ansible-changelog-fragment
-        - ansible-security-integration-trendmicro-deepsec-python27
-        - ansible-security-integration-trendmicro-deepsec-python36
-        - ansible-security-integration-trendmicro-deepsec-python38
-        - ansible-security-integration-trendmicro-deepsec-python38-stable29
-        - ansible-security-integration-trendmicro-deepsec-python38-stable211
-        - ansible-security-integration-trendmicro-deepsec-python38-stable212
-        - ansible-test-sanity-docker-devel:
-            voting: false
-        - ansible-test-sanity-docker-milestone
+        - network-ee-integration-trendmicro-deepsec-python27
+        - network-ee-integration-trendmicro-deepsec-python36
+        - network-ee-integration-trendmicro-deepsec-python38
+        - network-ee-integration-trendmicro-deepsec-python38-stable29
+        - network-ee-integration-trendmicro-deepsec-python38-stable210
+        - network-ee-integration-trendmicro-deepsec-python38-stable211
+        - network-ee-integration-trendmicro-deepsec-python38-stable212
+        - ansible-test-sanity-docker
         - ansible-test-sanity-docker-stable-2.9
         - ansible-test-sanity-docker-stable-2.10
         - ansible-test-sanity-docker-stable-2.11

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1323,7 +1323,6 @@
       jobs: &ansible-collections-security-ibm-qradar-jobs
         - build-ansible-collection
         - ansible-changelog-fragment
-        - network-ee-integration-qradar-python27
         - network-ee-integration-qradar-python36
         - network-ee-integration-qradar-python38
         - network-ee-integration-qradar-python38-stable29
@@ -1344,7 +1343,6 @@
       jobs: &ansible-collections-security-splunk-es-jobs
         - build-ansible-collection
         - ansible-changelog-fragment
-        - network-ee-integration-splunk-es-python27
         - network-ee-integration-splunk-es-python36
         - network-ee-integration-splunk-es-python38
         - network-ee-integration-splunk-es-python38-stable29
@@ -1365,7 +1363,6 @@
       jobs: &ansible-collections-security-trendmicro-deepsec-jobs
         - build-ansible-collection
         - ansible-changelog-fragment
-        - network-ee-integration-trendmicro-deepsec-python27
         - network-ee-integration-trendmicro-deepsec-python36
         - network-ee-integration-trendmicro-deepsec-python38
         - network-ee-integration-trendmicro-deepsec-python38-stable29


### PR DESCRIPTION
Depends-on: https://github.com/ansible/network-ee/pull/144

Migrate Security platforms integration test jobs to use network-ee and update from py36 to py38