### PR TITLE
Remove pinned k8s.core version for okd

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -573,7 +573,6 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/kubernetes.core
-                override-checkout: stable-2.2
         - ansible-test-sanity-docker-devel
         - ansible-test-sanity-docker-milestone
         - ansible-test-sanity-docker-stable-2.9


### PR DESCRIPTION
I don't remember why this was here, and I think we should probably just
remove it. My guess is this may be the reason why our sanity tests have
been intermittently failing, lately.