### PR TITLE
ensure py38 for aws integration jobs

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -286,6 +286,7 @@
       - name: build-ansible-collection
       - name: ansible-test-splitter
     pre-run:
+      - playbooks/ansible-cloud/py38/pre.yaml
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
     run: playbooks/ansible-test-base/run.yaml


### PR DESCRIPTION
We need py38 to run the integration jobs.
