### PR TITLE
kubernetes.core: use fedora-35-1vcpu

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -505,7 +505,7 @@
       - name: github.com/ansible/ansible
       - name: github.com/ansible-collections/kubernetes.core
     timeout: 7200
-    nodeset: centos-8-stream
+    nodeset: fedora-35-1vcpu
     vars:
       ansible_collections_repo: github.com/ansible-collections/kubernetes.core
       ansible_test_collections: true


### PR DESCRIPTION
Use fedora-35-1vcpu because the centos-8-stream is not yet
available. https://softwarefactory-project.io/r/c/config/+/24240
will address the situation. For now, we switch on Fedora 35.
