### PR TITLE
expend the vyos-1.1.8-python38 nodeset

### DIFF
--- a/zuul.ansible.d/nodesets.yaml
+++ b/zuul.ansible.d/nodesets.yaml
@@ -570,21 +570,6 @@
           - fedora-35
 
 - nodeset:
-    name: vyos-1.1.8-python38
-    nodes:
-      - name: centos-8-stream
-        label: centos-8-stream
-      - name: vyos-1.1.8
-        label: vyos-1.1.8-1vcpu
-    groups:
-      - name: appliance
-        nodes:
-          - vyos-1.1.8
-      - name: controller
-        nodes:
-          - centos-8-stream
-
-- nodeset:
     name: controller-python27
     nodes:
       - name: fedora-35

--- a/zuul.d/ansible-network-jobs.yaml
+++ b/zuul.d/ansible-network-jobs.yaml
@@ -12,7 +12,19 @@
       collection_name: network
       # NOTE(pabelanger): We can only use RSA ssh keys for vyos.
       test_fips_mode: false
-    nodeset: vyos-1.1.8-python38
+    nodeset:
+      nodes:
+        - name: centos-8-stream
+          label: centos-8-stream
+        - name: vyos-1.1.8
+          label: vyos-1.1.8-1vcpu
+      groups:
+        - name: appliance
+          nodes:
+            - vyos-1.1.8
+        - name: controller
+          nodes:
+            - centos-8-stream
 
 - job:
     name: network-ee-integration-tests-ansible-network-libssh
@@ -29,7 +41,20 @@
 - job:
     name: network-ee-integration-tests-ansible-network-stable-2.12
     parent: network-ee-integration-tests-stable-2.12
-    nodeset: vyos-1.1.8-python38
+    nodeset:
+      nodes:
+        - name: centos-8-stream
+          label: centos-8-stream
+        - name: vyos-1.1.8
+          label: vyos-1.1.8-1vcpu
+      groups:
+        - name: appliance
+          nodes:
+            - vyos-1.1.8
+        - name: controller
+          nodes:
+            - centos-8-stream
+
     vars:
       test_ansible_python_interpreter: /usr/bin/python3
       # NOTE(pabelanger): We can only use RSA ssh keys for vyos.

--- a/zuul.d/vyos-vyos-jobs.yaml
+++ b/zuul.d/vyos-vyos-jobs.yaml
@@ -13,7 +13,20 @@
         ansible_network_os: vyos
     required-projects:
       - name: github.com/ansible/ansible-zuul-jobs
-    nodeset: vyos-1.1.8-python38
+    nodeset:
+      nodes:
+        - name: centos-8-stream
+          label: centos-8-stream
+        - name: vyos-1.1.8
+          label: vyos-1.1.8-1vcpu
+      groups:
+        - name: appliance
+          nodes:
+            - vyos-1.1.8
+        - name: controller
+          nodes:
+            - centos-8-stream
+
     timeout: 10800
 
 # =============================================================================
@@ -56,7 +69,20 @@
 - job:
     name: network-ee-integration-tests-vyos
     parent: network-ee-integration-tests
-    nodeset: vyos-1.1.8-python38
+    nodeset:
+      nodes:
+        - name: centos-8-stream
+          label: centos-8-stream
+        - name: vyos-1.1.8
+          label: vyos-1.1.8-1vcpu
+      groups:
+        - name: appliance
+          nodes:
+            - vyos-1.1.8
+        - name: controller
+          nodes:
+            - centos-8-stream
+
     vars:
       test_ansible_python_interpreter: /usr/bin/python3
       # NOTE(pabelanger): We can only use RSA ssh keys for vyos.
@@ -77,7 +103,19 @@
 - job:
     name: network-ee-integration-tests-vyos-stable-2.12
     parent: network-ee-integration-tests-stable-2.12
-    nodeset: vyos-1.1.8-python38
+    nodeset:
+      nodes:
+        - name: centos-8-stream
+          label: centos-8-stream
+        - name: vyos-1.1.8
+          label: vyos-1.1.8-1vcpu
+      groups:
+        - name: appliance
+          nodes:
+            - vyos-1.1.8
+        - name: controller
+          nodes:
+            - centos-8-stream
     vars:
       test_ansible_python_interpreter: /usr/bin/python3
       # NOTE(pabelanger): We can only use RSA ssh keys for vyos.
@@ -98,7 +136,20 @@
 - job:
     name: network-ee-integration-tests-vyos-stable-2.11
     parent: network-ee-integration-tests-stable-2.11
-    nodeset: vyos-1.1.8-python38
+    nodeset:
+      nodes:
+        - name: centos-8-stream
+          label: centos-8-stream
+        - name: vyos-1.1.8
+          label: vyos-1.1.8-1vcpu
+      groups:
+        - name: appliance
+          nodes:
+            - vyos-1.1.8
+        - name: controller
+          nodes:
+            - centos-8-stream
+
     vars:
       test_ansible_python_interpreter: /usr/bin/python3
       # NOTE(pabelanger): We can only use RSA ssh keys for vyos.
@@ -119,7 +170,20 @@
 - job:
     name: network-ee-integration-tests-vyos-stable-2.9
     parent: network-ee-integration-tests-stable-2.9
-    nodeset: vyos-1.1.8-python38
+    nodeset:
+      nodes:
+        - name: centos-8-stream
+          label: centos-8-stream
+        - name: vyos-1.1.8
+          label: vyos-1.1.8-1vcpu
+      groups:
+        - name: appliance
+          nodes:
+            - vyos-1.1.8
+        - name: controller
+          nodes:
+            - centos-8-stream
+
     vars:
       test_ansible_python_interpreter: /usr/bin/python3
       # NOTE(pabelanger): We can only use RSA ssh keys for vyos.


### PR DESCRIPTION
It looks like in some cases, Zuul cannot load the nodesets from
zuul.ansible.d/nodesets.yaml
