### PR TITLE
Make nxos integration tests non-voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -377,6 +377,7 @@
         - ansible-ee-integration-cisco-nxos-cli-python39-latest:
             vars:
               ansible_test_collections: true
+            voting: false
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

Make nxos integration tests non-voting until we revert to ansible-test-* and split the job.