### PR TITLE
ansible-test-base: always call deploy-artifacts

### DIFF
--- a/playbooks/ansible-test-base/pre.yaml
+++ b/playbooks/ansible-test-base/pre.yaml
@@ -67,11 +67,6 @@
         TMPDIR: /var/tmp/ansible-test-pip
       shell: "~/venv/bin/pip install {{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"
 
-    # NOTE(pabelanger): For integration jobs, install collections after our
-    # appliance is configured. This stops pre-merged code from failing
-    # to configure appliances.
     - name: Fetch and install the artifacts
       import_role:
         name: deploy-artifacts
-      when:
-        - "'network-integration' not in ansible_test_command"


### PR DESCRIPTION
Avoid a special case and ensure we always run `deploy-artifacts`.
