### PR TITLE
move ansible-test-sanity-docker on f34

### DIFF
--- a/playbooks/ansible-cloud/py38/pre.yaml
+++ b/playbooks/ansible-cloud/py38/pre.yaml
@@ -1,8 +1,17 @@
 ---
 - hosts: all
   tasks:
-    - name: Ensure python3.8 is present
+    - name: Ensure python3.8 is present (Debian/Ubuntu)
       become: true
       package:
         name: python38-devel
         state: present
+      when: ansible_os_family != "RedHat"
+    - name: Ensure python3.8 is present (Red Hat)
+      become: true
+      package:
+        name:
+          - python3.8
+          - gcc
+        state: present
+      when: ansible_os_family == "RedHat"

--- a/zuul.d/ansible-test-jobs.yaml
+++ b/zuul.d/ansible-test-jobs.yaml
@@ -2,11 +2,13 @@
 - job:
     name: ansible-test-sanity-docker
     parent: unittests
-    nodeset: controller-python38
+    nodeset: controller-python38-f34
     dependencies:
       - name: build-ansible-collection
         soft: true
-    pre-run: playbooks/ansible-test-base/pre.yaml
+    pre-run:
+      - playbooks/ansible-cloud/py38/pre.yaml
+      - playbooks/ansible-test-base/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
     required-projects:
       - name: github.com/ansible/ansible


### PR DESCRIPTION
Move to Fedora 34 to avoid the reliability issue with Ubuntu kubic
repository.
