### PR TITLE
ansible-tox-docs: use Fedora 35

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -20,7 +20,7 @@
 - job:
     name: ansible-tox-docs
     parent: tox-docs
-    nodeset: centos-8-stream
+    nodeset: fedora-latest-1vcpu
 
 - job:
     name: ansible-tox-linters


### PR DESCRIPTION
centos-8-stream is EOL.
