### PR TITLE
ansible.utils: only use ansible-collections-ansible-utils-units

### DIFF
--- a/zuul.sf.d/project-templates.yaml
+++ b/zuul.sf.d/project-templates.yaml
@@ -45,29 +45,6 @@
         - ansible-test-units-openvswitch-python38
         - build-ansible-collection
 
-# ansible.utils
-- project-template:
-    name: ansible-collections-ansible-utils_no_network-ee
-    check:
-      jobs: &ansible-collections-ansible-utils-jobs_no_network_ee
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/ansible.netcommon
-              - name: github.com/ansible-collections/ansible.utils
-    gate:
-      queue: integrated
-      jobs: *ansible-collections-ansible-utils-jobs_no_network_ee
-    periodic:
-      jobs:
-        - ansible-test-sanity-docker-devel
-        - ansible-test-sanity-docker-milestone
-        - ansible-test-sanity-docker-stable-2.9
-        - ansible-test-sanity-docker-stable-2.10
-        - ansible-test-sanity-docker-stable-2.11
-        - ansible-test-sanity-docker-stable-2.12
-        - ansible-test-units-openvswitch-python38
-        - build-ansible-collection
-
 - project-template:
     name: ansible-collections-ansible-utils
     check:
@@ -76,15 +53,7 @@
       queue: integrated
       jobs: []
     periodic:
-      jobs:
-        - ansible-test-sanity-docker-devel
-        - ansible-test-sanity-docker-milestone
-        - ansible-test-sanity-docker-stable-2.9
-        - ansible-test-sanity-docker-stable-2.10
-        - ansible-test-sanity-docker-stable-2.11
-        - ansible-test-sanity-docker-stable-2.12
-        - ansible-test-units-openvswitch-python38
-        - build-ansible-collection
+      jobs: []
 
 - project-template:
     name: ansible-collections-ansible-utils-units
@@ -100,8 +69,7 @@
         - ansible-test-units-ansible-utils-python27
         - ansible-test-units-ansible-utils-python36
         - ansible-test-units-ansible-utils-python37
-        - network-ee-unit-tests:
-            voting: false
+        - build-ansible-collection
     gate:
       queue: integrated
       jobs: *ansible-collections-ansible-utils-units-jobs
@@ -113,5 +81,4 @@
         - ansible-test-sanity-docker-stable-2.10
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
-        - ansible-test-units-ansible-utils-python38
         - build-ansible-collection


### PR DESCRIPTION
- Remove ansible-collections-ansible-utils_no_network-ee, we don't use it.
- Disable network-ee-unit-tests
- Keep ansible-collections-ansible-utils for now, to avoid missing template reference
