### PR TITLE
Revert "Make network-ee-sanity-tests non-voting (#1262)"

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1341,8 +1341,7 @@
       network-ee-container-image-jobs project-template.
     check:
       jobs: &network-ee-test-jobs
-        - network-ee-sanity-tests:
-            voting: false
+        - network-ee-sanity-tests
         - network-ee-sanity-tests-stable-2.9
         - network-ee-sanity-tests-stable-2.10
         - network-ee-sanity-tests-stable-2.11


### PR DESCRIPTION
The fix has been committed to devel, so the tests should pass now.

This reverts commit cb1843ccbbb2e481d5016b4b7bdb446c7df3198e.