### PR TITLE
ansible-test-base: install the right Python version

### DIFF
--- a/playbooks/ansible-test-base/pre.yaml
+++ b/playbooks/ansible-test-base/pre.yaml
@@ -23,6 +23,12 @@
         - ansible_os_family == "Debian"
         - ansible_test_python is version('3.8', '==')
 
+    - name: Run ensure-python role (Fedora only for now)
+      include_role:
+        name: ensure-python
+      vars:
+        ensure_python__version: "{{ ansible_test_python }}"
+
     # NOTE(pabelanger): fedora-32 jobs, currently python3.7 only have
     # selinux bindings for python3.8. For now, disable selinux.
     - name: Disable selinux for python3.7 jobs

--- a/roles/ensure_python/tasks/main.yaml
+++ b/roles/ensure_python/tasks/main.yaml
@@ -1,0 +1,7 @@
+---
+- name: Install the right Python version (rpm)
+  become: true
+  package:
+    name: "python{{ ensure_python__version }}"
+    state: present
+  when: ansible_distribution == 'Fedora'


### PR DESCRIPTION
Use `ansible_test_python` to figure out what Python version needs to be
installed.

Also: https://review.opendev.org/c/zuul/zuul-jobs/+/818248
