### PR TITLE
Make network-ee test for utils non-voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -235,6 +235,8 @@
         - ansible-test-units-ansible-utils-python27
         - ansible-test-units-ansible-utils-python36
         - ansible-test-units-ansible-utils-python37
+        - network-ee-unit-tests:
+            voting: false
     gate:
       queue: integrated
       jobs: *ansible-collections-ansible-utils-units-jobs

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -212,7 +212,8 @@
     check:
       jobs: &ansible-collections-ansible-utils-jobs
         - build-ansible-collection
-        - network-ee-integration-tests-ansible-utils
+        - network-ee-integration-tests-ansible-utils:
+            voting: false
         - network-ee-integration-tests-ansible-utils-stable-2.12
         - network-ee-integration-tests-ansible-utils-stable-2.11
         - network-ee-integration-tests-ansible-utils-stable-2.9


### PR DESCRIPTION
Make network-ee test for utils non-voting until core fix get out for jinja2 failures

There are some failures in network-ee tests due to some changes in ansible devel branch. 
following is the issue created for those failures: https://github.com/ansible/ansible/issues/76442

we are making network-ee tests as non-voting as core team will release fix for these failures in next week.



following are the failures occures in utils network-ee tests.

````
Unit test controller with Python 3.8
============================= test session starts ==============================
platform linux -- Python 3.8.8, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /usr/share/ansible/collections/ansible_collections/ansible/utils/tests/unit, configfile: ../../../../../../../../local/lib/python3.8/site-packages/ansible_test/_data/pytest.ini
plugins: mock-3.6.1, forked-1.3.0, xdist-2.4.0
gw0 I / gw1 I / gw2 I / gw3 I
gw0 [222] / gw1 [222] / gw2 [222] / gw3 [222]

.................................F...F..F............................... [ 32%]
........................................................................ [ 64%]
........................................................................ [ 97%]
......                                                                   [100%]
=================================== FAILURES ===================================
________________________ TestGetPath.test_get_path_fail ________________________
[gw3] linux -- Python 3.8.8 /usr/bin/python3
self = <ansible_collections.ansible.utils.tests.unit.module_utils.test_get_path.TestGetPath testMethod=test_get_path_fail>

    def test_get_path_fail(self):
        var = {"a": {"b": {"c": {"d": [0, 1]}}}}
        path = "a.b.e"
        expected = "dict object' has no attribute 'e'"
        with self.assertRaises(Exception) as exc:
            get_path(var, path, environment=self._environment, wantlist=False)
>       self.assertIn(expected, str(exc.exception))
E       AssertionError: "dict object' has no attribute 'e'" not found in 'sequence item 0: expected str instance, AnsibleUndefined found'

tests/unit/module_utils/test_get_path.py:48: AssertionError
___________________ TestGetPath.test_get_path_pass_wantlist ____________________
[gw1] linux -- Python 3.8.8 /usr/bin/python3
self = <ansible_collections.ansible.utils.tests.unit.module_utils.test_get_path.TestGetPath testMethod=test_get_path_pass_wantlist>

    def test_get_path_pass_wantlist(self):
        var = {"a": {"b": {"c": {"d": [0, 1]}}}}
        path = "a.b.c.d[0]"
>       result = get_path(
            var, path, environment=self._environment, wantlist=True
        )

tests/unit/module_utils/test_get_path.py:36: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
plugins/module_utils/common/get_path.py:28: in get_path
    result = environment.from_string(string_to_variable).render(**var)
/usr/local/lib/python3.8/site-packages/jinja2/environment.py:1291: in render
    self.environment.handle_exception()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ansible.template.AnsibleEnvironment object at 0x7f008c241cd0>
source = None

    def handle_exception(self, source: t.Optional[str] = None) -> "te.NoReturn":
        """Exception handling helper.  This is used internally to either raise
        rewritten exceptions or return a rendered traceback for the template.
        """
        from .debug import rewrite_traceback_stack
    
>       raise rewrite_traceback_stack(source=source)
E       TypeError: sequence item 0: expected str instance, int found

/usr/local/lib/python3.8/site-packages/jinja2/environment.py:925: TypeError
________________________ TestGetPath.test_get_path_pass ________________________
[gw0] linux -- Python 3.8.8 /usr/bin/python3
self = <ansible_collections.ansible.utils.tests.unit.module_utils.test_get_path.TestGetPath testMethod=test_get_path_pass>

    def test_get_path_pass(self):
        var = {"a": {"b": {"c": {"d": [0, 1]}}}}
        path = "a.b.c.d[0]"
