### PR TITLE
Stop testing unit & sanity on zuul for netcommon

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -159,38 +159,6 @@
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
 
 - job:
-    name: ansible-test-units-netcommon-python36
-    parent: ansible-test-units-base-python36
-    required-projects:
-      - name: github.com/ansible-collections/ansible.netcommon
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
-
-- job:
-    name: ansible-test-units-netcommon-python37
-    parent: ansible-test-units-base-python37
-    required-projects:
-      - name: github.com/ansible-collections/ansible.netcommon
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
-
-- job:
-    name: ansible-test-units-netcommon-python38
-    parent: ansible-test-units-base-python38
-    required-projects:
-      - name: github.com/ansible-collections/ansible.netcommon
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
-
-- job:
-    name: ansible-test-units-netcommon-python39
-    parent: ansible-test-units-base-python39
-    required-projects:
-      - name: github.com/ansible-collections/ansible.netcommon
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
-
-- job:
     name: ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python38
     parent: ansible-test-network-integration-iosxr-python38
     vars:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1125,16 +1125,6 @@
     check:
       jobs: &ansible-collections-ansible-netcommon-units-jobs
         - ansible-changelog-fragment
-        - ansible-test-sanity-docker-devel
-        - ansible-test-sanity-docker-milestone
-        - ansible-test-sanity-docker-stable-2.9
-        - ansible-test-sanity-docker-stable-2.10
-        - ansible-test-sanity-docker-stable-2.11
-        - ansible-test-sanity-docker-stable-2.12
-        - ansible-test-units-netcommon-python36
-        - ansible-test-units-netcommon-python37
-        - ansible-test-units-netcommon-python38
-        - ansible-test-units-netcommon-python39
     gate:
       queue: integrated
       fail-fast: true


### PR DESCRIPTION
With https://github.com/ansible-collections/ansible.netcommon/pull/414 merged, we can probably stop running these tests here.

Let me know if I've missed something