### PR TITLE
use the generical python3-devel when possible

### DIFF
--- a/playbooks/ansible-cloud/py-devel/pre.yaml
+++ b/playbooks/ansible-cloud/py-devel/pre.yaml
@@ -1,0 +1,11 @@
+---
+- hosts: controller
+  gather_facts: false
+  tasks:
+    - name: Ensure python3-devel is present (Red Hat)
+      become: true
+      package:
+        name:
+          - python3-devel
+          - gcc
+        state: present

--- a/playbooks/network-ee-integration-tests/pre.yaml
+++ b/playbooks/network-ee-integration-tests/pre.yaml
@@ -9,10 +9,10 @@
       when:
         - test_fips_mode | bool
 
-    - name: Ensure python3.8 is present
+    - name: Ensure python3-devel is present
       become: true
       package:
-        name: python38-devel
+        name: python3-devel
         state: present
 
     - name: Install binary dependencies

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -540,7 +540,7 @@
       - name: build-ansible-collection
       - name: ansible-test-splitter
     pre-run:
-      - playbooks/ansible-cloud/py38/pre.yaml
+      - playbooks/ansible-cloud/py-devel/pre.yaml
       - playbooks/ansible-cloud/k8s/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
     files:

--- a/zuul.d/ansible-test-jobs.yaml
+++ b/zuul.d/ansible-test-jobs.yaml
@@ -7,7 +7,7 @@
       - name: build-ansible-collection
         soft: true
     pre-run:
-      - playbooks/ansible-cloud/py38/pre.yaml
+      - playbooks/ansible-cloud/py-devel/pre.yaml
       - playbooks/ansible-test-base/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
     required-projects:

--- a/zuul.d/cisco-ios-jobs.yaml
+++ b/zuul.d/cisco-ios-jobs.yaml
@@ -43,7 +43,7 @@
     name: ansible-ee-integration-ios-latest
     parent: ansible-ee-tests
     pre-run:
-      - playbooks/ansible-cloud/py38/pre.yaml
+      - playbooks/ansible-cloud/py-devel/pre.yaml
       - playbooks/ansible-ee/integration/pre.yaml
       # Ensure we install the bindeps
       - playbooks/ansible-network-appliance-base/pre.yaml


### PR DESCRIPTION
Don't pull the versionized python3Y-devel package. Use the generic
python3-devel alias to get the right version.
