### PR TITLE
Fix OKD downstream sanity tests

### DIFF
--- a/playbooks/ansible-cloud/okd/sanity.yaml
+++ b/playbooks/ansible-cloud/okd/sanity.yaml
@@ -1,6 +1,10 @@
 ---
 - hosts: controller
   tasks:
+    - name: Install yaml
+      pip:
+        name: yaml
+        virtualenv: "~/venv"
     - name: Build downstream collection
       shell: "source ~/venv/bin/activate; make downstream-build"
       args:

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -481,6 +481,7 @@
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: milestone
+    voting: false
 
 - job:
     name: ansible-test-sanity-okd-downstream-stable-2.9

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -566,7 +566,8 @@
               - name: github.com/ansible-collections/kubernetes.core
                 override-checkout: stable-2.2
         - ansible-test-sanity-docker-devel
-        - ansible-test-sanity-docker-milestone
+        - ansible-test-sanity-docker-milestone:
+            voting: false
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
         - ansible-test-sanity-docker-stable-2.13


### PR DESCRIPTION
The downstream collection bulid process needs the yaml package. I don't
know why, but this recently started failing saying it couldn't find
yaml. This also makes the milestone sanity tests non-voting as there is
currently a bug in the milestone branch that leads to failures.