### PR TITLE
deploy-artifacts: avoid the use of ansible_user_dir

### DIFF
--- a/playbooks/ansible-galaxy-importer/run.yaml
+++ b/playbooks/ansible-galaxy-importer/run.yaml
@@ -3,11 +3,11 @@
   tasks:
     - name: Generate version number for ansible collection
       args:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
-      shell: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv/bin/python -W ignore {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv/bin/generate-ansible-collection"
+        chdir: "~/{{ zuul.project.src_dir }}"
+      shell: "~/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv/bin/python -W ignore ~/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv/bin/generate-ansible-collection"
       register: _version
 
     - name: Confirm collection can be imported into galaxy
       args:
-        chdir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"
-      shell: "source .tox/venv/bin/activate; ./tools/validate-collection.sh {{ ansible_user_dir }}/downloads/{{ _version.stdout }}"
+        chdir: "~/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}"
+      shell: "source .tox/venv/bin/activate; ./tools/validate-collection.sh ~/downloads/{{ _version.stdout }}"

--- a/roles/deploy-artifacts/tasks/main.yaml
+++ b/roles/deploy-artifacts/tasks/main.yaml
@@ -18,6 +18,6 @@
 
 - name: Install require-project collection using ansible-galaxy
   args:
-    chdir: "{{ ansible_user_dir }}/downloads"
+    chdir: ~/downloads
     executable: /bin/bash
   shell: "source {{ deploy_artifacts_venv_path }}/bin/activate; ansible-galaxy collection install {{ __collections }}"


### PR DESCRIPTION
With container, `ansible_user_dir` point on /root which is another
unexisting directory.
