### PR TITLE
ansible-test-sanity-docker-milestone non-voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1006,7 +1006,8 @@
       jobs: &ansible-collections-kubernetes-core-units-jobs
         - build-ansible-collection
         - ansible-test-sanity-docker-devel
-        - ansible-test-sanity-docker-milestone
+        - ansible-test-sanity-docker-milestone:
+            voting: false
         - ansible-test-sanity-docker-stable-2.9
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12


### PR DESCRIPTION
There was a bug introduced in the latest milestone that broke k8s.core.
We hate to just keep making ci jobs non-voting, but we also don't want
unreleased ansible code to block PRs

See: https://github.com/ansible/ansible/issues/77764
