### PR TITLE
run ansible-build-python-tarball in container

### DIFF
--- a/playbooks/ansible-build-python-tarball/post.yaml
+++ b/playbooks/ansible-build-python-tarball/post.yaml
@@ -1,28 +1,12 @@
 ---
 - hosts: all
   tasks:
-    - name: Find tarballs and wheels in dist folder
-      find:
-        file_type: file
-        paths: "src/{{ zuul.project.canonical_name }}/dist"
-        patterns: "*.tar.gz,*.whl"
-      register: result
-
-    - name: Display stat for tarballs and wheels
-      stat:
-        path: "{{ item.path }}"
-      with_items: "{{ result.files }}"
-
     - name: Ensure artifacts directory exists
       file:
-        path: "{{ zuul.executor.work_root }}/artifacts"
+        path: "{{ ansible_user_dir }}/zuul-output/artifacts"
         state: directory
-      delegate_to: localhost
 
-    - name: Collect tarball artifacts.
-      synchronize:
-        dest: "{{ zuul.executor.work_root }}/artifacts/"
-        mode: pull
-        src: "{{ item.path }}"
-        verify_host: true
-      with_items: "{{ result.files }}"
+    - name: Copy the tarballs to the artifacts directory
+      shell: |
+       cp -v src/{{ zuul.project.canonical_name }}/dist/*.tar.gz {{ ansible_user_dir }}/zuul-output/artifacts
+       cp -v src/{{ zuul.project.canonical_name }}/dist/*.whl {{ ansible_user_dir }}/zuul-output/artifacts

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -109,7 +109,7 @@
     post-run: playbooks/ansible-build-python-tarball/post.yaml
     required-projects:
       - github.com/ansible-network/releases
-    nodeset: centos-8-stream
+    nodeset: container-ansible
     vars:
       release_python: python3
 


### PR DESCRIPTION
ansible-build-python-tarball: delegate the artifact upload to fetch-output-openshift

The {{ ansible_user_dir }}/zuul-output/artifacts directory is automatically downloaded.
We don't need to rely on synchronize.
