### PR TITLE
Use Python 3.8 for Cisco ASA devel jobs

### DIFF
--- a/zuul.d/cisco-asa-jobs.yaml
+++ b/zuul.d/cisco-asa-jobs.yaml
@@ -97,22 +97,22 @@
       ansible_test_python: 2.7
 
 - job:
-    name: ansible-test-network-integration-asa-python36
+    name: ansible-test-network-integration-asa-python38
     parent: ansible-test-network-integration-asa
-    nodeset: asav9-12-3-python36
+    nodeset: asav9-12-3-python38
     vars:
-      ansible_test_python: 3.6
+      ansible_test_python: 3.8
 
 - job:
-    name: ansible-test-network-integration-asa-libssh-python36
-    parent: ansible-test-network-integration-asa-python36
+    name: ansible-test-network-integration-asa-libssh-python38
+    parent: ansible-test-network-integration-asa-python38
     vars:
       ansible_test_network_cli_ssh_type: libssh
 
 - job:
-    name: ansible-test-network-integration-asa-python36-stable211
+    name: ansible-test-network-integration-asa-python38-stable211
     parent: ansible-test-network-integration-asa
-    nodeset: asav9-12-3-python36
+    nodeset: asav9-12-3-python38
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.11
@@ -120,15 +120,15 @@
       ansible_test_python: 3.6
 
 - job:
-    name: ansible-test-network-integration-asa-libssh-python36-stable211
-    parent: ansible-test-network-integration-asa-python36-stable211
+    name: ansible-test-network-integration-asa-libssh-python38-stable211
+    parent: ansible-test-network-integration-asa-python38-stable211
     vars:
       ansible_test_network_cli_ssh_type: libssh
 
 - job:
-    name: ansible-test-network-integration-asa-python36-stable29
+    name: ansible-test-network-integration-asa-python38-stable29
     parent: ansible-test-network-integration-asa
-    nodeset: asav9-12-3-python36
+    nodeset: asav9-12-3-python38
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.9
@@ -136,7 +136,7 @@
       ansible_test_python: 3.6
 
 - job:
-    name: ansible-test-network-integration-asa-libssh-python36-stable29
-    parent: ansible-test-network-integration-asa-python36-stable29
+    name: ansible-test-network-integration-asa-libssh-python38-stable29
+    parent: ansible-test-network-integration-asa-python38-stable29
     vars:
       ansible_test_network_cli_ssh_type: libssh

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -251,12 +251,12 @@
       jobs: &ansible-collections-cisco-asa-jobs
         - ansible-test-network-integration-asa-python27-stable211
         - ansible-test-network-integration-asa-python27-stable29
-        - ansible-test-network-integration-asa-python36
-        - ansible-test-network-integration-asa-python36-stable211
-        - ansible-test-network-integration-asa-python36-stable29
-        - ansible-test-network-integration-asa-libssh-python36
-        - ansible-test-network-integration-asa-libssh-python36-stable211
-        - ansible-test-network-integration-asa-libssh-python36-stable29
+        - ansible-test-network-integration-asa-python38
+        - ansible-test-network-integration-asa-python38-stable211
+        - ansible-test-network-integration-asa-python38-stable29
+        - ansible-test-network-integration-asa-libssh-python38
+        - ansible-test-network-integration-asa-libssh-python38-stable211
+        - ansible-test-network-integration-asa-libssh-python38-stable29
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon


### PR DESCRIPTION
Use Python 3.8 for Cisco ASA devel jobs