### PR TITLE
ansible-test-splitter needs git

### DIFF
--- a/playbooks/ansible-test-splitter/pre.yaml
+++ b/playbooks/ansible-test-splitter/pre.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  tasks:
+    - name: Install the dependencies
+      package:
+        name: git
+        state: present
+      become: true

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -263,6 +263,7 @@
 ### AWS
 - job:
     name: ansible-test-splitter
+    pre-run: playbooks/ansible-test-splitter/pre.yaml
     run: playbooks/ansible-test-splitter/run.yaml
     files:
       - ^plugins/.*$


### PR DESCRIPTION
Ensure we install git before we call ansible-test-splitter.
