### PR TITLE
downstream-ee testing for amazon.aws and vmware.vmware_rest

### DIFF
--- a/playbooks/downstream-ee-testing/aws/pre.yaml
+++ b/playbooks/downstream-ee-testing/aws/pre.yaml
@@ -1,0 +1,15 @@
+---
+- hosts: controller
+  gather_facts: false
+  tasks:
+    - name: Fetch the aws_session file from the controller
+      fetch:
+        flat: true
+        src: /tmp/aws_session.json
+        dest: '{{ zuul.executor.work_root }}/'
+    - set_fact:
+        aws_session: "{{ lookup('file','{{ zuul.executor.work_root }}/aws_session.json') | from_json }}"
+    - name: Prepare the site.yaml file
+      template:
+        src: "site.yaml.j2"
+        dest: "{{ zuul.projects[ansible_collections_repo].src_dir }}/tests/integration/targets/site.yaml"

--- a/playbooks/downstream-ee-testing/aws/run.yaml
+++ b/playbooks/downstream-ee-testing/aws/run.yaml
@@ -1,0 +1,7 @@
+---
+- hosts: controller
+  gather_facts: false
+  tasks:
+    - command: "ansible-navigator run --eei brew.registry.redhat.io/{{ downstream_ee_image }} site.yaml --mode=stdout --pull-policy=never"
+      args:
+        chdir: "~/{{ zuul.projects[ansible_collections_repo].src_dir }}/tests/integration/targets"

--- a/playbooks/downstream-ee-testing/aws/site.yaml.j2
+++ b/playbooks/downstream-ee-testing/aws/site.yaml.j2
@@ -1,0 +1,42 @@
+---
+- hosts: localhost
+  gather_facts: false
+  vars:
+    integration_tests_path: "~/{{ zuul.projects[ansible_collections_repo].src_dir }}/tests/integration/targets"
+    integration_target_failures: []
+    aws_access_key: "{{ aws_session.aws.credentials.access_key }}"
+    aws_secret_key: "{{ aws_session.aws.credentials.secret_key }}"
+    security_token: "{{ aws_session.aws.credentials.session_token }}"
+    aws_region: us-east-1
+    resource_prefix: "{{ zuul.build }}"
+    downstream_ee_testing_targets: "{{ downstream_ee_testing_targets }}"
+{% raw %}
+  tasks:
+    - when: not downstream_ee_testing_targets|length
+      block:
+        - name: Find integration test targets
+          find:
+            file_type: directory
+            paths: "{{ integration_tests_path | expanduser }}"
+            recurse: false
+          register: _targets
+
+        - name: Format integration targets
+          set_fact:
+            downstream_ee_testing_targets: "{{ _targets.files | map(attribute='path') | list | sort }}"
+
+    - name: Report missing integration targets
+      fail:
+        msg: "No integration targets found"
+      when: downstream_ee_testing_targets|length == 0
+
+    - name: Test targets to run
+      debug:
+        msg: "{{ downstream_ee_testing_targets }}"
+
+    - name: Run integration tests
+      include_tasks:
+        file: include_role.yaml
+      with_items:
+        - "{{ downstream_ee_testing_targets }}"
+{% endraw %}

--- a/playbooks/downstream-ee-testing/files/include_role.yaml
+++ b/playbooks/downstream-ee-testing/files/include_role.yaml
@@ -1,0 +1,13 @@
+---
+- name: Run target role
+  include_role:
+    name: "{{ item }}"
+
+- name: Clear gathered facts
+  ansible.builtin.meta: clear_facts
+
+- name: Reset SSH connections
+  ansible.builtin.meta: reset_connection
+
+- name: Force meta handlers to run
+  ansible.builtin.meta: flush_handlers

--- a/playbooks/downstream-ee-testing/pre.yaml
+++ b/playbooks/downstream-ee-testing/pre.yaml
@@ -1,0 +1,16 @@
+---
+- hosts: controller
+  gather_facts: false
+  tasks:
+    - name: Install pip
+      package:
+        name: python3-pip
+        state: present
+      become: true
+    - name: Pull the image
+      command: "podman pull brew.registry.redhat.io/{{ downstream_ee_image }}"
+    - command: pip3 install --user ansible-navigator
+    - name: Copy the include_role.yaml file
+      copy:
+        src: files/include_role.yaml
+        dest: "{{ zuul.projects[ansible_collections_repo].src_dir }}/tests/integration/targets/include_role.yaml"

--- a/playbooks/downstream-ee-testing/vmware_rest/pre.yaml
+++ b/playbooks/downstream-ee-testing/vmware_rest/pre.yaml
@@ -1,0 +1,23 @@
+---
+- hosts: controller
+  tasks:
+    - name: Create inventory file
+      import_role:
+        name: ansible-test-inventory
+      vars:
+        ansible_test_inventory_os: vmware_rest
+        ansible_test_inventory_dest: ~/inventory
+        vmware_ci_set_passwords_secret_dir: '{{ zuul.executor.work_root }}'
+    - name: Install ansible and deps to be able to prepare the env
+      package:
+        name:
+          - ansible
+          - python3-aiohttp
+          - python3-pyvmomi
+        state: present
+      become: true
+    - name: Install community.vmware and vmware.vmware_rest form Galaxy
+      command: "ansible-galaxy collection install {{ item }}"
+      with_items:
+        - community.vmware
+        - vmware.vmware_rest

