### PR TITLE
zuul.a.com: reenable one check job

### DIFF
--- a/zuul.ansible.d/project.yaml
+++ b/zuul.ansible.d/project.yaml
@@ -1,0 +1,7 @@
+---
+- project:
+    check:
+      jobs:
+        - ansible-tox-py39:
+            vars:
+              tox_envlist: pytest,black


### PR DESCRIPTION
Run one single job just to be sure we don't break the zuul.a.com
set-up.
