### PR TITLE
[WIP] Run CI for the only affected modules by the module_utils change

### DIFF
--- a/roles/ansible-test-splitter/files/list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/list_changed_targets.py
@@ -11,11 +11,9 @@ diff = subprocess.check_output(
     ["git", "diff", f"origin/{zuul_branch}", "--name-only"]
 ).decode()
 module_files = [PosixPath(d) for d in diff.split("\n") if d.startswith("plugins/")]
-for i in module_files:
-    if not i.is_file():
-        continue
-    target_name = i.stem
 
+
+def _update_targets(target_name):
     for t in targets_dir.iterdir():
         aliases = t / "aliases"
         if not aliases.is_file():
@@ -30,9 +28,17 @@ for i in module_files:
             targets_to_test.append(target_name)
             break
 
+
+for i in module_files:
+    if not i.is_file():
+        continue
+    target_name = i.stem
+    _update_targets(target_name)
+
 target_files = [
     PosixPath(d) for d in diff.split("\n") if d.startswith("tests/integration/targets/")
 ]
+
 for i in target_files:
     splitted = str(i).split("/")
     if len(splitted) < 5:
@@ -41,5 +47,25 @@ for i in target_files:
     aliases = targets_dir / target_name / "aliases"
     if aliases.is_file():
         targets_to_test.append(target_name)
+
+module_utils_files = [PosixPath(d) for d in diff.split("\n") if "module_utils" in d]
+modules_dir = PosixPath("plugins/")
+
+for i in module_utils_files:
+    for t in modules_dir.iterdir():
+        if not t.is_dir():
+            continue
+        target_name = i.stem
+
+        command = [
+            f"grep -nr '\w*module_utils.{target_name}\w*' plugins/ | cut -d: -f1 | sort -u"
+        ]
+        _result = subprocess.check_output(command, shell=True).decode()
+        result = list(filter(str.strip, _result.splitlines(True)))
+
+        for line in result:
+            _module_to_test = line.split("/")
+            module_to_test = _module_to_test[-1].split(".py")[0]
+            _update_targets(module_to_test)
 
 print(" ".join(list(set(targets_to_test))))


### PR DESCRIPTION
If there is a change in `module_utils`, run the CI only for the modules affected by that change.

This also solves the case where in the same PR there is a change in a module_utils file (e.g., rds) and a change in a module (e.g., ec2_vpc_igw), returning as `targets_to_test` ec2_vpc_igw and all modules affected by the change in module_utils. At the moment, `targets_to_test` is returned with only ec2_vpc_igw.

This would also require cross-collection testing (e.g., `amazon.aws` and `community.aws`), in case the change in module_utils within `amazon.aws` affects modules in `community.aws`.