### PR TITLE
Make network-ee-sanity-tests non-voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1341,7 +1341,8 @@
       network-ee-container-image-jobs project-template.
     check:
       jobs: &network-ee-test-jobs
-        - network-ee-sanity-tests
+        - network-ee-sanity-tests:
+            voting: false
         - network-ee-sanity-tests-stable-2.9
         - network-ee-sanity-tests-stable-2.10
         - network-ee-sanity-tests-stable-2.11


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

Due to failures in ansible/ansible , making  network-ee-sanity-tests non-voting

Failure:

```
ERROR: Found 1 import issue(s) on python 3.8 which need to be resolved:
2021-12-07 04:35:51.249863 | centos-8-stream | ERROR: plugins/action/deepsec_intrusion_prevention_rules.py:0:0: stderr: [WARNING]: packaging Python module unavailable; unable to validate collection
2021-12-07 04:35:51.249938 | centos-8-stream | See documentation for help: https://docs.ansible.com/ansible/devel/dev_guide/testing/sanity/import.html

```