### PR TITLE
use fedora-35 for the security collections

### DIFF
--- a/zuul.d/ansible-security-jobs.yaml
+++ b/zuul.d/ansible-security-jobs.yaml
@@ -138,12 +138,6 @@
       ansible_test_python: 2.7
 
 - job:
-    name: ansible-security-integration-trendmicro-deepsec-python35
-    parent: ansible-security-integration-trendmicro-deepsec
-    vars:
-      ansible_test_python: 3.5
-
-- job:
     name: ansible-security-integration-trendmicro-deepsec-python36
     parent: ansible-security-integration-trendmicro-deepsec
     vars:

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -726,8 +726,8 @@
 - nodeset:
     name: QRadarCE-7.3.1-python38
     nodes:
-      - name: ubuntu-bionic
-        label: ubuntu-bionic-1vcpu
+      - name: fedora-35
+        label: fedora-35-1vcpu
       - name: QRadarCE-7.3.1
         label: QRadarCE-7.3.1
     groups:
@@ -736,17 +736,17 @@
           - QRadarCE-7.3.1
       - name: controller
         nodes:
-          - ubuntu-bionic
+          - fedora-35
       - name: aws
         nodes:
           - QRadarCE-7.3.1
-          - ubuntu-bionic
+          - fedora-35
 
 - nodeset:
     name: SplunkEnterprise-SES-8.0.0-python38
     nodes:
-      - name: ubuntu-bionic
-        label: ubuntu-bionic-1vcpu
+      - name: fedora-35
+        label: fedora-35-1vcpu
       - name: SplunkEnterprise-SES-8.0.0
         label: SplunkEnterprise-SES-8.0.0
     groups:
@@ -755,17 +755,17 @@
           - SplunkEnterprise-SES-8.0.0
       - name: controller
         nodes:
-          - ubuntu-bionic
+          - fedora-35
       - name: aws
         nodes:
           - SplunkEnterprise-SES-8.0.0
-          - ubuntu-bionic
+          - fedora-35
 
 - nodeset:
     name: Trendmicro-DeepSecurity-20.0.344-python38
     nodes:
-      - name: ubuntu-bionic
-        label: ubuntu-bionic-1vcpu
+      - name: fedora-35
+        label: fedora-35-1vcpu
       - name: Trendmicro-DeepSecurity-20.0.344
         label: Trendmicro-DeepSecurity-20.0.344
     groups:
@@ -774,8 +774,8 @@
           - Trendmicro-DeepSecurity-20.0.344
       - name: controller
         nodes:
-          - ubuntu-bionic
+          - fedora-35
       - name: aws
         nodes:
           - Trendmicro-DeepSecurity-20.0.344
-          - ubuntu-bionic
+          - fedora-35

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1071,7 +1071,6 @@
         - build-ansible-collection
         - ansible-changelog-fragment
         - ansible-security-integration-trendmicro-deepsec-python27
-        - ansible-security-integration-trendmicro-deepsec-python35
         - ansible-security-integration-trendmicro-deepsec-python36
         - ansible-security-integration-trendmicro-deepsec-python38
         - ansible-security-integration-trendmicro-deepsec-python38-stable29


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1223

The goal is to remove ubuntu-bionic-1vcpu label from the AWS
configuration. The security collections are the last ones using
it.

Also, remove ansible-security-integration-trendmicro-deepsec-python35
because Fedora 35 does not provide Python 3.5.