### PR TITLE
Add amazon.cloud project

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -224,6 +224,28 @@
             voting: false
 
 - project-template:
+    name: ansible-collections-amazon-cloud
+    check:
+      queue: integrated-aws
+      jobs: &ansible-collections-amazon-cloud-jobs
+        - ansible-test-sanity-docker-devel
+        - ansible-test-sanity-docker-milestone
+        - ansible-test-sanity-docker-stable-2.9
+        - ansible-test-sanity-docker-stable-2.11
+        - ansible-test-sanity-docker-stable-2.12
+        - ansible-test-units-amazon-cloud-python38
+        - ansible-test-integration-amazon-cloud
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-collections/amazon.aws
+    gate:
+      queue: integrated-aws
+      jobs: *ansible-collections-amazon-cloud-jobs
+    ondemand:
+      queue: integrated-aws
+      jobs: *ansible-collections-amazon-cloud-jobs
+
+- project-template:
     name: ansible-collections-arista-eos-units
     check:
       jobs: &ansible-collections-arista-eos-units-jobs

--- a/zuul.sf.d/ansible-cloud-jobs.yaml
+++ b/zuul.sf.d/ansible-cloud-jobs.yaml
@@ -422,6 +422,27 @@
     name: integration-community.aws-13
     parent: ansible-test-cloud-integration-aws
 
+- job:
+    name: ansible-test-integration-amazon-cloud
+    parent: ansible-core-ci-aws-session
+    dependencies:
+      - name: build-ansible-collection
+    pre-run:
+      - playbooks/ansible-test-base/pre.yaml
+    run: playbooks/ansible-test-base/run.yaml
+    post-run:
+      - playbooks/ansible-test-integration-base/post.yaml
+      - playbooks/ansible-test-base/post.yaml
+    required-projects:
+      - name: github.com/ansible-collections/amazon.aws
+    timeout: 3600
+    vars:
+      ansible_test_collections: true
+      ansible_test_command: integration
+      ansible_test_python: 3.8
+      ansible_test_integration_targets: ""
+      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
+
 #### units
 
 - job:
@@ -437,6 +458,12 @@
         - tests/unit/requirements.txt
       ansible_test_constraint_files:
         - tests/unit/constraints.txt
+
+- job:
+    name: ansible-test-units-amazon-cloud-python38
+    parent: ansible-test-units-base-python38
+    vars:
+      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
 
 # TODO(Gonéri): do we still need this flavor of the job?
 - job:


### PR DESCRIPTION
This adds jobs for the new amazon.cloud project. We decided we are only going to do integration testing for a handful of modules, so there is no need to use the splitter.

I'm not really sure I know what I'm doing here, so this may be the wrong way to do things.