### PR TITLE
[python3.9] Add ansible-tox-py39 job

### DIFF
--- a/playbooks/ansible-tox-py39/pre.yaml
+++ b/playbooks/ansible-tox-py39/pre.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  tasks:
+    - name: Ensure python3.9 is present
+      become: true
+      package:
+        name: python39-devel
+        state: present

--- a/zuul.d/jobs-ansible-lint.yaml
+++ b/zuul.d/jobs-ansible-lint.yaml
@@ -91,3 +91,4 @@
     parent: ansible-tox-py39
     vars:
       tox_envlist: py39-ansibledevel
+  

--- a/zuul.d/jobs-ansible-lint.yaml
+++ b/zuul.d/jobs-ansible-lint.yaml
@@ -73,3 +73,21 @@
     parent: ansible-tox-py38
     vars:
       tox_envlist: py38-ansibledevel
+
+- job:
+    name: ansible-lint-tox-py39-ansible28
+    parent: ansible-tox-py39
+    vars:
+      tox_envlist: py39-ansible28
+
+- job:
+    name: ansible-lint-tox-py39-ansible29
+    parent: ansible-tox-py39
+    vars:
+      tox_envlist: py39-ansible29
+
+- job:
+    name: ansible-lint-tox-py39-ansibledevel
+    parent: ansible-tox-py39
+    vars:
+      tox_envlist: py39-ansibledevel

--- a/zuul.d/jobs-ansible-lint.yaml
+++ b/zuul.d/jobs-ansible-lint.yaml
@@ -91,4 +91,3 @@
     parent: ansible-tox-py39
     vars:
       tox_envlist: py39-ansibledevel
-  

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -80,6 +80,13 @@
     nodeset: centos-8-stream
 
 - job:
+    name: ansible-tox-py39
+    parent: tox-py39
+    pre-run: playbooks/ansible-tox-py39/pre.yaml
+    timeout: 3600
+    nodeset: centos-8-stream
+
+- job:
     name: ansible-build-python-tarball
     description: |
       Test building python tarballs / wheels and the packaging metadata
@@ -335,6 +342,11 @@
     <<: *ansible-tox-molecule-base
     name: molecule-tox-py38
     parent: ansible-tox-py38
+
+- job:
+    <<: *ansible-tox-molecule-base
+    name: molecule-tox-py39
+    parent: ansible-tox-py39
 
 - job:
     name: ansible-ee-tests-base

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -44,10 +44,12 @@
       jobs:
         - ansible-tox-py36
         - ansible-tox-py38
+        - ansible-tox-py39
     gate:
       jobs:
         - ansible-tox-py36
         - ansible-tox-py38
+        - ansible-tox-py39
 
 - project-template:
     name: ansible-collections-amazon-aws

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -7,6 +7,9 @@
         - ansible-tox-py38:
             vars:
               tox_envlist: pytest,black
+        - ansible-tox-py39:
+            vars:
+              tox_envlist: pytest,black
         - ansible-network-asa-appliance:
             files:
               - playbooks/ansible-network-appliance-base/.*
@@ -63,6 +66,9 @@
     gate:
       jobs:
         - ansible-tox-py38:
+            vars:
+              tox_envlist: pytest,black
+        - ansible-tox-py39:
             vars:
               tox_envlist: pytest,black
         - ansible-network-asa-appliance:


### PR DESCRIPTION
`molecule-libvirt`'s CI keep failing because `python38-devel` is not available in Fedora 34.

Python 3.9 is the default version in Fedora 34

_EDIT_

From @goneri comment about possible confusion between CentOS and Fedora:

> Yeah in our tests we are using `ansible-tox-py38` which is based on `centos-8-stream` for Fedora :D
> https://github.com/ansible-community/molecule-libvirt/blob/main/zuul.d/layout.yaml#L4



