### PR TITLE
turns network-ee-sanity-tests non-voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1355,7 +1355,8 @@
       network-ee-container-image-jobs project-template.
     check:
       jobs: &network-ee-test-jobs
-        - network-ee-sanity-tests
+        - network-ee-sanity-tests:
+            voting: false
         - network-ee-sanity-tests-stable-2.9
         - network-ee-sanity-tests-stable-2.10
         - network-ee-sanity-tests-stable-2.11


### PR DESCRIPTION
The network-ee-sanity-tests job is based on ansible/ansible devel and breaks
pretty often. Then this happens, the check/gate pipelines are blocked and
we've got to resolve the situation ASAP. It's often just a trivial problem
but this still sounds like a source of endless distraction for some.