--- a/playbooks/downstream-ee-testing/vmware_rest/run.yaml
+++ b/playbooks/downstream-ee-testing/vmware_rest/run.yaml
@@ -1,0 +1,11 @@
+---
+- hosts: controller
+  gather_facts: false
+  tasks:
+    - shell: |
+        export INVENTORY_PATH=/home/zuul/inventory
+        source ~/{{ zuul.projects[ansible_collections_repo].src_dir }}/tests/integration/targets/init.sh
+        ansible-playbook {{ downstream_ee_testing_targets[0] }}/prepare.yaml
+        ansible-navigator run --eei brew.registry.redhat.io/{{ downstream_ee_image }} {{ downstream_ee_testing_targets[0] }}/run.yaml --mode=stdout --pull-policy=never --pass-environment-variable VMWARE_HOST --pass-environment-variable VMWARE_USER --pass-environment-variable VMWARE_PASSWORD --pass-environment-variable ESXI1_HOSTNAME --pass-environment-variable ESXI1_USERNAME --pass-environment-variable ESXI1_PASSWORD --pass-environment-variable VMWARE_VALIDATE_CERTS
+      args:
+        chdir: "~/{{ zuul.projects[ansible_collections_repo].src_dir }}/tests/integration/targets"

--- a/zuul.d/downstream-ee-amazon-aws.yaml
+++ b/zuul.d/downstream-ee-amazon-aws.yaml
@@ -1,0 +1,97 @@
+---
+- job:
+    name: downstream-ee-amazon-aws
+    parent: downstream-ee-integration
+    pre-run:
+      - playbooks/downstream-ee-testing/pre.yaml
+      - playbooks/downstream-ee-testing/aws/pre.yaml
+    run: playbooks/downstream-ee-testing/aws/run.yaml
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: milestone
+      - name: github.com/ansible-collections/amazon.aws
+    timeout: 3600
+    nodeset: rhel8
+    vars:
+      downstream_ee_image: rh-osbs/ansible-automation-platform-22-ee-supported-rhel8:latest
+      ansible_collections_repo: "github.com/ansible-collections/amazon.aws"
+      downstream_ee_testing_targets:
+        - "{{ zuul.job.split('-')[-1] }}"
+    semaphore: ansible-test-cloud-integration-aws
+
+- job:
+    name: downstream-ee-amazon-aws-aws_az_info
+    parent: downstream-ee-amazon-aws
+
+- job:
+    name: downstream-ee-amazon-aws-aws_caller_info
+    parent: downstream-ee-amazon-aws
+- job:
+    name: downstream-ee-amazon-aws-aws_s3
+    parent: downstream-ee-amazon-aws
+- job:
+    name: downstream-ee-amazon-aws-cloudformation
+    parent: downstream-ee-amazon-aws
+- job:
+    name: downstream-ee-amazon-aws-ec2_ami
+    parent: downstream-ee-amazon-aws
+- job:
+    name: downstream-ee-amazon-aws-ec2_eni
+    parent: downstream-ee-amazon-aws
+- job:
+    name: downstream-ee-amazon-aws-ec2_instance
+    parent: downstream-ee-amazon-aws
+- job:
+    name: downstream-ee-amazon-aws-ec2_key
+    parent: downstream-ee-amazon-aws
+- job:
+    name: downstream-ee-amazon-aws-ec2_spot_instance
+    parent: downstream-ee-amazon-aws
+- job:
+    name: downstream-ee-amazon-aws-ec2_tag
+    parent: downstream-ee-amazon-aws
+- job:
+    name: downstream-ee-amazon-aws-ec2_vol
+    parent: downstream-ee-amazon-aws
+- job:
+    name: downstream-ee-amazon-aws-ec2_vpc_dhcp_option
+    parent: downstream-ee-amazon-aws
+- job:
+    name: downstream-ee-amazon-aws-ec2_vpc_endpoint_service_info
+    parent: downstream-ee-amazon-aws
+- job:
+    name: downstream-ee-amazon-aws-ec2_vpc_igw
+    parent: downstream-ee-amazon-aws
+- job:
+    name: downstream-ee-amazon-aws-ec2_vpc_nat_gateway
+    parent: downstream-ee-amazon-aws
+- job:
+    name: downstream-ee-amazon-aws-ec2_vpc_net
+    parent: downstream-ee-amazon-aws
+- job:
+    name: downstream-ee-amazon-aws-ec2_vpc_route_table
+    parent: downstream-ee-amazon-aws
+- job:
+    name: downstream-ee-amazon-aws-ec2_vpc_subnet
+    parent: downstream-ee-amazon-aws
+- job:
+    name: downstream-ee-amazon-aws-elb_classic_lb
+    parent: downstream-ee-amazon-aws
+- job:
+    name: downstream-ee-amazon-aws-inventory_aws_ec2
+    parent: downstream-ee-amazon-aws
+- job:
+    parent: downstream-ee-amazon-aws
+    name: downstream-ee-amazon-aws-lookup_aws_secret
+- job:
+    parent: downstream-ee-amazon-aws
+    name: downstream-ee-amazon-aws-lookup_aws_service_ip_ranges
+- job:
+    parent: downstream-ee-amazon-aws
+    name: downstream-ee-amazon-aws-module_utils_core
+- job:
+    parent: downstream-ee-amazon-aws
+    name: downstream-ee-amazon-aws-module_utils_waiter
+- job:
+    parent: downstream-ee-amazon-aws
+    name: downstream-ee-amazon-aws-s3_bucket

