### PR TITLE
sf/ansible-tox-linters: use a container

### DIFF
--- a/zuul.ansible.d/nodesets.yaml
+++ b/zuul.ansible.d/nodesets.yaml
@@ -731,3 +731,9 @@
         nodes:
           - Trendmicro-DeepSecurity-20.0.344
           - fedora-35
+
+- nodeset:
+    name: ansible-tox-linters
+    nodes:
+      - name: controller
+        label: ansible-fedora-35-1vcpu

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -25,7 +25,7 @@
 - job:
     name: ansible-tox-linters
     parent: tox-linters
-    nodeset: fedora-latest-1vcpu
+    nodeset: ansible-tox-linters
 
 - job: &ansible-tox-molecule-base
     name: ansible-tox-molecule-base

--- a/zuul.sf.d/nodesets.yaml
+++ b/zuul.sf.d/nodesets.yaml
@@ -285,3 +285,9 @@
     nodes:
       - name: controller
         label: ansible-fedora-35-1vcpu
+
+- nodeset:
+    name: ansible-tox-linters
+    nodes:
+      - name: controller
+        label: zuul-worker-ansible


### PR DESCRIPTION
Run `ansible-tox-linters` in a container by default on SF.
