### PR TITLE
Set py27 unit test to non-voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -163,7 +163,7 @@
         - ansible-test-sanity-docker-stable-2.10
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
-        - ansible-test-units-eos-python27
+        - ansible-test-units-eos-python27:
           vars:
             voting: false
         - ansible-test-units-eos-python38

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -164,6 +164,8 @@
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
         - ansible-test-units-eos-python27
+          vars:
+            voting: false
         - ansible-test-units-eos-python38
         - ansible-test-units-eos-python36
         - ansible-test-units-eos-python37

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -164,7 +164,6 @@
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
         - ansible-test-units-eos-python27:
-          vars:
             voting: false
         - ansible-test-units-eos-python38
         - ansible-test-units-eos-python36


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

This is a temp fix, until the jinja2 issue is resolved.

https://e91f3a37009934a632d8-e4588f048c512dbef1dbadcbe02d2a9c.ssl.cf2.rackcdn.com/293/03e35a6c095b217a6b843dfa26f9711e30f544ef/check/ansible-test-units-eos-python27/30c4278/job-output.txt