--- a/zuul.d/downstream-ee-vmware-vmware_rest.yaml
+++ b/zuul.d/downstream-ee-vmware-vmware_rest.yaml
@@ -1,0 +1,33 @@
+---
+- job:
+    name: downstream-ee-vmware-vmware_rest
+    parent: downstream-ee-integration
+    pre-run:
+      - playbooks/downstream-ee-testing/pre.yaml
+      # NOTE: this one pulls the bindep which are actually not
+      # required
+      - playbooks/ansible-network-appliance-base/pre.yaml
+      - playbooks/ansible-cloud/vcenter-appliance/pre.yaml
+      - playbooks/downstream-ee-testing/vmware_rest/pre.yaml
+    run: playbooks/downstream-ee-testing/vmware_rest/run.yaml
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: milestone
+      - name: github.com/ansible-collections/vmware.vmware_rest
+    timeout: 3600
+    nodeset: vmware-vcsa_1esxi-7.0.3-rhel
+    vars:
+      downstream_ee_image: rh-osbs/ansible-automation-platform-22-ee-supported-rhel8:latest
+      ansible_collections_repo: "github.com/ansible-collections/vmware.vmware_rest"
+      downstream_ee_testing_targets:
+        - "{{ zuul.job.split('-')[-1] }}"
+    host-vars:
+      vcenter:
+        ansible_network_os: vmware_rest
+      esxi1:
+        ansible_network_os: vmware_rest
+    semaphore: ansible-test-cloud-integration-vmware-rest
+
+- job:
+    name: downstream-ee-vmware-vmware_rest-vcenter_vm_scenario1
+    parent: downstream-ee-vmware-vmware_rest

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -306,6 +306,26 @@
           - esxi2
 
 - nodeset:
+    name: vmware-vcsa_1esxi-7.0.3-rhel
+    nodes:
+      - name: controller
+        label: ansible-rhel-8.5
+      - name: vcenter
+        label: ansible-vmware-vcsa-7.0.3
+      - name: esxi1
+        label: ansible-esxi-7.0.3
+    groups:
+      - name: appliance-ssh
+        nodes:
+          - vcenter
+      - name: appliance
+        nodes:
+          - esxi1
+      - name: esxis
+        nodes:
+          - esxi1
+
+- nodeset:
     name: controller-python27
     nodes:
       - name: controller

--- a/zuul.d/project.yaml
+++ b/zuul.d/project.yaml
@@ -21,3 +21,31 @@
         - ansible-tox-py39:
             vars:
               tox_envlist: pytest,black
+    periodic:
+      jobs:
+        - downstream-ee-amazon-aws-aws_az_info
+        - downstream-ee-amazon-aws-aws_caller_info
+        - downstream-ee-amazon-aws-aws_s3
+        - downstream-ee-amazon-aws-cloudformation
+        - downstream-ee-amazon-aws-ec2_ami
+        - downstream-ee-amazon-aws-ec2_eni
+        - downstream-ee-amazon-aws-ec2_instance
+        - downstream-ee-amazon-aws-ec2_key
+        - downstream-ee-amazon-aws-ec2_spot_instance
+        - downstream-ee-amazon-aws-ec2_tag
+        - downstream-ee-amazon-aws-ec2_vol
+        - downstream-ee-amazon-aws-ec2_vpc_dhcp_option
+        - downstream-ee-amazon-aws-ec2_vpc_endpoint_service_info
+        - downstream-ee-amazon-aws-ec2_vpc_igw
+        - downstream-ee-amazon-aws-ec2_vpc_nat_gateway
+        - downstream-ee-amazon-aws-ec2_vpc_net
+        - downstream-ee-amazon-aws-ec2_vpc_route_table
+        - downstream-ee-amazon-aws-ec2_vpc_subnet
+        - downstream-ee-amazon-aws-elb_classic_lb
+        - downstream-ee-amazon-aws-inventory_aws_ec2
+        - downstream-ee-amazon-aws-lookup_aws_secret
+        - downstream-ee-amazon-aws-lookup_aws_service_ip_ranges
+        - downstream-ee-amazon-aws-module_utils_core
+        - downstream-ee-amazon-aws-module_utils_waiter
+        - downstream-ee-amazon-aws-s3_bucket
+        - downstream-ee-vmware-vmware_rest-vcenter_vm_scenario1


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware.vmware_rest/pull/318

New set of periodical jobs that run the last snapshot of the Downstream-EE
image against amazon.aws and vmware.vmware_rest.