### PR TITLE
configure-mirrors-fork/yum: retries 3 times on failure

### DIFF
--- a/roles/configure-mirrors-fork/handlers/main.yaml
+++ b/roles/configure-mirrors-fork/handlers/main.yaml
@@ -11,6 +11,9 @@
 - name: Update yum/dnf cache
   become: true
   command: "{{ item }}"
+  register: result
+  until: result is succeeded
+  retries: 3
   args:
     warn: false
   # verbose is needed in order to make it possible to debug potential failures

--- a/roles/configure-mirrors-fork/tasks/mirror/Fedora.yaml
+++ b/roles/configure-mirrors-fork/tasks/mirror/Fedora.yaml
@@ -1,4 +1,9 @@
 ---
+- name: Remove fedora-cisco-openh264 repository
+  become: true
+  file:
+    path: /etc/yum.repos.d/fedora-cisco-openh264.repo
+    state: absent
 - name: Install Fedora repository files
   become: true
   template:


### PR DESCRIPTION
This is most of the time just a temporary error. Also remove Fedora's
fedora-cisco-openh264 repository.
