### PR TITLE
introduce the ansible-ee-tests template

### DIFF
--- a/playbooks/ansible-ee/pre.yaml
+++ b/playbooks/ansible-ee/pre.yaml
@@ -1,0 +1,41 @@
+---
+- hosts: all
+  tasks:
+    - name: Setup download-artifact-fork role
+      include_role:
+        name: download-artifact-fork
+      vars:
+        download_artifact_directory: "{{ zuul.projects['github.com/ansible/network-ee'].src_dir }}/_build/collections"
+        download_artifact_type: ansible_collection
+
+    - name: Adjust the requirements.yaml file to point on the local colletion tarballs
+      replace:
+        path: "{{ zuul.projects['github.com/ansible/network-ee'].src_dir }}/_build/requirements.yml"
+        regexp: "{{ item.name }}$"
+        replace: "collections/{{ item.url | basename }}"
+      with_items: "{{ zuul.artifacts }}"
+      when: "'metadata' in item and 'type' in item.metadata and (item.metadata.type == 'ansible_collection')"
+
+    - name: Install podman
+      package:
+        name: podman
+        state: present
+      become: true
+
+    - name: Build the image
+      shell: |
+        set -eux
+        podman pull quay.io/ansible/ansible-runner:{{ ansible_runner_container_version }}
+        podman pull quay.io/ansible/ansible-builder:latest
+        podman pull quay.io/ansible/python-builder:latest
+
+        ANSIBLE_GALAXY_CLI_COLLECTION_OPTS=""
+        if [ ! "{{ ansible_runner_container_version }}" = "stable-2.9-devel" ]; then
+          ANSIBLE_GALAXY_CLI_COLLECTION_OPTS="--pre"
+        fi
+        podman build . --pull-never --build-arg ANSIBLE_GALAXY_CLI_COLLECTION_OPTS=$ANSIBLE_GALAXY_CLI_COLLECTION_OPTS --build-arg EE_BASE_IMAGE=quay.io/ansible/ansible-runner:{{ ansible_runner_container_version }} --tag quay.io/ansible/network-ee:to-test
+        podman build tests --pull-never --build-arg NETWORK_EE_IMAGE=quay.io/ansible/network-ee:to-test --tag quay.io/ansible/network-ee-tests:to-test
+        podman build tests --pull-never --file Containerfile.ansible-test --target network-ee-unit-tests --build-arg NETWORK_EE_TESTS_IMAGE=quay.io/ansible/network-ee-tests:to-test --tag quay.io/ansible/network-ee-unit-tests:to-test
+        podman build tests --pull-never --file Containerfile.ansible-test --target network-ee-sanity-tests --build-arg NETWORK_EE_TESTS_IMAGE=quay.io/ansible/network-ee-tests:to-test --tag quay.io/ansible/network-ee-sanity-tests:to-test
+      args:
+        chdir: "{{ zuul.projects['github.com/ansible/network-ee'].src_dir }}"

--- a/playbooks/ansible-ee/run.yaml
+++ b/playbooks/ansible-ee/run.yaml
@@ -1,0 +1,16 @@
+---
+- hosts: all
+  tasks:
+    - name: Setup collection_namespace
+      set_fact:
+        collection_namespace: "{{ zuul.project.short_name.split('.')[0] }}"
+      when: collection_namespace is not defined
+
+    - name: Setup collection_name
+      set_fact:
+        collection_name: "{{ zuul.project.short_name.split('.')[1] }}"
+      when: collection_name is not defined
+
+    - name: Run test container
+      shell: "podman run --pull=never -w /usr/share/ansible/collections/ansible_collections/{{ collection_namespace }}/{{ collection_name }} {{ container_image_name }}-{{ item }}-tests:to-test"
+      with_items: "{{ container_image_tests }}"

--- a/zuul.d/ee-jobs.yaml
+++ b/zuul.d/ee-jobs.yaml
@@ -1,0 +1,62 @@
+---
+- job:
+    name: ansible-ee-tests
+    abstract: true
+    irrelevant-files:
+      - .pre-commit-config.yaml
+    pre-run:
+      - playbooks/ansible-ee/pre.yaml
+    run: playbooks/ansible-ee/run.yaml
+    required-projects:
+      - name: github.com/ansible/network-ee
+    dependencies:
+      - build-ansible-collection
+    vars:
+      container_image_name: quay.io/ansible/network-ee
+    nodeset: controller-python35
+
+# latest
+- job:
+    name: ansible-ee-tests-latest
+    parent: ansible-ee-tests
+    vars:
+      ansible_runner_container_version: latest
+      container_image_tests:
+        - sanity
+        - unit
+
+- job:
+    name: ansible-ee-tests-stable-2.12
+    parent: ansible-ee-tests
+    vars:
+      ansible_runner_container_version: stable-2.12-devel
+      container_image_tests:
+        - sanity
+        - unit
+
+- job:
+    name: ansible-ee-tests-stable-2.11
+    parent: ansible-ee-tests
+    vars:
+      ansible_runner_container_version: stable-2.11-devel
+      container_image_tests:
+        - sanity
+        - unit
+
+- job:
+    name: ansible-ee-tests-stable-2.10
+    parent: ansible-ee-tests
+    vars:
+      ansible_runner_container_version: stable-2.10-devel
+      container_image_tests:
+        - sanity
+        - unit
+
+- job:
+    name: ansible-ee-tests-stable-2.9
+    parent: ansible-ee-tests
+    vars:
+      ansible_runner_container_version: stable-2.9-devel
+      container_image_tests:
+        - sanity
+        - unit

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1325,6 +1325,21 @@
     name: ansible-test-network-integration
 
 - project-template:
+    name: ansible-ee-tests
+    description: |
+      This is a set of jobs, run the sanity and unit tests from within
+      a clean and up to date EE container.
+    check:
+      jobs: &ansible-ee-test-jobs
+        - ansible-ee-tests-latest
+        - ansible-ee-tests-stable-2.9
+        - ansible-ee-tests-stable-2.10
+        - ansible-ee-tests-stable-2.11
+        - ansible-ee-tests-stable-2.12
+    gate:
+      jobs: *ansible-ee-test-jobs
+
+- project-template:
     name: network-ee-tests
     description: |
       This is a set of jobs, run from within a network execution environment


### PR DESCRIPTION
Based on network-ee-test with the following differences:

The jobs build the EE container themselves:

- no network-ee-build jobs
- no cache registry in the middle
- simplify the job hierachy. All the job inherite from on single
  job.
- run on Fedora-35, this can be revisited later.
