### PR TITLE
ansible-tox-linters: ensure py38

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -25,6 +25,7 @@
 - job:
     name: ansible-tox-linters
     parent: tox-linters
+    pre-run: playbooks/ansible-tox-py38/pre.yaml
     nodeset: ansible-tox-linters
 
 - job: &ansible-tox-molecule-base


### PR DESCRIPTION
See: https://dashboard.zuul.ansible.com/t/ansible/build/e555b7961b0141d8b1997299a9cc97eb/logs
