### PR TITLE
Set ansible-ee-tests-stable-2.9 as non-voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1409,12 +1409,11 @@
       a clean and up to date EE container.
     check:
       jobs: &ansible-ee-test-jobs
-        - ansible-ee-tests-latest:
-            voting: false
+        - ansible-ee-tests-latest
         - ansible-ee-tests-stable-2.9
-        - ansible-ee-tests-stable-2.11
-        - ansible-ee-tests-stable-2.12:
             voting: false
+        - ansible-ee-tests-stable-2.11
+        - ansible-ee-tests-stable-2.12
     gate:
       jobs: *ansible-ee-test-jobs
 


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

ansible-ee-tests-stable-2.9 fails because of rstcheck version 5.0.0. Until this issue is fixed, this job will remain non-voting.

This PR also sets other ansible-ee-tests job , back to voting.