### PR TITLE
AWS tests - stable-2.12 sanity tests

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -106,6 +106,7 @@
         - ansible-test-sanity-docker-stable-2.9
         - ansible-test-sanity-docker-stable-2.10
         - ansible-test-sanity-docker-stable-2.11
+        - ansible-test-sanity-docker-stable-2.12
         - ansible-test-units-community-aws-python38
         - build-ansible-collection:
             required-projects:


### PR DESCRIPTION
Ansible 2.12 has branched - we should test against it.

Devel branch is *supposed* to be able to break, make it optional so that new tests/containers don't break everything the day they land.