### PR TITLE
Revert "ansible-test-sanity-* don't pin on py38 (#1509)"

### DIFF
--- a/zuul.d/ansible-test-jobs.yaml
+++ b/zuul.d/ansible-test-jobs.yaml
@@ -20,6 +20,7 @@
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
       ansible_test_command: sanity
       ansible_test_docker: true
+      ansible_test_python: 3.8
       container_command: podman
 
 - job:


### PR DESCRIPTION
We actually need the variable to install the right Python version:

```
The task includes an option with an undefined variable. The error was: {{ ansible_test_python }}: 'ansible_test_python' is undefined

The error appears to be in '/var/lib/zuul/builds/fef885f591624e1ea6513aeb20b8c87f/untrusted/project_2/github.com/ansible/ansible-zuul-jobs/roles/our-ensure-python/tasks/main.yaml': line 2, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

---
- name: Install the right Python version (rpm)
  ^ here
```

See: https://github.com/ansible-collections/community.vmware/pull/1294

This reverts commit 4900aae80299ce70c321e9f9873fd5b2a0b4fa68.
