### PR TITLE
ansible-test-units: don't generate the coverage report

### DIFF
--- a/playbooks/ansible-test-units-base/post.yaml
+++ b/playbooks/ansible-test-units-base/post.yaml
@@ -1,4 +1,5 @@
 ---
+# playbook used to generate the coverage report.
 - hosts: controller
   vars:
     ansible_test_location: "{{ ansible_user_dir }}/{{ zuul.projects[ansible_collections_repo].src_dir }}"

--- a/roles/ansible-test/tasks/init_test_options.yaml
+++ b/roles/ansible-test/tasks/init_test_options.yaml
@@ -24,14 +24,14 @@
     ansible_test_options: "{{ ansible_test_options }} --requirements"
   when: not ansible_test_collections
 
-- name: Enable coverage commands for unit tests
+- name: Adjust options for unit tests
   set_fact:
-    ansible_test_options: "--coverage"
+    ansible_test_options: ""
   when: ansible_test_test_command == 'units'
 
 - when: ansible_test_test_command == 'sanity'
   block:
-    - name: Enable coverage commands for unit tests
+    - name: Install requirements with unit tests
       set_fact:
         ansible_test_options: "--requirements"
 

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -217,7 +217,7 @@
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
-    post-run: playbooks/ansible-test-units-base/post.yaml
+    # post-run: playbooks/ansible-test-units-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.9


### PR DESCRIPTION
This feature depends on the coverage module that may not be available.
As far as I know, nobody really actually care about the coverage report
anyway.
