### PR TITLE
a-t-molecule-kubernetes-core: test milestone and devel

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -430,6 +430,21 @@
       ansible_test_venv_path: "~/venv"
 
 - job:
+    name: ansible-test-molecule-kubernetes-core-devel
+    parent: ansible-test-molecule-kubernetes-core
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: devel
+    voting: false
+
+- job:
+    name: ansible-test-molecule-kubernetes-core-milestone
+    parent: ansible-test-molecule-kubernetes-core
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: milestone
+
+- job:
     name: ansible-test-molecule-kubernetes-core-2.9
     parent: ansible-test-molecule-kubernetes-core
     required-projects:
@@ -448,6 +463,8 @@
     parent: ansible-test-molecule-kubernetes-core
     required-projects:
       - name: github.com/ansible-collections/cloud.common
+      - name: github.com/ansible/ansible
+        override-checkout: milestone
     vars:
       ansible_test_environment:
         ENABLE_TURBO_MODE: true

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -513,10 +513,7 @@
             required-projects:
               - name: github.com/ansible-collections/community.vmware
               - name: github.com/ansible-collections/vmware.vmware_rest
-        - ansible-test-molecule-kubernetes-core:
-            vars:
-              ansible_test_environment:
-                ENABLE_TURBO_MODE: true
+        - ansible-test-molecule-kubernetes-core-with-turbo
     gate:
       jobs: *ansible-collections-cloud-common-jobs
     periodic:
@@ -765,7 +762,8 @@
         - ansible-test-sanity-docker-stable-2.10
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-units-kubernetes-core-python38
-        - ansible-test-molecule-kubernetes-core
+        - ansible-test-molecule-kubernetes-core-devel
+        - ansible-test-molecule-kubernetes-core-milestone
         - ansible-test-molecule-kubernetes-core-2.9
         - ansible-test-molecule-kubernetes-core-2.10
         - ansible-test-molecule-kubernetes-core-with-turbo


### PR DESCRIPTION
devel is now non-voting. Also use ansible-test-molecule-kubernetes-core-with-turbo
to test cloud.common.
