### PR TITLE
ansible-build-python-tarball: replace synchronize with fetch

### DIFF
--- a/playbooks/ansible-build-python-tarball/post.yaml
+++ b/playbooks/ansible-build-python-tarball/post.yaml
@@ -20,9 +20,8 @@
       delegate_to: localhost
 
     - name: Collect tarball artifacts.
-      synchronize:
+      fetch:
         dest: "{{ zuul.executor.work_root }}/artifacts/"
-        mode: pull
         src: "{{ item.path }}"
-        verify_host: true
+        flat: true
       with_items: "{{ result.files }}"


### PR DESCRIPTION
synchronize does not work with kubectl connection.
