### PR TITLE
drop the ansible_test_collections variable

### DIFF
--- a/playbooks/ansible-cloud/okd/sanity.yaml
+++ b/playbooks/ansible-cloud/okd/sanity.yaml
@@ -14,6 +14,4 @@
         name: ansible-test
       vars:
         ansible_test_test_command: "{{ ansible_test_command }}"
-        ansible_test_collection_namespace: "redhat"
-        ansible_test_collection_name: "openshift"
         ansible_test_venv_path: "~/venv"

--- a/playbooks/ansible-test-base/pre.yaml
+++ b/playbooks/ansible-test-base/pre.yaml
@@ -74,5 +74,4 @@
       import_role:
         name: deploy-artifacts
       when:
-        - ansible_test_collections | default(False)
         - "'network-integration' not in ansible_test_command"

--- a/playbooks/ansible-test-base/run.yaml
+++ b/playbooks/ansible-test-base/run.yaml
@@ -1,17 +1,15 @@
 ---
 - hosts: controller
   tasks:
-    - when: ansible_test_collections | default(False)
-      block:
-        - name: Copy the galaxy.yml on the controller
-          fetch:
-            src: "{{ ansible_test_location }}/galaxy.yml"
-            dest: '{{ zuul.executor.work_root }}/tmp_fetch'
-          register: _fetch
-        - name: Load information from galaxy.yml
-          include_vars:
-            file: '{{ _fetch.dest }}'
-            name: galaxy_info
+    - name: Copy the galaxy.yml on the controller
+      fetch:
+        src: "{{ ansible_test_location }}/galaxy.yml"
+        dest: '{{ zuul.executor.work_root }}/tmp_fetch'
+      register: _fetch
+    - name: Load information from galaxy.yml
+      include_vars:
+        file: '{{ _fetch.dest }}'
+        name: galaxy_info
 
     - name: Enable FIPS mode
       when:
@@ -30,5 +28,3 @@
         ansible_test_location: "{{ ansible_user_dir }}/{{ zuul.projects[ansible_collections_repo].src_dir }}"
         ansible_test_git_branch: "{{ zuul.projects['github.com/ansible/ansible'].checkout }}"
         ansible_test_ansible_path: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
-        ansible_test_collection_namespace: "{{ ansible_test_collections|ternary(galaxy_info.namespace, '') }}"
-        ansible_test_collection_name: "{{ ansible_test_collections|ternary(galaxy_info.name, '') }}"

--- a/playbooks/ansible-test-network-integration-base/pre.yaml
+++ b/playbooks/ansible-test-network-integration-base/pre.yaml
@@ -36,9 +36,3 @@
         ansible_test_inventory_os: "{{ _network_os }}"
         ansible_test_inventory_dest: ~/inventory
         vmware_ci_set_passwords_secret_dir: '{{ zuul.executor.work_root }}'
-
-    - name: Fetch and install the artifacts
-      import_role:
-        name: deploy-artifacts
-      when:
-        - ansible_test_collections | default(False)

