### PR TITLE
Fix check for py39 on fedora 34/35 (old)

### DIFF
--- a/playbooks/ansible-tox-py39/pre.yaml
+++ b/playbooks/ansible-tox-py39/pre.yaml
@@ -1,8 +1,21 @@
 ---
 - hosts: all
+  vars:
+    python3_devel_pkg: python39-devel
   tasks:
-    - name: Ensure python3.9 is present
+
+    - name: Set python package name for Fedora 34
+      set_fact:
+        python3_devel_pkg: python3-devel
+      when: ansible_distribution == 'Fedora' and ansible_distribution_major_version == '34'
+
+    - name: Set python package name for Fedora 35
+      set_fact:
+        python3_devel_pkg: python3.9
+      when: ansible_distribution == 'Fedora' and ansible_distribution_major_version == '35'
+
+    - name: Ensure python3.9 devel is present
       become: true
       package:
-        name: python39-devel
+        name: "{{ python3_devel_pkg }}"
         state: present

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -87,6 +87,11 @@
     nodeset: centos-8-stream
 
 - job:
+    name: ansible-tox-py39-fedora
+    parent: ansible-tox-py39
+    nodeset: fedora-latest-1vcpu
+
+- job:
     name: ansible-build-python-tarball
     description: |
       Test building python tarballs / wheels and the packaging metadata

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -10,6 +10,9 @@
         - ansible-tox-py39:
             vars:
               tox_envlist: pytest,black
+        - ansible-tox-py39-fedora:
+            vars:
+              tox_envlist: pytest,black
         - ansible-network-asa-appliance:
             files:
               - playbooks/ansible-network-appliance-base/.*
@@ -69,6 +72,9 @@
             vars:
               tox_envlist: pytest,black
         - ansible-tox-py39:
+            vars:
+              tox_envlist: pytest,black
+        - ansible-tox-py39-fedora:
             vars:
               tox_envlist: pytest,black
         - ansible-network-asa-appliance:


### PR DESCRIPTION
Address wrongly assumption that py39 devel package is always named `python39-devel`.

Fixes bug introduced by https://github.com/ansible/ansible-zuul-jobs/pull/1201

Required-By: https://github.com/ansible-community/molecule-libvirt/pull/31