### PR TITLE
introduce the ansible-ee-tests template

### DIFF
--- a/playbooks/ansible-ee/pre.yaml
+++ b/playbooks/ansible-ee/pre.yaml
@@ -1,0 +1,35 @@
+- hosts: all
+  tasks:
+    - name: Setup download-artifact-fork role
+      include_role:
+        name: download-artifact-fork
+      vars:
+        download_artifact_directory: "{{ zuul.projects['github.com/ansible/network-ee'].src_dir }}/_build/collections"
+        download_artifact_type: ansible_collection
+
+    - name: Adjust the requirements.yaml file to point on the local colletion tarballs
+      replace:
+        path: "{{ zuul.projects['github.com/ansible/network-ee'].src_dir }}/_build/requirements.yml"
+        regexp: "{{ item.name }}$"
+        replace: "collections/{{ item.url | basename }}"
+      with_items: "{{ zuul.artifacts }}"
+      when: "'metadata' in item and 'type' in item.metadata and (item.metadata.type == 'ansible_collection')"
+
+    - name: Install podman
+      package:
+        name: podman
+        state: present
+      become: true
+
+    - name: Build the image
+      command: |
+        podman pull quay.io/ansible/ansible-runner:{{ ansible_runner_container_version }}
+        podman pull quay.io/ansible/ansible-builder:latest
+
+        # later: turn --pull-never on for these commands
+        podman build . --build-arg ANSIBLE_GALAXY_CLI_COLLECTION_OPTS=--pre --build-arg EE_BASE_IMAGE=quay.io/ansible/ansible-runner:latest --tag quay.io/ansible/network-ee:to-test
+        podman build tests --build-arg NETWORK_EE_IMAGE=quay.io/ansible/network-ee:to-test --tag quay.io/ansible/network-ee-tests:to-test
+        podman build test --file Containerfile.ansible-test --target network-ee-unit-tests --build-arg NETWORK_EE_TESTS_IMAGE=quay.io/ansible/network-ee-tests:to-test --tag quay.io/ansible/network-ee-unit-tests:to-test
+        podman build test --file Containerfile.ansible-test --target network-ee-sanity-tests --build-arg NETWORK_EE_TESTS_IMAGE=quay.io/ansible/network-ee-tests:to-test --tag quay.io/ansible/network-ee-sanity-tests:to-test
+      args:
+        chdir: "{{ zuul.projects['github.com/ansible/network-ee'].src_dir }}"

--- a/playbooks/ansible-ee/run.yaml
+++ b/playbooks/ansible-ee/run.yaml
@@ -1,0 +1,15 @@
+---
+- hosts: all
+  tasks:
+    - name: Setup collection_namespace
+      set_fact:
+        collection_namespace: "{{ zuul.project.short_name.split('.')[0] }}"
+      when: collection_namespace is not defined
+
+    - name: Setup collection_name
+      set_fact:
+        collection_name: "{{ zuul.project.short_name.split('.')[1] }}"
+      when: collection_name is not defined
+
+    - name: Run test container
+      shell: "podman run --pull=never -w /usr/share/ansible/collections/ansible_collections/{{ collection_namespace }}/{{ collection_name }} {{ container_image_name }}-{{ container_image_test }}-tests:to-test"

--- a/zuul.d/ee-jobs.yaml
+++ b/zuul.d/ee-jobs.yaml
@@ -1,0 +1,91 @@
+---
+- job:
+    name: ansible-ee-tests-base
+    abstract: true
+    irrelevant-files:
+      - .pre-commit-config.yaml
+    pre-run:
+      - playbooks/ansible-ee/pre.yaml
+    run: playbooks/ansible-ee/run.yaml
+    required-projects:
+      - name: github.com/ansible/network-ee
+    dependencies:
+      - build-ansible-collection
+    vars:
+      container_image_name: quay.io/ansible/ansible-ee
+    nodeset: controller-python35
+
+# latest
+- job:
+    name: ansible-ee-sanity-tests-latest
+    parent: ansible-ee-tests-base
+    vars:
+      ansible_runner_container_version: latest
+      container_image_test: sanity
+
+- job:
+    name: ansible-ee-unit-tests-latest
+    parent: ansible-ee-tests-base
+    vars:
+      ansible_runner_container_version: latest
+      container_image_test: unit
+
+# 2.12
+- job:
+    name: ansible-ee-sanity-tests-stable-2.12
+    parent: ansible-ee-tests-base
+    vars:
+      ansible_runner_container_version: stable-2.12-devel
+      container_image_test: sanity
+
+- job:
+    name: ansible-ee-unit-tests-stable-2.12
+    parent: ansible-ee-tests-base
+    vars:
+      ansible_runner_container_version: stable-2.12-devel
+      container_image_test: unit
+
+# 2.11
+- job:
+    name: ansible-ee-sanity-tests-stable-2.11
+    parent: ansible-ee-tests-base
+    vars:
+      ansible_runner_container_version: stable-2.11-devel
+      container_image_test: sanity
+
+- job:
+    name: ansible-ee-unit-tests-stable-2.11
+    parent: ansible-ee-tests-base
+    vars:
+      ansible_runner_container_version: stable-2.11-devel
+      container_image_test: unit
+
+# 2.10
+- job:
+    name: ansible-ee-sanity-tests-stable-2.10
+    parent: ansible-ee-tests-base
+    vars:
+      ansible_runner_container_version: stable-2.10-devel
+      container_image_test: sanity
+
+- job:
+    name: ansible-ee-unit-tests-stable-2.10
+    parent: ansible-ee-tests-base
+    vars:
+      ansible_runner_container_version: stable-2.10-devel
+      container_image_test: unit
+
+# 2.9
+- job:
+    name: ansible-ee-sanity-tests-stable-2.9
+    parent: ansible-ee-tests-base
+    vars:
+      ansible_runner_container_version: stable-2.9-devel
+      container_image_test: sanity
+
+- job:
+    name: ansible-ee-unit-tests-stable-2.9
+    parent: ansible-ee-tests-base
+    vars:
+      ansible_runner_container_version: stable-2.9-devel
+      container_image_test: unit

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -155,47 +155,18 @@
 - project-template:
     name: ansible-collections-arista-eos-units
     check:
