### PR TITLE
ios: avoid an interference caused by local ssh keys

### DIFF
--- a/playbooks/ansible-network-ios-appliance/pre.yaml
+++ b/playbooks/ansible-network-ios-appliance/pre.yaml
@@ -18,6 +18,12 @@
         dest: ~/.ssh/config
         mode: "0600"
 
+    # NOTE: hack to ensure Paramiko won't try to do a key based auth
+    # before using the login/pw
+    - name: Remove the local SSH keys
+      shell: |
+        rm ~/.ssh/id_*
+
     - name: Ensure tox
       include_role:
         name: ensure-tox


### PR DESCRIPTION
This is an attempt to avoid errors like this one:
^
~~~
ansible.module_utils.connection.ConnectionError: No existing session
fatal: [ios]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/home/runner/.ansible/tmp/ansible-local-24crojkc0b/ansible-tmp-1648665643.5571449-91-59187499776078/AnsiballZ_cli_config.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/home/runner/.ansible/tmp/ansible-local-24crojkc0b/ansible-tmp-1648665643.5571449-91-59187499776078/AnsiballZ_cli_config.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/runner/.ansible/tmp/ansible-local-24crojkc0b/ansible-tmp-1648665643.5571449-91-59187499776078/AnsiballZ_cli_config.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.ansible.netcommon.plugins.modules.cli_config', init_globals=dict(_module_fqn='ansible_collections.ansible.netcommon.plugins.modules.cli_config', _modlib_path=modlib_path),\n  File \"/usr/lib64/python3.8/runpy.py\", line 207, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.8/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib64/python3.8/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_ansible.netcommon.cli_config_payload_t48hccde/ansible_ansible.netcommon.cli_config_payload.zip/ansible_collections/ansible/netcommon/plugins/modules/cli_config.py\", line 473, in <module>\n  File \"/tmp/ansible_ansible.netcommon.cli_config_payload_t48hccde/ansible_ansible.netcommon.cli_config_payload.zip/ansible_collections/ansible/netcommon/plugins/modules/cli_config.py\", line 426, in main\n  File \"/tmp/ansible_ansible.netcommon.cli_config_payload_t48hccde/ansible_ansible.netcommon.cli_config_payload.zip/ansible/module_utils/connection.py\", line 200, in __rpc__\nansible.module_utils.connection.ConnectionError: No existing session\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
~~~
