### PR TITLE
vcenter: don't reuse cached files

### DIFF
--- a/playbooks/ansible-cloud/vcenter-appliance/pre.yaml
+++ b/playbooks/ansible-cloud/vcenter-appliance/pre.yaml
@@ -87,32 +87,9 @@
 - hosts: controller
   gather_facts: false
   tasks:
-    - name: Restore the cache files for the NFS datastore
+    - name: Prepare the NFS server
       when: "'esxis' in groups"
       block:
-        - name: Create the ISO directory
-          file:
-            path: /srv/share/isos
-            state: directory
-          become: true
-
-        - name: Move the cached files
-          shell: |
-             test -f /opt/cache/files/fedora-open-vm-tools-livecd.iso && cp -l /opt/cache/files/fedora-open-vm-tools-livecd.iso /srv/share/isos/centos.iso
-             test -f /opt/cache/files/fedora-open-vm-tools-livecd.iso && cp -l /opt/cache/files/fedora-open-vm-tools-livecd.iso /srv/share/isos/fedora.iso
-          args:
-            creates: /srv/share/isos/fedora.iso
-          become: true
-
-        - name: Adjust the ownership
-          file:
-            path: /srv/share/isos
-            state: directory
-            recurse: true
-            owner: '1000'
-            group: '1000'
-          become: true
-
         - name: Prepare the NFS datastore
           import_role:
             name: vmware-ci-nfs-share

--- a/roles/vmware-ci-nfs-share/tasks/main.yaml
+++ b/roles/vmware-ci-nfs-share/tasks/main.yaml
@@ -1,10 +1,15 @@
 ---
+- name: Create the share directory
+  file:
+    path: /srv/share
+    state: directory
+  become: true
+
 - name: Prepare the NFS shares
   file:
     path: '{{ item }}'
     state: directory
-    owner: '{{ vmware_ci_nfs_share_owner_uid }}'
-    group: '{{ vmware_ci_nfs_share_owner_gid }}'
+    owner: '{{ ansible_user }}'
   with_items:
     - /srv/share/vms
     - /srv/share/isos
@@ -25,6 +30,26 @@
     checksum: '{{ item.value.checksum }}'
     mode: '0644'
   with_dict: "{{ vmware_ci_nfs_share_iso_files }}"
+
+- name: Adjust the ownership of the isos dir
+  file:
+    path: /srv/share/isos
+    state: directory
+    recurse: true
+    owner: '{{ vmware_ci_nfs_share_owner_uid }}'
+    group: '{{ vmware_ci_nfs_share_owner_gid }}'
+    mode: '0555'
+  become: true
+
+- name: Adjust the ownership of the vms dir
+  file:
+    path: /srv/share/isos
+    state: directory
+    recurse: true
+    owner: '{{ vmware_ci_nfs_share_owner_uid }}'
+    group: '{{ vmware_ci_nfs_share_owner_gid }}'
+    mode: '0755'
+  become: true
 
 - name: Install nfs-utils
   package:


### PR DESCRIPTION
The controllers on SF don't have these cached files.
