### PR TITLE
install libffi-dev on Xenial and any dpkg based OS

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -2,7 +2,7 @@
 # see http://docs.openstack.org/infra/bindep/ for additional information.
 
 gcc-c++ [test platform:rpm]
-libffi-dev [test platform:ubuntu-bionic]
+libffi-dev [test platform:dpkg ]
 libssh-devel [test platform:rpm]
 libssh-dev [test platform:dpkg]
 libxml2-dev [test platform:ubuntu-bionic]


### PR DESCRIPTION
e.g: https://dashboard.zuul.ansible.com/t/ansible/build/c9dbbfc72cc6415782966ad7d7bfb49a
