### PR TITLE
use centos-8-stream everywhere

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -108,7 +108,7 @@
     run: playbooks/ansible-galaxy-importer/run.yaml
     required-projects:
       - github.com/ansible-network/releases
-    nodeset: centos-8-1vcpu
+    nodeset: centos-8-stream
 
 - job:
     name: ansible-network-appliance-base

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -12,12 +12,6 @@
         label: centos-7-4vcpu
 
 - nodeset:
-    name: centos-8-1vcpu
-    nodes:
-      - name: centos-8
-        label: centos-8-1vcpu
-
-- nodeset:
     name: centos-8-stream
     nodes:
       - name: centos-8-stream
@@ -165,7 +159,7 @@
     name: asav9-12-3-python36
     nodes:
       - name: centos-8
-        label: centos-8-1vcpu
+        label: centos-8-stream
       - name: asav9-12-3
         label: asav9-12-3
     groups:
@@ -240,7 +234,7 @@
     name: eos-4.24.6-python36
     nodes:
       - name: centos-8
-        label: centos-8-1vcpu
+        label: centos-8-stream
       - name: eos-4.24.6
         label: eos-4.24.6
     groups:
@@ -330,7 +324,7 @@
     name: iosxr-6.1.3-python36
     nodes:
       - name: centos-8
-        label: centos-8-1vcpu
+        label: centos-8-stream
       - name: iosxr-6.1.3
         label: iosxrv-6.1.3
     groups:
@@ -404,7 +398,7 @@
     name: iosxr-7.0.2-python36
     nodes:
       - name: centos-8
-        label: centos-8-1vcpu
+        label: centos-8-stream
       - name: iosxr-7.0.2
         label: iosxrv-7.0.2
     groups:
@@ -524,7 +518,7 @@
     name: vqfx-18.1R3-python36
     nodes:
       - name: centos-8
-        label: centos-8-1vcpu
+        label: centos-8-stream
       - name: vqfx-18.1R3
         label: vqfx-18.1R3
     groups:
@@ -599,7 +593,7 @@
     name: vsrx3-18.4R1-python36
     nodes:
       - name: centos-8
-        label: centos-8-1vcpu
+        label: centos-8-stream
       - name: vsrx3-18.4R1
         label: vsrx3-18.4R1
     groups:


### PR DESCRIPTION
The centos-8 stream image does not boot properly, the image is superseeded
by centos-8-stream anyway.

This will reduce the number of image in use.
