### PR TITLE
CentOS: use Facebook mirror instead of Vexxhost

### DIFF
--- a/roles/configure-mirrors-fork/vars/CentOS.yaml
+++ b/roles/configure-mirrors-fork/vars/CentOS.yaml
@@ -1,3 +1,3 @@
 ---
 epel_mirror: https://mirror.csclub.uwaterloo.ca/fedora/epel
-package_mirror: http://centos.mirror.vexxhost.com
+package_mirror: http://mirror.facebook.net/centos


### PR DESCRIPTION
We've got some recurrent stability problem with Vexxhost's mirror. Let's
try another one.
