### PR TITLE
Revert "run controller-python37 on Fedora 35 (#1219)"

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -248,8 +248,6 @@
 - job:
     name: ansible-test-units-community-vmware-python37
     parent: ansible-test-units-base-python37
-    pre-run:
-      - playbooks/ansible-tox-py37/pre.yaml
     required-projects:
       - name: github.com/ansible-collections/community.vmware
     vars:

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -685,12 +685,12 @@
 - nodeset:
     name: controller-python37
     nodes:
-      - name: fedora-35
-        label: fedora-35-1vcpu
+      - name: fedora-32
+        label: fedora-32-1vcpu
     groups:
       - name: controller
         nodes:
-          - fedora-35
+          - fedora-32
 
 - nodeset:
     name: controller-python38


### PR DESCRIPTION
This commit breaks cisco.ios.

This reverts commit a289014810cd47f9920fc9b2217c9175bab8b2d4.
