### PR TITLE
ansible-test: don't use the mirror with limestone

### DIFF
--- a/roles/ansible-test/tasks/init_test_options.yaml
+++ b/roles/ansible-test/tasks/init_test_options.yaml
@@ -51,7 +51,7 @@
     - ansible_test_python
 
 - name: Use the mirror to pull the container image
-  when: ansible_test_docker and nodepool.cloud in ["ansible-vexxhost", "ansible-limestone"]
+  when: ansible_test_docker and nodepool.cloud in ["ansible-vexxhost"]
   block:
     - name: Install nss-mdns
       package:


### PR DESCRIPTION
We need to investigate why the clients cannot reach the mirror.
