### PR TITLE
restore playbooks/ansible-cloud/py38/pre.yaml

### DIFF
--- a/playbooks/ansible-cloud/py38/pre.yaml
+++ b/playbooks/ansible-cloud/py38/pre.yaml
@@ -1,0 +1,17 @@
+---
+- hosts: all
+  tasks:
+    - name: Ensure python3.8 is present (Debian/Ubuntu)
+      become: true
+      package:
+        name: python38-devel
+        state: present
+      when: ansible_os_family != "RedHat"
+    - name: Ensure python3.8 is present (Red Hat)
+      become: true
+      package:
+        name:
+          - python3.8
+          - gcc
+        state: present
+      when: ansible_os_family == "RedHat"


### PR DESCRIPTION
The file is still required by kubernetes.core molecule tests.
