### PR TITLE
kubernetes: increate the timeout to 2h

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -434,7 +434,7 @@
     required-projects:
       - name: github.com/ansible/ansible
       - name: github.com/ansible-collections/kubernetes.core
-    timeout: 5400
+    timeout: 7200
     nodeset: centos-8-stream
     vars:
       ansible_collections_repo: github.com/ansible-collections/kubernetes.core


### PR DESCRIPTION
Ideally, we should split these jobs to avoid these longs run.
