### PR TITLE
Add 2.13 sanity test for community.okd

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -516,6 +516,13 @@
       - name: github.com/ansible/ansible
         override-checkout: stable-2.12
 
+- job:
+    name: ansible-test-sanity-okd-downstream-stable-2.13
+    parent: ansible-test-sanity-okd-downstream
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.13
+
 ### Kubernetes Core
 - job:
     name: ansible-test-units-kubernetes-core-python38

--- a/zuul.d/ansible-test-jobs.yaml
+++ b/zuul.d/ansible-test-jobs.yaml
@@ -70,3 +70,10 @@
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.12
+
+- job:
+    name: ansible-test-sanity-docker-stable-2.13
+    parent: ansible-test-sanity-docker
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.13

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -578,6 +578,7 @@
         - ansible-test-sanity-okd-downstream-milestone
         - ansible-test-sanity-okd-downstream-stable-2.11
         - ansible-test-sanity-okd-downstream-stable-2.12
+        - ansible-test-sanity-okd-downstream-stable-2.13
 
 - project-template:
     name: ansible-collections-cloud-common

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -570,6 +570,7 @@
         - ansible-test-sanity-docker-milestone
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
+        - ansible-test-sanity-docker-stable-2.13
         - ansible-galaxy-importer:
             voting: false
         - ansible-test-units-community-okd-python38


### PR DESCRIPTION
This adds a 2.13 sanity test job for the community.okd collection. It also adds the new 2.13 sanity test job as mentioned in https://github.com/ansible-collections/news-for-maintainers/issues/14.

Partially addresses https://github.com/openshift/community.okd/issues/146.