### PR TITLE
Add amazon.aws as dependency for unit tests

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -249,7 +249,7 @@
     check:
       jobs: &ansible-collections-amazon-cloud-generator-jobs
         - ansible-tox-linters
-        - ansible-tox-py38
+        - ansible-tox-py38:
             required-projects:
               - name: github.com/ansible-collections/amazon.aws
     gate:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -250,6 +250,8 @@
       jobs: &ansible-collections-amazon-cloud-generator-jobs
         - ansible-tox-linters
         - ansible-tox-py38
+            required-projects:
+              - name: github.com/ansible-collections/amazon.aws
     gate:
       jobs: *ansible-collections-amazon-cloud-generator-jobs
 


### PR DESCRIPTION
The code being unit tested for the amazon_cloud_code_generator imports from amazon.aws.