### PR TITLE
k8s/molecule: ensure selinux is disabled

### DIFF
--- a/playbooks/ansible-cloud/k8s/molecule.yaml
+++ b/playbooks/ansible-cloud/k8s/molecule.yaml
@@ -4,7 +4,12 @@
     ansible_zuul_src_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible-zuul-jobs'].src_dir }}"
   tasks:
     - name: Test using Molecule
-      shell: "source {{ ansible_test_venv_path }}/bin/activate; molecule test"
+      shell: |
+        source {{ ansible_test_venv_path }}/bin/activate
+        set -eux
+        pip freeze
+        python3 -c 'import selinux; assert selinux.is_selinux_enabled() is False'
+        molecule test
       environment: "{{ ansible_test_environment | default({}) }}"
       args:
         chdir: ~/.ansible/collections/ansible_collections/kubernetes/core

--- a/playbooks/ansible-cloud/k8s/pre.yaml
+++ b/playbooks/ansible-cloud/k8s/pre.yaml
@@ -33,12 +33,6 @@
     - name: Upgrade pip
       shell: "{{ ansible_test_venv_path }}/bin/pip install --upgrade pip"
 
-    - name: Install SELinux Python bindings using yum
-      yum:
-        name: libselinux-python3
-        state: present
-      become: true
-
     - name: Install Ansible into virtualenv
       environment:
         ANSIBLE_SKIP_CONFLICT_CHECK: 1
@@ -57,9 +51,13 @@
           - kubernetes
           - flake8
           - jsonpatch
-          - selinux_please_lie_to_me
         virtualenv: '{{ ansible_test_venv_path }}'
         virtualenv_python: python3
+
+    - name: Disable selinux with selinux_please_lie_to_me
+      shell: |
+        {{ ansible_test_venv_path }}/bin/pip uninstall -y selinux
+        {{ ansible_test_venv_path }}/bin/pip install selinux_please_lie_to_me
 
     - name: Install Kubernetes cluster
       include_role:


### PR DESCRIPTION
We intall `selinux_please_lie_to_me` way to late. If a package has pulled the regular `selinux` before, it will be to large.