### PR TITLE
reverse recent changes on ansible-network-openvswitch-appliance/pre.yaml

### DIFF
--- a/playbooks/ansible-ee/openvswitch/pre.yaml
+++ b/playbooks/ansible-ee/openvswitch/pre.yaml
@@ -1,0 +1,24 @@
+---
+- hosts: openvswitch
+  tasks:
+    - when: ansible_distribution == 'Fedora'
+      block:
+        - name: Install openvswitch package
+          become: true
+          package:
+            name:
+              - openvswitch
+            state: present
+        - name: Start the service
+          become: true
+          service:
+            name: openvswitch
+            state: started
+    - when: ansible_distribution == 'Ubuntu'
+      block:
+        - name: Install openvswitch package
+          become: true
+          package:
+            name:
+              - openvswitch-switch
+            state: present

--- a/playbooks/ansible-network-openvswitch-appliance/pre.yaml
+++ b/playbooks/ansible-network-openvswitch-appliance/pre.yaml
@@ -1,24 +1,14 @@
 ---
-- hosts: openvswitch
+- hosts: controller
   tasks:
-    - when: ansible_distribution == 'Fedora'
-      block:
-        - name: Install openvswitch package
-          become: true
-          package:
-            name:
-              - openvswitch
-            state: present
-        - name: Start the service
-          become: true
-          service:
-            name: openvswitch
-            state: started
-    - when: ansible_distribution == 'Ubuntu'
-      block:
-        - name: Install openvswitch package
-          become: true
-          package:
-            name:
-              - openvswitch-switch
-            state: present
+    - name: Ensure tox
+      include_role:
+        name: ensure-tox
+    - name: Setup tox role
+      include_role:
+        name: tox
+      vars:
+        tox_envlist: venv
+        tox_extra_args: -vv -- ansible-playbook -v playbooks/ansible-network-openvswitch-appliance/files/bootstrap.yaml
+        tox_install_siblings: false
+        zuul_work_dir: "{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"

--- a/zuul.d/openvswitch-openvswitch-jobs.yaml
+++ b/zuul.d/openvswitch-openvswitch-jobs.yaml
@@ -94,7 +94,7 @@
     name: ansible-ee-integration-ovs-latest
     parent: ansible-ee-tests
     pre-run:
-      - playbooks/ansible-network-openvswitch-appliance/pre.yaml
+      - playbooks/ansible-ee/openvswitch/pre.yaml
     vars:
       ansible_runner_container_version: latest
       container_image_tests:


### PR DESCRIPTION
The change reverts the recents change on playbooks/ansible-network-openvswitch-appliance/pre.yaml and creates a new  playbooks/ansible-ee/openvswitch/pre.yaml file that isolate the tasks related to the new ansible-ee jobs.