### PR TITLE
sf: run ansible-tox-linters in container

### DIFF
--- a/zuul.ansible.d/jobs.yaml
+++ b/zuul.ansible.d/jobs.yaml
@@ -1,0 +1,5 @@
+---
+- job:
+    name: ansible-tox-linters
+    parent: tox-linters
+    nodeset: fedora-latest-1vcpu

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -22,11 +22,6 @@
     parent: tox-docs
     nodeset: centos-8-stream
 
-- job:
-    name: ansible-tox-linters
-    parent: tox-linters
-    nodeset: fedora-latest-1vcpu
-
 - job: &ansible-tox-molecule-base
     name: ansible-tox-molecule-base
     # Stub job used to define only properties specific to molecule jobs,

--- a/zuul.sf.d/jobs.yaml
+++ b/zuul.sf.d/jobs.yaml
@@ -1,0 +1,5 @@
+---
+- job:
+    name: ansible-tox-linters
+    parent: tox-linters
+    nodeset: zuul-worker-f35


### PR DESCRIPTION
On SoftwareFactory, we now run `ansible-tox-linters` in a `zuul-worker-f35`
container.
