### PR TITLE
cloud.common: temp turn k8s check non votin

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -527,7 +527,8 @@
             required-projects:
               - name: github.com/ansible-collections/community.vmware
               - name: github.com/ansible-collections/vmware.vmware_rest
-        - ansible-test-molecule-kubernetes-core-with-turbo
+        - ansible-test-molecule-kubernetes-core-with-turbo:
+            voting: false
     gate:
       jobs: *ansible-collections-cloud-common-jobs
     periodic:


### PR DESCRIPTION
Temporarily disable ansible-test-molecule-kubernetes-core-with-turbo until
we land https://github.com/ansible-collections/cloud.common/pull/92.
