### PR TITLE
playbooks/ansible-cloud/py38/pre.yaml is not required anymore

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -24,7 +24,6 @@
     dependencies:
       - name: build-ansible-collection
     pre-run:
-      - playbooks/ansible-cloud/py38/pre.yaml
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/govcsim-base/pre.yaml
       - playbooks/ansible-cloud/vcenter-integration-controller/pre.yaml
@@ -287,7 +286,6 @@
       - name: build-ansible-collection
       - name: ansible-test-splitter
     pre-run:
-      - playbooks/ansible-cloud/py38/pre.yaml
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
     run: playbooks/ansible-test-base/run.yaml


### PR DESCRIPTION
playbooks/ansible-test-base/pre.yaml should now pull the right python version automatically.
