### PR TITLE
ansible-test: typo the second SF provider is ansible-limestone

### DIFF
--- a/roles/ansible-test/tasks/init_test_options.yaml
+++ b/roles/ansible-test/tasks/init_test_options.yaml
@@ -51,7 +51,7 @@
     - ansible_test_python
 
 - name: Use the mirror to pull the container image
-  when: ansible_test_docker and nodepool.cloud in ["ansible-vexxhost", "ansible-vexxhost"]
+  when: ansible_test_docker and nodepool.cloud in ["ansible-vexxhost", "ansible-limestone"]
   block:
     - name: Install nss-mdns
       package:


### PR DESCRIPTION
Ensure we use the mirror with Limestone too.
