### PR TITLE
ansible-test-splitter: reduce the targets_per_slot to 10

### DIFF
--- a/roles/ansible-test-splitter/files/list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/list_changed_targets.py
@@ -334,7 +334,7 @@ class ElGrandeSeparator:
     def __init__(self, collections, total_jobs=13, ansible_releases=[]):
         self.collections = collections
         self.total_jobs = total_jobs  # aka slot
-        self.targets_per_slot = 20
+        self.targets_per_slot = 10
         self.releases = ansible_releases
 
         total_targets = sum([len(c._my_test_plan) for c in self.collections])


### PR DESCRIPTION
20 is a bit ambitious and leads to TIMED_OUT sometimes.
See: https://ansible.softwarefactory-project.io/zuul/buildset/8cf435c60f854a7a86fe688bd6ac01f6
