### PR TITLE
[WIP] community.vmware: Drop unit tests for Python < 3.8

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -625,9 +625,6 @@
         - ansible-test-sanity-docker-milestone
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
-        - ansible-test-units-community-vmware-python27
-        - ansible-test-units-community-vmware-python36
-        - ansible-test-units-community-vmware-python37
         - ansible-test-units-community-vmware-python38
         - ansible-test-cloud-integration-vcenter7_only-python36-stable211
         - ansible-test-cloud-integration-vcenter7_2esxi-python36-stable211
@@ -641,9 +638,6 @@
         - ansible-test-sanity-docker-milestone
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
-        - ansible-test-units-community-vmware-python27
-        - ansible-test-units-community-vmware-python36
-        - ansible-test-units-community-vmware-python37
         - ansible-test-units-community-vmware-python38
         - ansible-test-cloud-integration-govcsim-python38_1_of_3
         - ansible-test-cloud-integration-govcsim-python38_2_of_3


### PR DESCRIPTION
The CI runs in [community.vmware](https://github.com/ansible-collections/community.vmware) fail at the moment (see ansible-collections/community.vmware#1280 as an example). I'm not 100% sure but I think that the tests use the `devel`, `milestone` or `stable-2.13` branch for this tests and they don't support Python < 3.8 anymore.

I don't know how to fix this so I'll try to remove the tests in order to merge some PRs. I think this is a risk we could accept since a) Python < 3.8 is quite old and b) if the unit tests run on Python 3.8 succeed, the code is also OK for older versions.

cc @goneri 