### PR TITLE
Netcommon integration tests reference nxos modules

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1139,6 +1139,7 @@
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/cisco.iosxr
+              - name: github.com/ansible-collections/cisco.nxos
               - name: github.com/ansible-collections/junipernetworks.junos
     gate:
       queue: integrated


### PR DESCRIPTION
Even when skipped, it looks like those tasks are read and raise an error if the module is missing.

See https://990daad537a7f173d2de-e48c3b824b43194948ea6b5964ea3d5e.ssl.cf5.rackcdn.com/390/b6b3f4fe2577c1b218f826dc70c39cde840844d0/check/ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python38/cbf51f6/job-output.txt, search for `nxos_feature`