### PR TITLE
ansible-galaxy-importer: avoid ansible_user_dir

### DIFF
--- a/playbooks/ansible-galaxy-importer/pre.yaml
+++ b/playbooks/ansible-galaxy-importer/pre.yaml
@@ -18,4 +18,4 @@
       import_role:
         name: deploy-artifacts
       vars:
-        deploy_artifacts_venv_path: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv"
+        deploy_artifacts_venv_path: "~/{{ zuul.projects['github.com/ansible-network/releases'].src_dir }}/.tox/venv"


### PR DESCRIPTION
The variable should remain empty when the controller is a container.
