### PR TITLE
c.vmware: ansible-galaxy-importer non-voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -128,6 +128,10 @@
         - ansible-test-cloud-integration-aws-py38_5
         - ansible-galaxy-importer:
             voting: false
+    third-party-check:
+      jobs:
+        - ansible-galaxy-importer:
+            voting: false
     gate:
       queue: integrated-aws
       jobs: *ansible-collections-community-aws-jobs


### PR DESCRIPTION
Ensure ansible-galaxy-importer from third-party-check is also non-voting.
