### PR TITLE
vmware: split up more the integration jobs

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -141,7 +141,7 @@
         override-checkout: stable-2.11
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_1_of_2
+    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_part1
     parent: ansible-test-cloud-integration-vcenter7_1esxi-python36
     required-projects:
       - name: github.com/ansible/ansible
@@ -151,14 +151,85 @@
       ansible_test_do_number: 1
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_2_of_2
+    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_part2
     parent: ansible-test-cloud-integration-vcenter7_1esxi-python36
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.11
     vars:
-      ansible_test_split_in: 2
+      ansible_test_split_in: 9
       ansible_test_do_number: 2
+
+- job:
+    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_part3
+    parent: ansible-test-cloud-integration-vcenter7_1esxi-python36
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
+    vars:
+      ansible_test_split_in: 9
+      ansible_test_do_number: 3
+
+- job:
+    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_part4
+    parent: ansible-test-cloud-integration-vcenter7_1esxi-python36
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
+    vars:
+      ansible_test_split_in: 9
+      ansible_test_do_number: 4
+
+
+- job:
+    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_part5
+    parent: ansible-test-cloud-integration-vcenter7_1esxi-python36
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
+    vars:
+      ansible_test_split_in: 9
+      ansible_test_do_number: 5
+
+- job:
+    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_part6
+    parent: ansible-test-cloud-integration-vcenter7_1esxi-python36
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
+    vars:
+      ansible_test_split_in: 9
+      ansible_test_do_number: 6
+
+- job:
+    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_part7
+    parent: ansible-test-cloud-integration-vcenter7_1esxi-python36
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
+    vars:
+      ansible_test_split_in: 9
+      ansible_test_do_number: 7
+
+- job:
+    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_part8
+    parent: ansible-test-cloud-integration-vcenter7_1esxi-python36
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
+    vars:
+      ansible_test_split_in: 9
+      ansible_test_do_number: 8
+
+- job:
+    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_part9
+    parent: ansible-test-cloud-integration-vcenter7_1esxi-python36
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
+    vars:
+      ansible_test_split_in: 9
+      ansible_test_do_number: 9
 
 
 - job:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -579,12 +579,6 @@
     name: ansible-collections-community-vmware
     check:
       jobs:
-        - ansible-test-cloud-integration-govcsim-python38_1_of_3:
-            voting: false
-        - ansible-test-cloud-integration-govcsim-python38_2_of_3:
-            voting: false
-        - ansible-test-cloud-integration-govcsim-python38_3_of_3:
-            voting: false
         - ansible-tox-linters
         - build-ansible-collection:
             required-projects:
@@ -599,8 +593,15 @@
         - ansible-test-units-community-vmware-python38
         - ansible-test-cloud-integration-vcenter7_only-python36-stable211
         - ansible-test-cloud-integration-vcenter7_2esxi-python36-stable211
-        - ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_1_of_2
-        - ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_2_of_2
+        - ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_part1
+        - ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_part2
+        - ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_part3
+        - ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_part4
+        - ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_part5
+        - ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_part6
+        - ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_part7
+        - ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_part8
+        - ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_part9
     gate:
       jobs:
         - ansible-tox-linters


### PR DESCRIPTION
- split in 9 subjobs the integration jobs
- remove govcsim
