### PR TITLE
workaround: use IPv4 to reach files.pythonhosted.org

### DIFF
--- a/playbooks/ansible-cloud/pypi-ipv6/pre.yaml
+++ b/playbooks/ansible-cloud/pypi-ipv6/pre.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: controller
+  tasks:
+    - name: Ensure we use IPv4 to reach files.pythonhosted.org
+      lineinfile:
+        path: /etc/hosts
+        line: 151.101.137.63 files.pythonhosted.org
+      become: true

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -71,6 +71,7 @@
     dependencies:
       - name: build-ansible-collection
     pre-run:
+      - playbooks/ansible-cloud/pypi-ipv6/pre.yaml
       - playbooks/ansible-cloud/py36/pre.yaml
       - playbooks/ansible-test-base/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
@@ -202,6 +203,7 @@
     dependencies:
       - name: build-ansible-collection
     pre-run:
+      - playbooks/ansible-cloud/pypi-ipv6/pre.yaml
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-test-network-integration-base/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
@@ -287,6 +289,7 @@
       - name: ansible-test-splitter
     pre-run:
       - playbooks/ansible-cloud/py38/pre.yaml
+      - playbooks/ansible-cloud/pypi-ipv6/pre.yaml
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
     run: playbooks/ansible-test-base/run.yaml

--- a/zuul.d/ansible-test-jobs.yaml
+++ b/zuul.d/ansible-test-jobs.yaml
@@ -7,6 +7,7 @@
       - name: build-ansible-collection
         soft: true
     pre-run:
+      - playbooks/ansible-cloud/pypi-ipv6/pre.yaml
       - playbooks/ansible-cloud/py38/pre.yaml
       - playbooks/ansible-test-base/pre.yaml
     run: playbooks/ansible-test-base/run.yaml


### PR DESCRIPTION
This to address the current timeout issues that we're facing currently.
