### PR TITLE
ansible-ee/ansible-runner: use the -latest version

### DIFF
--- a/zuul.d/ee-jobs.yaml
+++ b/zuul.d/ee-jobs.yaml
@@ -29,7 +29,7 @@
     name: ansible-ee-tests-stable-2.12
     parent: ansible-ee-tests
     vars:
-      ansible_runner_container_version: stable-2.12-devel
+      ansible_runner_container_version: stable-2.12-latest
       container_image_tests:
         - sanity
         - unit
@@ -38,7 +38,7 @@
     name: ansible-ee-tests-stable-2.11
     parent: ansible-ee-tests
     vars:
-      ansible_runner_container_version: stable-2.11-devel
+      ansible_runner_container_version: stable-2.11-latest
       container_image_tests:
         - sanity
         - unit
@@ -47,7 +47,7 @@
     name: ansible-ee-tests-stable-2.10
     parent: ansible-ee-tests
     vars:
-      ansible_runner_container_version: stable-2.10-devel
+      ansible_runner_container_version: stable-2.10-latest
       container_image_tests:
         - sanity
         - unit
@@ -56,7 +56,7 @@
     name: ansible-ee-tests-stable-2.9
     parent: ansible-ee-tests
     vars:
-      ansible_runner_container_version: stable-2.9-devel
+      ansible_runner_container_version: stable-2.9-latest
       container_image_tests:
         - sanity
         - unit

--- a/zuul.d/openvswitch-openvswitch-jobs.yaml
+++ b/zuul.d/openvswitch-openvswitch-jobs.yaml
@@ -108,22 +108,22 @@
     name: ansible-ee-integration-ovs-stable2.11
     parent: ansible-ee-integration-ovs-latest
     vars:
-      ansible_runner_container_version: stable-2.11-devel
+      ansible_runner_container_version: stable-2.11-latest
 
 - job:
     name: ansible-ee-integration-ovs-stable2.12
     parent: ansible-ee-integration-ovs-latest
     vars:
-      ansible_runner_container_version: stable-2.12-devel
+      ansible_runner_container_version: stable-2.12-latest
 
 - job:
     name: ansible-ee-integration-ovs-stable2.10
     parent: ansible-ee-integration-ovs-latest
     vars:
-      ansible_runner_container_version: stable-2.10-devel
+      ansible_runner_container_version: stable-2.10-latest
 
 - job:
     name: ansible-ee-integration-ovs-stable2.9
     parent: ansible-ee-integration-ovs-latest
     vars:
-      ansible_runner_container_version: stable-2.9-devel
+      ansible_runner_container_version: stable-2.9-latest


### PR DESCRIPTION
Use the images with the `-latest` suffix instead of `-devel` as
suggested by Shrews.
