### PR TITLE
arista.eos/stable-2.11: define python_interpreter

### DIFF
--- a/zuul.d/arista-eos-jobs.yaml
+++ b/zuul.d/arista-eos-jobs.yaml
@@ -134,6 +134,7 @@
     name: ansible-ee-integration-arista-eos-libssh-stable-2.11
     parent: ansible-ee-integration-arista-eos-httpapi-latest
     vars:
+      test_ansible_python_interpreter: /usr/bin/python3.8
       ansible_runner_container_version: stable-2.11-devel
       test_ansible_network_cli_ssh_type: libssh
       test_fips_mode: true


### PR DESCRIPTION
With Ansible 2.9 and 2.11, we need to set manually set
`test_ansible_python_interpreter` to `/usr/bin/python3.8`.
