### PR TITLE
ansible-2.11 to run the unittests when pyver<3.8

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -234,6 +234,9 @@
     parent: ansible-test-units-base
     nodeset: controller-node
     abstract: true
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
     vars:
       ansible_test_python: 2.7
 
@@ -242,6 +245,9 @@
     parent: ansible-test-units-base
     nodeset: controller-node
     abstract: true
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
     vars:
       ansible_test_python: 3.5
 
@@ -250,6 +256,9 @@
     parent: ansible-test-units-base
     nodeset: controller-node
     abstract: true
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
     vars:
       ansible_test_python: 3.6
 
@@ -258,6 +267,9 @@
     parent: ansible-test-units-base
     nodeset: controller-node
     abstract: true
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
     vars:
       ansible_test_python: 3.7
 


### PR DESCRIPTION
Ansible devel, milestone and stable-2.13 only support Python 3.8+.

See: https://github.com/ansible/ansible-zuul-jobs/pull/1477
