### PR TITLE
system-required: remove github-workflows

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1418,12 +1418,6 @@
       repository should use this directly.
     # Include a check queue so that initially every repo has a check queue
     # and we can report invalid zuul.yaml files.
-    check:
-      jobs:
-        - github-workflows
-    gate:
-      jobs:
-        - github-workflows
     lgtm:
       jobs:
         - noop


### PR DESCRIPTION
We don't need the jobs anymore.

See: https://github.com/ansible/ansible-zuul-jobs/pull/1255
