### PR TITLE
drop the controller-python38-f34 nodeset

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -281,7 +281,7 @@
 - job:
     name: ansible-test-cloud-integration-aws-py38
     parent: ansible-core-ci-aws-session
-    nodeset: controller-python38-f34
+    nodeset: controller-python38
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter

--- a/zuul.d/ansible-test-jobs.yaml
+++ b/zuul.d/ansible-test-jobs.yaml
@@ -2,7 +2,7 @@
 - job:
     name: ansible-test-sanity-docker
     parent: unittests
-    nodeset: controller-python38-f34
+    nodeset: controller-python38
     dependencies:
       - name: build-ansible-collection
         soft: true

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -646,16 +646,6 @@
         nodes:
           - fedora-34
 
-- nodeset:
-    name: controller-python38-f34
-    nodes:
-      - name: fedora-34
-        label: fedora-34-1vcpu
-    groups:
-      - name: controller
-        nodes:
-          - fedora-34
-
 # Ansible Security appliance nodesets
 - nodeset:
     name: QRadarCE-7.3.1-python38


### PR DESCRIPTION
`controller-python38` uses Fedora 35 and it should be enough.
