### PR TITLE
Revert "Set py27 unit test to non-voting"

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -163,8 +163,7 @@
         - ansible-test-sanity-docker-stable-2.10
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
-        - ansible-test-units-eos-python27:
-            voting: false
+        - ansible-test-units-eos-python27
         - ansible-test-units-eos-python38
         - ansible-test-units-eos-python36
         - ansible-test-units-eos-python37


### PR DESCRIPTION
Reverts ansible/ansible-zuul-jobs#1237

Setting eos py27 unit test job as voting.