-      jobs: &ansible-collections-arista-eos-units-jobs
-        - ansible-changelog-fragment
-        - ansible-test-sanity-docker-devel
-        - ansible-test-sanity-docker-milestone
-        - ansible-test-sanity-docker-stable-2.9
-        - ansible-test-sanity-docker-stable-2.10
-        - ansible-test-sanity-docker-stable-2.11
-        - ansible-test-sanity-docker-stable-2.12
-        - ansible-test-units-eos-python27:
-            voting: false
-        - ansible-test-units-eos-python38
-        - ansible-test-units-eos-python36
-        - ansible-test-units-eos-python37
+      # TMP, DNM
+      jobs: []
     gate:
-      queue: integrated
-      jobs: *ansible-collections-arista-eos-units-jobs
+      # TMP, DNM
+      jobs: []
 
 - project-template:
     name: ansible-collections-arista-eos
     check:
-      jobs: &ansible-collections-arista-eos-jobs
-        - network-ee-integration-tests-arista-eos-httpapi
-        - network-ee-integration-tests-arista-eos-httpapi-stable-2.9
-        - network-ee-integration-tests-arista-eos-httpapi-stable-2.11
-        - network-ee-integration-tests-arista-eos-httpapi-stable-2.12
-        - network-ee-integration-tests-arista-eos
-        - network-ee-integration-tests-arista-eos-stable-2.9
-        - network-ee-integration-tests-arista-eos-stable-2.11
-        - network-ee-integration-tests-arista-eos-stable-2.12
-        - network-ee-integration-tests-arista-eos-libssh
-        - network-ee-integration-tests-arista-eos-libssh-stable-2.9
-        - network-ee-integration-tests-arista-eos-libssh-stable-2.11
-        - network-ee-integration-tests-arista-eos-libssh-stable-2.12
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/ansible.netcommon
-              - name: github.com/ansible-collections/ansible.utils
+      jobs: []
     gate:
-      queue: integrated
-      fail-fast: true
-      jobs: *ansible-collections-arista-eos-jobs
+      jobs: []
     periodic:
       jobs:
         - ansible-test-sanity-docker-devel
@@ -1325,7 +1296,31 @@
     name: ansible-test-network-integration
 
 - project-template:
+    #name: ansible-ee-tests
     name: network-ee-tests
+    description: |
+      This is a set of jobs, run the sanity and unit tests from within
+      a clean and up to date EE container.
+    check:
+      jobs: &ansible-ee-test-jobs
+        - ansible-ee-sanity-tests-latest
+        - ansible-ee-sanity-tests-stable-2.9
+        - ansible-ee-sanity-tests-stable-2.10
+        - ansible-ee-sanity-tests-stable-2.11
+        - ansible-ee-sanity-tests-stable-2.12
+        - ansible-ee-unit-tests-latest
+        - ansible-ee-unit-tests-stable-2.9
+        - ansible-ee-unit-tests-stable-2.10
+        - ansible-ee-unit-tests-stable-2.11
+        - ansible-ee-unit-tests-stable-2.12
+        # for testing
+        - build-ansible-collection-pod
+    gate:
+      jobs: *ansible-ee-test-jobs
+
+- project-template:
+    #name: network-ee-tests
+    name: network-ee-testsa
     description: |
       This is a set of jobs, run from within a network execution environment
       to validate network collections are working properly. This depends on


### PR DESCRIPTION
Based on network-ee-test with the following differences:

The jobs build the EE container themselves:

- no network-ee-build jobs
- no cache registry in the middle
- simplify the job hierachy. All the job inherite from on single job.
- run on Fedora-35, this can be revisited later.