### PR TITLE
vcenter: don't run configure-swap

### DIFF
--- a/playbooks/ansible-cloud/vcenter-appliance/pre.yaml
+++ b/playbooks/ansible-cloud/vcenter-appliance/pre.yaml
@@ -59,15 +59,6 @@
       vars:
         vmware_ci_set_passwords_secret_dir: '{{ zuul.executor.work_root }}'
 
-- hosts: vcenter
-  gather_facts: false
-  tasks:
-    - import_role:
-        name: configure-swap
-      vars:
-        configure_swap_current_total: 0
-        configure_swap_size: 2000
-
 - hosts: localhost
   gather_facts: false
   tasks:


### PR DESCRIPTION
Our instances are large enough to avoid this step.
