### PR TITLE
vcenter-appliance: no more controller group

### DIFF
--- a/playbooks/ansible-cloud/vcenter-appliance/pre.yaml
+++ b/playbooks/ansible-cloud/vcenter-appliance/pre.yaml
@@ -49,7 +49,7 @@
           vcenter: "{{ hostvars['vcenter']['nodepool']['interface_ip']}}"
           esxi1: "{{ 'esxi1' in hostvars and hostvars['esxi1']['nodepool']['interface_ip']}}"
           esxi2: "{{ 'esxi2' in hostvars and hostvars['esxi2']['nodepool']['interface_ip']}}"
-          datastore: "{{ hostvars[groups['controller'][0]]['nodepool']['interface_ip']}}"
+          datastore: "{{ hostvars['controller']['nodepool']['interface_ip']}}"
 
 - hosts: appliance:appliance-ssh
   gather_facts: false

--- a/zuul.ansible.d/nodesets.yaml
+++ b/zuul.ansible.d/nodesets.yaml
@@ -74,7 +74,7 @@
 - nodeset:
     name: vmware-vcsa-7.0.3-python36
     nodes:
-      - name: fedora-34
+      - name: controller
         label: fedora-34-1vcpu
       - name: vcenter
         label: ansible-vmware-vcsa-7.0.3
@@ -82,14 +82,11 @@
       - name: appliance-ssh
         nodes:
           - vcenter
-      - name: controller
-        nodes:
-          - fedora-34
 
 - nodeset:
     name: vmware-vcsa_1esxi-7.0.3-python36
     nodes:
-      - name: fedora-34
+      - name: controller
         label: fedora-34-1vcpu
       - name: vcenter
         label: ansible-vmware-vcsa-7.0.3
@@ -105,14 +102,11 @@
       - name: esxis
         nodes:
           - esxi1
-      - name: controller
-        nodes:
-          - fedora-34
 
 - nodeset:
     name: vmware-vcsa_2esxi-7.0.3-python36
     nodes:
-      - name: fedora-34
+      - name: controller
         label: fedora-34-1vcpu
       - name: vcenter
         label: ansible-vmware-vcsa-7.0.3
@@ -132,9 +126,6 @@
         nodes:
           - esxi1
           - esxi2
-      - name: controller
-        nodes:
-          - fedora-34
 
 # Ansible network appliance nodesets
 - nodeset:


### PR DESCRIPTION
Use the controller name to identify the controller. This instead of
a group.
