### PR TITLE
ansible-test-base/container: only podman on Fedora

### DIFF
--- a/playbooks/ansible-test-base/pre.yaml
+++ b/playbooks/ansible-test-base/pre.yaml
@@ -6,11 +6,20 @@
         path: "{{ ansible_user_dir }}/zuul-output/logs/controller"
         state: directory
 
-    - name: Install container runtime
-      include_role:
-        name: "ensure-{{ (container_command == 'docker') | ternary('docker', 'podman') }}"
-      when:
-        - ansible_test_docker | default(False)
+    - when: ansible_test_docker | default(False)
+      block:
+      - name: Install podman
+        package:
+          name: podman
+          state: present
+        when:
+          - ansible_distribution = 'Fedora'
+
+      - name: Install container runtime
+        include_role:
+          name: "ensure-{{ (container_command == 'docker') | ternary('docker', 'podman') }}"
+        when:
+          - ansible_distribution != 'Fedora'
 
     - name: Add python38 support if needed
       block:


### PR DESCRIPTION
We don't need anything else to run our container on Fedora.
