### PR TITLE
Revert "cloud.common: temp turn k8s check non votin (#1176)"

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -527,8 +527,7 @@
             required-projects:
               - name: github.com/ansible-collections/community.vmware
               - name: github.com/ansible-collections/vmware.vmware_rest
-        - ansible-test-molecule-kubernetes-core-with-turbo:
-            voting: false
+        - ansible-test-molecule-kubernetes-core-with-turbo
     gate:
       jobs: *ansible-collections-cloud-common-jobs
     periodic:


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/cloud.common/pull/92
Depends-On: https://github.com/ansible-collections/kubernetes.core/pull/261

This reverts commit 20f01732ed04d1f21005cd9d05257355d0138b96 introduced by https://github.com/ansible/ansible-zuul-jobs/pull/1176.
