### PR TITLE
centos8stream: use centos's vault

### DIFF
--- a/roles/configure-mirrors-fork/templates/centos8-stream/etc/yum.repos.d/CentOS-Stream-AppStream.repo.j2
+++ b/roles/configure-mirrors-fork/templates/centos8-stream/etc/yum.repos.d/CentOS-Stream-AppStream.repo.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 [appstream]
 name=CentOS Stream $releasever - AppStream
-baseurl={{ package_mirror }}/$stream/AppStream/$basearch/os/
+baseurl=https://vault.centos.org/8.5.2111/AppStream/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial

--- a/roles/configure-mirrors-fork/templates/centos8-stream/etc/yum.repos.d/CentOS-Stream-BaseOS.repo.j2
+++ b/roles/configure-mirrors-fork/templates/centos8-stream/etc/yum.repos.d/CentOS-Stream-BaseOS.repo.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 [baseos]
 name=CentOS Stream $releasever - BaseOS
-baseurl={{ package_mirror }}/$stream/BaseOS/$basearch/os/
+baseurl=https://vault.centos.org/8.5.2111/BaseOS/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial

--- a/roles/configure-mirrors-fork/templates/centos8-stream/etc/yum.repos.d/CentOS-Stream-Extras.repo.j2
+++ b/roles/configure-mirrors-fork/templates/centos8-stream/etc/yum.repos.d/CentOS-Stream-Extras.repo.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 [extras]
 name=CentOS Stream $releasever - Extras
-baseurl={{ package_mirror }}/$stream/extras/$basearch/os/
+baseurl=https://vault.centos.org/8.5.2111/extras/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial

--- a/roles/configure-mirrors-fork/templates/centos8-stream/etc/yum.repos.d/CentOS-Stream-PowerTools.repo.j2
+++ b/roles/configure-mirrors-fork/templates/centos8-stream/etc/yum.repos.d/CentOS-Stream-PowerTools.repo.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 [powertools]
 name=CentOS Stream $releasever - PowerTools
-baseurl={{ package_mirror }}/$stream/PowerTools/$basearch/os/
+baseurl=https://vault.centos.org/8.5.2111/PowerTools/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial

--- a/roles/configure-mirrors-fork/vars/CentOS.yaml
+++ b/roles/configure-mirrors-fork/vars/CentOS.yaml
@@ -1,3 +1,2 @@
 ---
 epel_mirror: https://mirror.csclub.uwaterloo.ca/fedora/epel
-package_mirror: http://mirror.facebook.net/centos


### PR DESCRIPTION
Use a mirror of the CentOS vault.

We cannot use https://vault.centos.org/8-stream/ (yet?) because some part are missing.
