### PR TITLE
downstream-ee-testing: use a different loop_control var name

### DIFF
--- a/playbooks/downstream-ee-testing/aws/site.yaml.j2
+++ b/playbooks/downstream-ee-testing/aws/site.yaml.j2
@@ -38,6 +38,7 @@
     - name: Run integration tests
       include_tasks:
         file: include_role.yaml
-      with_items:
-        - "{{ downstream_ee_testing_targets }}"
+      loop: "{{ downstream_ee_testing_targets }}"
+      loop_control:
+        loop_var: current_target
 {% endraw %}

--- a/playbooks/downstream-ee-testing/files/include_role.yaml
+++ b/playbooks/downstream-ee-testing/files/include_role.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Run target role
   include_role:
-    name: "{{ item }}"
+    name: "{{ current_target }}"
 
 - name: Clear gathered facts
   ansible.builtin.meta: clear_facts


### PR DESCRIPTION
This to avoid name clash with any existing loop.