>       result = get_path(
            var, path, environment=self._environment, wantlist=False
        )

tests/unit/module_utils/test_get_path.py:27: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
plugins/module_utils/common/get_path.py:28: in get_path
    result = environment.from_string(string_to_variable).render(**var)
/usr/local/lib/python3.8/site-packages/jinja2/environment.py:1291: in render
    self.environment.handle_exception()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ansible.template.AnsibleEnvironment object at 0x7f60cf01ad30>
source = None

    def handle_exception(self, source: t.Optional[str] = None) -> "te.NoReturn":
        """Exception handling helper.  This is used internally to either raise
        rewritten exceptions or return a rendered traceback for the template.
        """
        from .debug import rewrite_traceback_stack
    
>       raise rewrite_traceback_stack(source=source)
E       TypeError: sequence item 0: expected str instance, int found

/usr/local/lib/python3.8/site-packages/jinja2/environment.py:925: TypeError
- generated xml file: /usr/share/ansible/collections/ansible_collections/ansible/utils/tests/output/junit/python3.8-controller-units.xml -
=========================== short test summary info ============================
FAILED tests/unit/module_utils/test_get_path.py::TestGetPath::test_get_path_fail
FAILED tests/unit/module_utils/test_get_path.py::TestGetPath::test_get_path_pass_wantlist
FAILED tests/unit/module_utils/test_get_path.py::TestGetPath::test_get_path_pass
======================== 3 failed, 219 passed in 19.96s ========================
ERROR: Command "pytest --boxed -r a -n auto --color no -p no:cacheprovider -c /usr/local/lib/python3.8/site-packages/ansible_test/_data/pytest.ini --junit-xml /usr/share/ansible/collections/ansible_collections/ansible/utils/tests/output/junit/python3.8-controller-units.xml --strict-markers tests/unit/module_utils/test_argspec_validate.py tests/unit/module_utils/test_dict_merge.py tests/unit/module_utils/test_get_path.py tests/unit/module_utils/test_index_of.py tests/unit/module_utils/test_sort_list.py tests/unit/module_utils/test_to_paths.py tests/unit/plugins/action/test_cli_parse.py tests/unit/plugins/action/test_fact_diff.py tests/unit/plugins/action/test_update_fact.py tests/unit/plugins/action/test_validate.py tests/unit/plugins/filter/test_from_xml.py tests/unit/plugins/filter/test_param_list_compare.py tests/unit/plugins/filter/test_to_xml.py tests/unit/plugins/filter/test_usable_range.py tests/unit/plugins/filter/test_validate.py tests/unit/plugins/lookup/test_validate.py tests/unit/plugins/sub_plugins/cli_parsers/test_json_parser.py tests/unit/plugins/sub_plugins/cli_parsers/test_textfsm_parser.py tests/unit/plugins/sub_plugins/cli_parsers/test_ttp_parser.py tests/unit/plugins/sub_plugins/cli_parsers/test_xml_parser.py tests/unit/plugins/test/test_in_any_network.py tests/unit/plugins/test/test_in_network.py tests/unit/plugins/test/test_in_one_network.py tests/unit/plugins/test/test_ip.py tests/unit/plugins/test/test_ip_address.py tests/unit/plugins/test/test_ipv4.py tests/unit/plugins/test/test_ipv4_address.py tests/unit/plugins/test/test_ipv4_hostmask.py tests/unit/plugins/test/test_ipv4_netmask.py tests/unit/plugins/test/test_ipv6.py tests/unit/plugins/test/test_ipv6_address.py tests/unit/plugins/test/test_ipv6_ipv4_mapped.py tests/unit/plugins/test/test_ipv6_sixtofour.py tests/unit/plugins/test/test_ipv6_teredo.py tests/unit/plugins/test/test_loopback.py tests/unit/plugins/test/test_mac.py tests/unit/plugins/test/test_multicast.py tests/unit/plugins/test/test_private.py tests/unit/plugins/test/test_public.py tests/unit/plugins/test/test_reserved.py tests/unit/plugins/test/test_resolvable.py tests/unit/plugins/test/test_subnet_of.py tests/unit/plugins/test/test_supernet_of.py tests/unit/plugins/test/test_unspecified.py tests/unit/plugins/test/test_validate.py" returned exit status 1.```