### PR TITLE
cloud.common needs kubernetes.core

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -566,6 +566,7 @@
             required-projects:
               - name: github.com/ansible-collections/community.vmware
               - name: github.com/ansible-collections/vmware.vmware_rest
+              - name: github.com/ansible-collections/kubernetes.core
         - ansible-test-molecule-kubernetes-core-with-turbo
     gate:
       jobs: *ansible-collections-cloud-common-jobs


### PR DESCRIPTION
`ansible-test-molecule-kubernetes-core-with-turbo` depends on
kubernetes.core.
