### PR TITLE
Replaced centos-8-1vcpu label with centos-8-stream

### DIFF
--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -171,7 +171,7 @@
     name: asav9-12-3-python36
     nodes:
       - name: centos-8
-        label: centos-8-1vcpu
+        label: centos-8-stream
       - name: asav9-12-3
         label: asav9-12-3
     groups:
@@ -246,7 +246,7 @@
     name: eos-4.24.6-python36
     nodes:
       - name: centos-8
-        label: centos-8-1vcpu
+        label: centos-8-stream
       - name: eos-4.24.6
         label: eos-4.24.6
     groups:
@@ -336,7 +336,7 @@
     name: iosxr-6.1.3-python36
     nodes:
       - name: centos-8
-        label: centos-8-1vcpu
+        label: centos-8-stream
       - name: iosxr-6.1.3
         label: iosxrv-6.1.3
     groups:
@@ -410,7 +410,7 @@
     name: iosxr-7.0.2-python36
     nodes:
       - name: centos-8
-        label: centos-8-1vcpu
+        label: centos-8-stream
       - name: iosxr-7.0.2
         label: iosxrv-7.0.2
     groups:
@@ -530,7 +530,7 @@
     name: vqfx-18.1R3-python36
     nodes:
       - name: centos-8
-        label: centos-8-1vcpu
+        label: centos-8-stream
       - name: vqfx-18.1R3
         label: vqfx-18.1R3
     groups:
@@ -605,7 +605,7 @@
     name: vsrx3-18.4R1-python36
     nodes:
       - name: centos-8
-        label: centos-8-1vcpu
+        label: centos-8-stream
       - name: vsrx3-18.4R1
         label: vsrx3-18.4R1
     groups:


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

Replaced centos-8-1vcpu label with centos-8-stream
