### PR TITLE
Revert change to fedora for ansible-tox-linters

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -25,7 +25,7 @@
 - job:
     name: ansible-tox-linters
     parent: tox-linters
-    nodeset: fedora-latest-1vcpu
+    nodeset: centos-8-stream
 
 - job: &ansible-tox-molecule-base
     name: ansible-tox-molecule-base


### PR DESCRIPTION
The change at https://github.com/ansible/ansible-zuul-jobs/pull/1157
basically pins this job to only run under AWS. Where centos-8-stream
available on 4 providers.

I would suggest, project that want to use fedora-latest override the
centos-8-stream nodeset vs applying this to all projects.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>