### PR TITLE
setup-kind: retry 3 time to download kubectl

### DIFF
--- a/roles/setup-kind/tasks/main.yml
+++ b/roles/setup-kind/tasks/main.yml
@@ -9,6 +9,10 @@
   ansible.builtin.get_url:
     url: "https://dl.k8s.io/release/{{ kubectl_release }}/bin/linux/amd64/kubectl"
     dest: '{{ kubectl_path }}'
+  register: result
+  until: result is not failed
+  retries: 3
+  delay: 60
   become: true
 
 - name: Make Kind as executable


### PR DESCRIPTION
We've also got a story for a better long term solution.

See: https://issues.redhat.com/browse/ACA-471
