### PR TITLE
ansible-test: pip install, retry one time on failure

### DIFF
--- a/roles/ansible-test/tasks/init_collection.yaml
+++ b/roles/ansible-test/tasks/init_collection.yaml
@@ -11,6 +11,10 @@
 
 - name: Install python requirements
   shell: "{{ ansible_test_venv_path }}/bin/pip install {{ _test_requirements }} {{ _test_constraints }}"
+  register: r
+  until: r.rc == 0
+  retries: 2
+  delay: 60
 
 - name: Copy potential cloud provider configuration for ansible-test in the collection
   shell: "cp -v {{ ansible_test_ansible_path }}/test/integration/cloud-config-*.ini {{ _test_location }}/tests/integration/"


### PR DESCRIPTION
We've got some network related failures time to time. A retry is enough
most of the times to avoid a job failure.
