### PR TITLE
sf: use the ansible-cloud-fedora-35 label for Fedora

### DIFF
--- a/zuul.sf.d/nodesets.yaml
+++ b/zuul.sf.d/nodesets.yaml
@@ -10,44 +10,44 @@
     name: asav9-12-3-python27
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: asav9-12-3-python36
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: asav9-12-3-python38
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: centos-7-1vcpu
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: centos-8-stream
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: centos-8-stream-small
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: eos-4.24.6-python38
     nodes:
       - name: controller
         # TODO
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
       - name: eos-4.24.6
         label: vEOS-4.24.6F
     groups:
@@ -59,61 +59,61 @@
     name: fedora-35-1vcpu
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: fedora-latest-1vcpu
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: ios-15.6-2T-python38
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: iosxr-7.0.2-python27
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: iosxr-7.0.2-python35
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: iosxr-7.0.2-python36
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: iosxr-7.0.2-python37
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: iosxr-7.0.2-python38
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: nxos-7.0.3-python36
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: nxos-7.0.3-python38
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: openvswitch-2.9.0-python38
@@ -134,7 +134,7 @@
     name: openvswitch-2.15.0-python38
     nodes:
       - name: controller
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
     groups:
       - name: openvswitch
         nodes:
@@ -144,79 +144,79 @@
     name: QRadarCE-7.3.1-python38
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: SplunkEnterprise-SES-8.0.0-python38
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: Trendmicro-DeepSecurity-20.0.344-python27
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: Trendmicro-DeepSecurity-20.0.344-python36
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: Trendmicro-DeepSecurity-20.0.344-python38
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: ubuntu-bionic-1vcpu
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: ubuntu-xenial-1vcpu
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: vqfx-18.1R3-python36
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: vsrx3-18.4R1-python27
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: vsrx3-18.4R1-python35
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: vsrx3-18.4R1-python36
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: vsrx3-18.4R1-python38
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: vyos-1.1.8-python38
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 ## end aliases
 
 # Ansible cloud appliance nodesets
@@ -224,7 +224,7 @@
     name: vmware-govcsim-python38
     nodes:
       - name: fedora-35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
     groups:
       - name: controller
         nodes:
@@ -235,7 +235,7 @@
     name: vmware-vcsa-7.0.3-python36
     nodes:
       - name: controller
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
       - name: vcenter
         label: ansible-vmware-vcsa-7.0.3
     groups:
@@ -247,7 +247,7 @@
     name: vmware-vcsa_1esxi-7.0.3-python36
     nodes:
       - name: controller
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
       - name: vcenter
         label: ansible-vmware-vcsa-7.0.3
       - name: esxi1
@@ -267,7 +267,7 @@
     name: vmware-vcsa_2esxi-7.0.3-python36
     nodes:
       - name: controller
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
       - name: vcenter
         label: ansible-vmware-vcsa-7.0.3
       - name: esxi1
@@ -291,32 +291,32 @@
     name: controller-python27
     nodes:
       - name: controller
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: controller-python35
     nodes:
       - name: controller
         # note: there is no py35 on f35
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: controller-python36
     nodes:
       - name: controller
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: controller-python37
     nodes:
       - name: controller
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: controller-python38
     nodes:
       - name: controller
-        label: ansible-fedora-35-1vcpu
+        label: ansible-cloud-fedora-35
 
 - nodeset:
     name: ansible-tox-linters


### PR DESCRIPTION
- ansible-fedora-35-1vcpu is the original cloud image as vendored by
  Fedora
- ansible-cloud-fedora-35 is the same image, but refresh to include
  an update to date list of pacakges.