--- a/playbooks/ansible-test-network-integration-base/templates/inventory-asa.j2
+++ b/playbooks/ansible-test-network-integration-base/templates/inventory-asa.j2
@@ -6,10 +6,10 @@ asav9-12-3 ansible_port=22 ansible_host={{ hostvars['asav9-12-3'].ansible_host }
 
 [asa:vars]
 ansible_become=true
-ansible_become_method={% if ansible_test_collections is defined -%}ansible.netcommon.{%- endif %}enable
+ansible_become_method=ansible.netcommon.enable
 ansible_become_pass=cisco
-ansible_connection={% if ansible_test_collections is defined -%}ansible.netcommon.{%- endif %}network_cli
-ansible_network_os={% if ansible_test_collections is defined -%}cisco.asa.{%- endif %}asa
+ansible_connection=ansible.netcommon.network_cli
+ansible_network_os=cisco.asa.asa
 ansible_python_interpreter=python
 
 cli={'authorize': true}

--- a/roles/ansible-test-inventory/templates/inventory-eos.j2
+++ b/roles/ansible-test-inventory/templates/inventory-eos.j2
@@ -5,10 +5,10 @@
 eos-4.24.6 ansible_port=22 ansible_host={{ hostvars['eos-4.24.6'].ansible_host }} ansible_user=zuul
 
 [eos:vars]
-ansible_become_method={% if ansible_test_collections is defined -%}ansible.netcommon.{%- endif %}enable
-ansible_connection={% if ansible_test_collections is defined -%}ansible.netcommon.{%- endif %}network_cli
+ansible_become_method=ansible.netcommon.enable
+ansible_connection=ansible.netcommon.network_cli
 ansible_httpapi_pass=superSecretPass
-ansible_network_os={% if ansible_test_collections is defined -%}arista.eos.{%- endif %}eos
+ansible_network_os=arista.eos.eos
 ansible_python_interpreter=python
 
 debug=False

--- a/roles/ansible-test-inventory/templates/inventory-iosxr.j2
+++ b/roles/ansible-test-inventory/templates/inventory-iosxr.j2
@@ -9,8 +9,8 @@ iosxr
 
 [iosxr:vars]
 ansible_become=true
-ansible_become_method={% if ansible_test_collections is defined -%}ansible.netcommon.{%- endif %}enable
-ansible_network_os={% if ansible_test_collections is defined -%}cisco.iosxr.{%- endif %}iosxr
+ansible_become_method=ansible.netcommon.enable
+ansible_network_os=cisco.iosxr.iosxr
 ansible_python_interpreter=/home/zuul/venv/bin/python
 ansible_ssh_private_key_file=/home/zuul/.ssh/id_rsa
 cli={'transport': 'cli'}
@@ -22,8 +22,8 @@ iosxr-7.0.2 ansible_port=22 ansible_host={{ hostvars['iosxr-7.0.2'].nodepool.pri
 
 [netconf:vars]
 ansible_become=true
-ansible_become_method={% if ansible_test_collections is defined -%}ansible.netcommon.{%- endif %}enable
-ansible_network_os={% if ansible_test_collections is defined -%}cisco.iosxr.{%- endif %}iosxr
+ansible_become_method=ansible.netcommon.enable
+ansible_network_os=cisco.iosxr.iosxr
 ansible_python_interpreter=/home/zuul/venv/bin/python
 ansible_ssh_private_key_file=/home/zuul/.ssh/id_rsa
 cli={'transport': 'cli'}

--- a/roles/ansible-test-inventory/templates/inventory-junos.j2
+++ b/roles/ansible-test-inventory/templates/inventory-junos.j2
@@ -8,7 +8,7 @@ vsrx3 ansible_host={{ hostvars['vsrx3'].ansible_host }} ansible_user=zuul
 junos
 
 [junos:vars]
-ansible_network_os={% if ansible_test_collections is defined -%}junipernetworks.junos.{%- endif %}junos
+ansible_network_os=junipernetworks.junos.junos
 ansible_python_interpreter=/home/zuul/venv/bin/python
 netconf={'transport': 'netconf'}
 
@@ -16,6 +16,6 @@ netconf={'transport': 'netconf'}
 vsrx3 ansible_host={{ hostvars['vsrx3'].ansible_host }} ansible_user=zuul
 
 [netconf:vars]
-ansible_network_os={% if ansible_test_collections is defined -%}junipernetworks.junos.{%- endif %}junos
+ansible_network_os=junipernetworks.junos.junos
 ansible_python_interpreter=/home/zuul/venv/bin/python
 netconf={'transport': 'netconf'}

--- a/roles/ansible-test-inventory/templates/inventory-vyos.j2
+++ b/roles/ansible-test-inventory/templates/inventory-vyos.j2
@@ -5,6 +5,6 @@
 vyos-1.1.8 ansible_port=22 ansible_host={{ hostvars['vyos-1.1.8'].ansible_host }} ansible_user=zuul
 
 [vyos:vars]
-ansible_connection={% if ansible_test_collections is defined -%}ansible.netcommon.{%- endif %}network_cli
-ansible_network_os={% if ansible_test_collections is defined -%}vyos.vyos.{%- endif %}vyos
+ansible_connection=ansible.netcommon.network_cli
+ansible_network_os=vyos.vyos.vyos
 ansible_python_interpreter=/home/zuul/venv/bin/python

--- a/roles/ansible-test/defaults/main.yaml
+++ b/roles/ansible-test/defaults/main.yaml
@@ -1,9 +1,4 @@
 ---
-ansible_test_collections: false
-# Need to be defined of ansible_test_collections is true
-ansible_test_collection_namespace: ''
-# Need to be defined of ansible_test_collections is true
-ansible_test_collection_name: ''
 ansible_test_integration_targets: ''
 ansible_test_test_command: 'integration'
 ansible_test_continue_on_error: true

--- a/roles/ansible-test/molecule/default/converge.yml
+++ b/roles/ansible-test/molecule/default/converge.yml
@@ -7,8 +7,5 @@
       include_role:
         name: ansible-test
       vars:
-        ansible_test_collections: true
         ansible_test_test_command: sanity
-        ansible_test_collection_namespace: foo
-        ansible_test_collection_name: bar
         ansible_test_executable: /root/fake-ansible-test

--- a/roles/ansible-test/molecule/sanity-full/converge.yml
+++ b/roles/ansible-test/molecule/sanity-full/converge.yml
@@ -7,10 +7,7 @@
       include_role:
         name: ansible-test
       vars:
-        ansible_test_collections: true
         ansible_test_test_command: sanity
-        ansible_test_collection_namespace: foo
-        ansible_test_collection_name: bar
         ansible_test_executable: /root/fake-ansible-test
         ansible_test_sanity_skiptests:
           - skip_1

--- a/roles/ansible-test/tasks/init_collection.yaml
+++ b/roles/ansible-test/tasks/init_collection.yaml
@@ -1,8 +1,18 @@
 ---
+- name: Copy the galaxy.yml on the controller
+  fetch:
+    src: "{{ ansible_test_location }}/galaxy.yml"
+    dest: '{{ zuul.executor.work_root }}/tmp_fetch'
+  register: _fetch
+- name: Load information from galaxy.yml
+  include_vars:
+    file: '{{ _fetch.dest }}'
+    name: galaxy_info
+
 - name: Setup location of project for integration tests
   set_fact:
-    _test_location: "{{ ansible_test_collection_dir }}/{{ ansible_test_collection_namespace }}/{{ ansible_test_collection_name }}"
-    _test_cfg_location: "{{ ansible_test_collection_dir }}/{{ ansible_test_collection_namespace }}/{{ ansible_test_collection_name }}/tests/integration/{{ ansible_test_test_command }}.cfg"
+    _test_location: "{{ ansible_test_collection_dir }}/{{ galaxy_info.namespace }}/{{ galaxy_info.name }}"
+    _test_cfg_location: "{{ ansible_test_collection_dir }}/{{ galaxy_info.namespace }}/{{ galaxy_info.name }}/tests/integration/{{ ansible_test_test_command }}.cfg"
 
 - name: Setup minimum test requirements
   set_fact:

--- a/roles/ansible-test/tasks/init_test_options.yaml
+++ b/roles/ansible-test/tasks/init_test_options.yaml
@@ -23,7 +23,6 @@
   set_fact:
     ansible_test_options: "{{ ansible_test_options }} --requirements"
   when:
-    - not ansible_test_collections
     - not ansible_test_docker
 
 - name: Adjust options for unit tests

--- a/roles/ansible-test/tasks/main.yaml
+++ b/roles/ansible-test/tasks/main.yaml
@@ -8,13 +8,8 @@
 - name: Prepare ansible-test parameters
   import_tasks: init_test_options.yaml
 
-- name: Single ansible mode
-  import_tasks: init_single_mode.yaml
-  when: not ansible_test_collections
-
 - name: Ansible with collections
   import_tasks: init_collection.yaml
-  when: ansible_test_collections
 
 - name: Enable persistent connection logging
   ini_file:

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -41,7 +41,6 @@
         VMWARE_TEST_PLATFORM: static
       ansible_test_continue_on_error: false
       ansible_test_retry_on_error: true
-      ansible_test_collections: true
 
 # vcenter 7.0.3
 - job:
@@ -170,7 +169,6 @@
       ansible_collections_repo: github.com/ansible-collections/vmware.vmware_rest
       ansible_test_command: network-integration
       ansible_test_integration_targets: "zuul/"
-      ansible_test_collections: true
     timeout: 3600
     semaphore: ansible-test-cloud-integration-vmware-rest
 
@@ -254,7 +252,6 @@
       - name: github.com/ansible-collections/community.aws
     timeout: 3600
     vars:
-      ansible_test_collections: true
       ansible_test_command: integration
       ansible_test_python: 3.8
       ansible_test_retry_on_error: true
@@ -390,7 +387,6 @@
       - name: github.com/ansible-collections/amazon.aws
     timeout: 3600
     vars:
-      ansible_test_collections: true
       ansible_test_command: integration
       ansible_test_python: 3.8
       ansible_test_integration_targets: ""
@@ -549,7 +545,6 @@
     timeout: 3600
     nodeset: centos-8-stream-large
     vars:
-      ansible_test_collections: true
       ansible_test_command: integration
       ansible_test_python: 3.8
       ansible_test_retry_on_error: true

--- a/zuul.d/ansible-security-jobs.yaml
+++ b/zuul.d/ansible-security-jobs.yaml
@@ -33,7 +33,6 @@
       ansible_collections_repo: github.com/ansible-collections/splunk.es
       ansible_test_command: network-integration
       ansible_test_integration_targets: "splunk_.*"
-      ansible_test_collections: true
 
 - job:
     name: ansible-security-integration-splunk-es-python36
@@ -94,7 +93,6 @@
       ansible_collections_repo: github.com/ansible-collections/ibm.qradar
       ansible_test_command: network-integration
       ansible_test_integration_targets: "qradar_.*"
-      ansible_test_collections: true
 
 - job:
     name: ansible-test-security-integration-qradar-python36
@@ -155,7 +153,6 @@
       ansible_collections_repo: github.com/ansible-collections/trendmicro.deepsec
       ansible_test_command: network-integration
       ansible_test_integration_targets: "deepsec_.*"
-      ansible_test_collections: true
 
 - job:
     name: ansible-security-integration-trendmicro-deepsec-python36

--- a/zuul.d/ansible-test-jobs.yaml
+++ b/zuul.d/ansible-test-jobs.yaml
@@ -16,7 +16,6 @@
     irrelevant-files:
       - .pre-commit-config.yaml
     vars:
-      ansible_test_collections: true
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
       ansible_test_command: sanity
       ansible_test_docker: true

--- a/zuul.d/cisco-asa-jobs.yaml
+++ b/zuul.d/cisco-asa-jobs.yaml
@@ -33,7 +33,6 @@
     timeout: 9000
     vars:
       ansible_collections_repo: github.com/ansible-collections/cisco.asa
-      ansible_test_collections: true
       ansible_test_command: network-integration
       ansible_test_integration_targets: "asa_.*"
 

--- a/zuul.d/cisco-iosxr-jobs.yaml
+++ b/zuul.d/cisco-iosxr-jobs.yaml
@@ -78,7 +78,6 @@
     parent: ansible-test-network-integration-iosxr
     abstract: true
     vars:
-      ansible_test_collections: true
       ansible_test_skip_tags: local,network_cli
 
 - job:
@@ -86,7 +85,6 @@
     parent: ansible-test-network-integration-iosxr
     abstract: true
     vars:
-      ansible_test_collections: true
       ansible_test_skip_tags: local,netconf
 
 - job:

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -143,7 +143,6 @@
       - playbooks/ansible-test-base/post.yaml
     timeout: 10800
     vars:
-      ansible_test_collections: true
       ansible_test_command: integration
       ansible_test_integration_targets: ""
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
@@ -222,7 +221,6 @@
     irrelevant-files:
       - .pre-commit-config.yaml
     vars:
-      ansible_test_collections: true
       ansible_test_command: units
       ansible_test_integration_targets: ""
       # NOTE(pabelanger): ansible_test_python to be removed

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -378,8 +378,6 @@
     check:
       jobs:
         - ansible-ee-integration-cisco-nxos-cli-python39-latest:
-            vars:
-              ansible_test_collections: true
             voting: false
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
@@ -407,9 +405,7 @@
     name: ansible-community-ansible-plugin-builder
     check:
       jobs:
-        - ansible-test-integration-ansible-plugin-builder:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-integration-ansible-plugin-builder
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.utils
@@ -417,9 +413,7 @@
       queue: integrated
       fail-fast: true
       jobs:
-        - ansible-test-integration-ansible-plugin-builder:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-integration-ansible-plugin-builder
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.utils
@@ -527,8 +521,6 @@
     check:
       jobs:
         - ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python38:
-            vars:
-              ansible_test_collections: true
             voting: false
         - build-ansible-collection:
             required-projects:
@@ -754,61 +746,47 @@
       jobs:
         - ansible-test-network-integration-junos-vsrx-netconf-python36-stable29:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
             voting: false
         - ansible-test-network-integration-junos-vsrx-netconf-python36-stable211:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
             voting: false
         - ansible-test-network-integration-junos-vsrx-netconf-python38-stable212:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-netconf-python38:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-network_cli-python36-stable29:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
             voting: false
         - ansible-test-network-integration-junos-vsrx-network_cli-python36-stable211:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
             voting: false
         - ansible-test-network-integration-junos-vsrx-network_cli-python38-stable212:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-network_cli-python38:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python36-stable29:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
             voting: false
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python36-stable211:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
             voting: false
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python38-stable212:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python38:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-ee-integration-cisco-nxos-cli-python39-latest:
-            vars:
-              ansible_test_collections: true
             voting: false
         - ansible-ee-integration-arista-eos-latest
         - ansible-ee-integration-arista-eos-stable-2.9
@@ -849,34 +827,26 @@
       jobs:
         - ansible-test-network-integration-junos-vsrx-netconf-python36-stable29:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
             voting: false
         - ansible-test-network-integration-junos-vsrx-netconf-python38:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-network_cli-python36-stable29:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
             voting: false
         - ansible-test-network-integration-junos-vsrx-network_cli-python38:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python36-stable29:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
             voting: false
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python38:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-ee-integration-cisco-nxos-cli-python39-latest:
-            vars:
-              ansible_test_collections: true
             voting: false
         - ansible-ee-integration-arista-eos-latest
         - ansible-ee-integration-arista-eos-httpapi-stable-2.9:
@@ -906,59 +876,45 @@
       jobs: &ansible-collections-juniper-junos-jobs
         - ansible-test-network-integration-junos-vsrx-netconf-python38:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-netconf-python39:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-netconf-python36-stable211:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-netconf-python38-stable212:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-netconf-python36-stable29:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-network_cli-python38:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-network_cli-python39:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-network_cli-python38-stable212:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-network_cli-python36-stable211:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-network_cli-python36-stable29:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python38:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python38-stable212:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python36-stable29:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python36-stable211:
             vars:
-              ansible_test_collections: true
               ansible_test_integration_targets: "junos_.*"
         - build-ansible-collection:
             required-projects:
@@ -985,9 +941,7 @@
     name: ansible-collections-juniper-junos-netconf
     check:
       jobs: &ansible-collections-juniper-junos-netconf-jobs
-        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python38:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python38
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
@@ -1207,9 +1161,7 @@
     name: ansible-collections-ansible-yang-juniper-junos
     check:
       jobs: &ansible-collections-juniper-junos-ansible-yang-jobs
-        - ansible-test-network-integration-ansible-yang-junos-vsrx-netconf-python39:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-network-integration-ansible-yang-junos-vsrx-netconf-python39
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.yang
@@ -1226,12 +1178,8 @@
     check:
       jobs: &ansible-collections-cisco-iosxr-ansible-yang-jobs
         - ansible-test-network-integration-ansible-yang-iosxr-netconf-python36:
-            vars:
-              ansible_test_collections: true
             voting: false
         - ansible-test-network-integration-ansible-yang-iosxr-netconf-python38:
-            vars:
-              ansible_test_collections: true
             voting: false
         - build-ansible-collection:
             required-projects:
@@ -1268,9 +1216,7 @@
     name: ansible-collections-community-yang-juniper-junos
     check:
       jobs: &ansible-collections-juniper-junos-yang-jobs
-        - ansible-test-network-integration-community-yang-junos-vsrx-netconf-python36:
-            vars:
-              ansible_test_collections: true
+        - ansible-test-network-integration-community-yang-junos-vsrx-netconf-python36
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/community.yang
@@ -1287,8 +1233,6 @@
     check:
       jobs: &ansible-collections-cisco-iosxr-yang-jobs
         - ansible-test-network-integration-community-yang-iosxr-netconf-python36:
-            vars:
-              ansible_test_collections: true
             voting: false
         - build-ansible-collection:
             required-projects:


### PR DESCRIPTION
This feature was introduced to allow us to continue to tests our modules
when they were maintained in ansible/ansible.
We only test collections now, this is not something we need anymore.
