### PR TITLE
rename build-ansible-collection2

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -24,7 +24,7 @@
     abstract: true
     parent: ansible-cloud-vcenter-appliance
     dependencies:
-      - name: build-ansible-collection2
+      - name: build-ansible-collection
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/vcenter-integration-controller/pre.yaml
@@ -154,7 +154,7 @@
     parent: ansible-cloud-vmware-rest-appliance
     abstract: true
     dependencies:
-      - name: build-ansible-collection2
+      - name: build-ansible-collection
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-test-network-integration-base/pre.yaml
@@ -235,7 +235,7 @@
     parent: ansible-core-ci-aws-session
     nodeset: container-ansible
     dependencies:
-      - name: build-ansible-collection2
+      - name: build-ansible-collection
       - name: ansible-test-splitter
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
@@ -377,7 +377,7 @@
     name: ansible-test-integration-amazon-cloud
     parent: ansible-core-ci-aws-session
     dependencies:
-      - name: build-ansible-collection2
+      - name: build-ansible-collection
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
@@ -537,7 +537,7 @@
 - job:
     name: ansible-test-cloud-integration-kubernetes-core
     dependencies:
-      - name: build-ansible-collection2
+      - name: build-ansible-collection
       - name: ansible-test-splitter
     pre-run:
       - playbooks/ansible-cloud/py38/pre.yaml

--- a/zuul.d/ansible-security-jobs.yaml
+++ b/zuul.d/ansible-security-jobs.yaml
@@ -16,7 +16,7 @@
     name: ansible-security-integration-splunk
     abstract: true
     dependencies:
-      - name: build-ansible-collection2
+      - name: build-ansible-collection
         soft: true
     parent: ansible-security-splunk-appliance
     pre-run:
@@ -76,7 +76,7 @@
     name: ansible-test-security-integration-qradar
     abstract: true
     dependencies:
-      - name: build-ansible-collection2
+      - name: build-ansible-collection
         soft: true
     parent: ansible-security-qradar-appliance
     pre-run:
@@ -136,7 +136,7 @@
     name: ansible-security-integration-trendmicro-deepsec
     abstract: true
     dependencies:
-      - name: build-ansible-collection2
+      - name: build-ansible-collection
         soft: true
     parent: ansible-security-trendmicro-deepsec-appliance
     pre-run:

--- a/zuul.d/ansible-test-jobs.yaml
+++ b/zuul.d/ansible-test-jobs.yaml
@@ -4,7 +4,7 @@
     parent: unittests
     nodeset: controller-python38
     dependencies:
-      - name: build-ansible-collection2
+      - name: build-ansible-collection
         soft: true
     pre-run:
       - playbooks/ansible-cloud/py38/pre.yaml

--- a/zuul.d/cisco-asa-jobs.yaml
+++ b/zuul.d/cisco-asa-jobs.yaml
@@ -17,7 +17,7 @@
     name: ansible-test-network-integration-asa
     abstract: true
     dependencies:
-      - name: build-ansible-collection2
+      - name: build-ansible-collection
         soft: true
     parent: ansible-network-asa-appliance
     pre-run:

--- a/zuul.d/ee-jobs.yaml
+++ b/zuul.d/ee-jobs.yaml
@@ -10,7 +10,7 @@
     required-projects:
       - name: github.com/ansible/network-ee
     dependencies:
-      - build-ansible-collection2
+      - build-ansible-collection
     vars:
       container_image_name: quay.io/ansible/network-ee
     nodeset: controller-node

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -8,7 +8,7 @@
       nodes: []
 
 - job:
-    name: build-ansible-collection2
+    name: build-ansible-collection
     description: |
       Build ansible collections and return artifacts to zuul
     pre-run: playbooks/build-ansible-collection/pre.yaml
@@ -127,7 +127,7 @@
     description: |
       Build ansible collections and return artifacts to zuul
     dependencies:
-      - name: build-ansible-collection2
+      - name: build-ansible-collection
     pre-run: playbooks/ansible-galaxy-importer/pre.yaml
     run: playbooks/ansible-galaxy-importer/run.yaml
     required-projects:
@@ -147,7 +147,7 @@
     name: ansible-test-integration-base
     abstract: true
     dependencies:
-      - name: build-ansible-collection2
+      - name: build-ansible-collection
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
@@ -189,7 +189,7 @@
     nodeset: controller-node
     abstract: true
     dependencies:
-      - name: build-ansible-collection2
+      - name: build-ansible-collection
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
     run: playbooks/ansible-test-base/run.yaml

--- a/zuul.d/junipernetworks-junos-jobs.yaml
+++ b/zuul.d/junipernetworks-junos-jobs.yaml
@@ -29,7 +29,7 @@
     name: ansible-test-network-integration-junos-vsrx
     abstract: true
     dependencies:
-      - name: build-ansible-collection2
+      - name: build-ansible-collection
         soft: true
     parent: ansible-network-junos-vsrx-appliance
     pre-run:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -60,7 +60,7 @@
         - ansible-test-sanity-aws-ansible-2.9-python38
         - ansible-test-sanity-aws-ansible-2.11-python38
         - ansible-test-units-amazon-aws-python38
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/ansible.netcommon
@@ -108,7 +108,7 @@
     ondemand:
       queue: integrated-aws
       jobs:
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/ansible.netcommon
@@ -160,7 +160,7 @@
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
         - ansible-test-units-community-aws-python38
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/amazon.aws
               - name: github.com/ansible-collections/ansible.netcommon
@@ -199,7 +199,7 @@
     ondemand:
       queue: integrated-aws
       jobs:
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/amazon.aws
               - name: github.com/ansible-collections/ansible.netcommon
@@ -233,7 +233,7 @@
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
         - ansible-test-integration-amazon-cloud
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/amazon.aws
     gate:
@@ -287,7 +287,7 @@
         - ansible-ee-integration-arista-eos-libssh-stable-2.9
         - ansible-ee-integration-arista-eos-libssh-stable-2.11
         - ansible-ee-integration-arista-eos-libssh-stable-2.12
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
@@ -304,7 +304,7 @@
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
         - ansible-test-units-eos-python38
-        - build-ansible-collection2
+        - build-ansible-collection
 
 - project-template:
     name: ansible-collections-cisco-asa-units
@@ -341,7 +341,7 @@
         - ansible-test-network-integration-asa-libssh-python38-stable211
         - ansible-test-network-integration-asa-libssh-python38-stable29:
             voting: false
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
@@ -382,7 +382,7 @@
       queue: integrated
       fail-fast: true
       jobs:
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
@@ -395,14 +395,14 @@
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
         - ansible-test-units-nxos-python38
-        - build-ansible-collection2
+        - build-ansible-collection
 
 - project-template:
     name: ansible-community-ansible-plugin-builder
     check:
       jobs:
         - ansible-test-integration-ansible-plugin-builder
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.utils
     gate:
@@ -410,7 +410,7 @@
       fail-fast: true
       jobs:
         - ansible-test-integration-ansible-plugin-builder
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.utils
 
@@ -446,7 +446,7 @@
         - ansible-ee-integration-ios-libssh-stable-2.9
         - ansible-ee-integration-ios-libssh-stable-2.11
         - ansible-ee-integration-ios-libssh-stable-2.12
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
@@ -462,7 +462,7 @@
         - ansible-test-sanity-docker-stable-2.10
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
-        - build-ansible-collection2
+        - build-ansible-collection
 
 - project-template:
     name: ansible-collections-cisco-iosxr-units
@@ -488,7 +488,7 @@
     name: ansible-collections-cisco-iosxr
     check:
       jobs:
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
@@ -496,7 +496,7 @@
       queue: integrated
       fail-fast: true
       jobs:
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
@@ -509,7 +509,7 @@
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
         - ansible-test-units-iosxr-python38
-        - build-ansible-collection2
+        - build-ansible-collection
 
 - project-template:
     name: ansible-collections-cisco-iosxr-netconf
@@ -517,7 +517,7 @@
       jobs:
         - ansible-test-network-integration-ansible-netcommon-iosxr-netconf-python38:
             voting: false
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
@@ -532,7 +532,7 @@
       queue: integrated
       fail-fast: true
       jobs:
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
@@ -548,7 +548,7 @@
     name: ansible-collections-community-kubernetes
     third-party-check:
       jobs:
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/cloud.common
               - name: github.com/ansible-collections/kubernetes.core
@@ -557,7 +557,7 @@
     name: ansible-collections-community-okd
     third-party-check:
       jobs:
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/kubernetes.core
                 override-checkout: stable-2.2
@@ -584,7 +584,7 @@
         - ansible-test-cloud-integration-vmware-rest-python38:
             required-projects:
               - name: github.com/ansible-collections/vmware.vmware_rest
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/community.vmware
               - name: github.com/ansible-collections/vmware.vmware_rest
@@ -608,14 +608,14 @@
       jobs:
         - ansible-test-sanity-docker-devel
         - ansible-test-sanity-docker-milestone
-        - build-ansible-collection2
+        - build-ansible-collection
 
 - project-template:
     name: ansible-collections-community-vmware
     check:
       jobs:
         - ansible-tox-linters
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/vmware.vmware_rest
               - name: github.com/ansible-collections/cloud.common
@@ -634,7 +634,7 @@
     gate:
       jobs:
         - ansible-tox-linters
-        - build-ansible-collection2
+        - build-ansible-collection
         - ansible-test-sanity-docker-stable-2.13
         - ansible-test-units-community-vmware-python38
 
@@ -643,7 +643,7 @@
     check:
       jobs: &ansible-collections-community-vmware-rest-jobs
         - ansible-test-cloud-integration-vmware-rest-python38
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/cloud.common
               - name: github.com/ansible-collections/community.vmware
@@ -662,21 +662,21 @@
         - ansible-test-sanity-docker-stable-2.9
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
-        - build-ansible-collection2
+        - build-ansible-collection
 
 - project-template:
     name: ansible-collections-community-vmware-rest-code-generator
     check:
       jobs:
         - ansible-test-cloud-integration-vmware-rest-python38
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/cloud.common
               - name: github.com/ansible-collections/community.vmware
     gate:
       jobs:
         - ansible-test-cloud-integration-vmware-rest-python38
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/cloud.common
               - name: github.com/ansible-collections/community.vmware
@@ -685,13 +685,13 @@
     name: ansible-collections-community-asa
     check:
       jobs:
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
     gate:
       jobs:
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
@@ -800,7 +800,7 @@
         - ansible-ee-integration-ios-libssh-stable-2.12
         - ansible-ee-integration-vyos-latest
         - ansible-ee-integration-vyos-libssh-latest
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/arista.eos
@@ -848,7 +848,7 @@
         - ansible-ee-integration-ios-libssh-stable-2.11
         - ansible-ee-integration-vyos-latest
         - ansible-ee-integration-vyos-libssh-latest
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/arista.eos
@@ -905,7 +905,7 @@
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python36-stable211:
             vars:
               ansible_test_integration_targets: "junos_.*"
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
@@ -924,14 +924,14 @@
         - ansible-test-sanity-docker-stable-2.12
         - ansible-test-units-junos-python38
         - ansible-test-units-junos-python39
-        - build-ansible-collection2
+        - build-ansible-collection
 
 - project-template:
     name: ansible-collections-juniper-junos-netconf
     check:
       jobs: &ansible-collections-juniper-junos-netconf-jobs
         - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python38
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
@@ -947,7 +947,7 @@
     name: ansible-collections-kubernetes-core-units
     check:
       jobs: &ansible-collections-kubernetes-core-units-jobs
-        - build-ansible-collection2
+        - build-ansible-collection
         - ansible-test-sanity-docker-devel
         - ansible-test-sanity-docker-milestone:
             voting: false
@@ -987,7 +987,7 @@
       jobs: *ansible-collections-kubernetes-core-units-jobs
     ondemand:
       jobs:
-        - build-ansible-collection2
+        - build-ansible-collection
         - ansible-test-splitter:
             required-projects:
               - name: github.com/ansible-collections/kubernetes.core
@@ -1048,7 +1048,7 @@
         - ansible-ee-integration-vyos-libssh-stable-2.12
         - ansible-ee-integration-vyos-libssh-stable-2.11
         - ansible-ee-integration-vyos-libssh-stable-2.9
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
@@ -1065,7 +1065,7 @@
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
         - ansible-test-units-vyos-python38
-        - build-ansible-collection2
+        - build-ansible-collection
 
 - project-template:
     name: ansible-collections-frr-frr-units
@@ -1093,7 +1093,7 @@
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
         - ansible-test-units-frr-python38
-        - build-ansible-collection2
+        - build-ansible-collection
 
 - project-template:
     name: ansible-collections-ansible-netcommon-units
@@ -1110,7 +1110,7 @@
     check:
       jobs: &ansible-collections-ansible-network-units-jobs
         - ansible-changelog-fragment
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.network
@@ -1133,7 +1133,7 @@
     check:
       jobs: &ansible-collections-ansible-security-jobs
         - ansible-changelog-fragment
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.security
@@ -1170,7 +1170,7 @@
     check:
       jobs: &ansible-collections-juniper-junos-ansible-yang-jobs
         - ansible-test-network-integration-ansible-yang-junos-vsrx-netconf-python39
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.yang
               - name: github.com/ansible-collections/cisco.iosxr
@@ -1189,7 +1189,7 @@
             voting: false
         - ansible-test-network-integration-ansible-yang-iosxr-netconf-python38:
             voting: false
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.yang
               - name: github.com/ansible-collections/cisco.iosxr
@@ -1225,7 +1225,7 @@
     check:
       jobs: &ansible-collections-juniper-junos-yang-jobs
         - ansible-test-network-integration-community-yang-junos-vsrx-netconf-python36
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/community.yang
               - name: github.com/ansible-collections/cisco.iosxr
@@ -1242,7 +1242,7 @@
       jobs: &ansible-collections-cisco-iosxr-yang-jobs
         - ansible-test-network-integration-community-yang-iosxr-netconf-python36:
             voting: false
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/community.yang
               - name: github.com/ansible-collections/cisco.iosxr
@@ -1274,7 +1274,7 @@
     name: ansible-collections-security-ibm-qradar
     check:
       jobs: &ansible-collections-security-ibm-qradar-jobs
-        - build-ansible-collection2
+        - build-ansible-collection
         - ansible-changelog-fragment
         - ansible-test-security-integration-qradar-python36
         - ansible-test-security-integration-qradar-python37
@@ -1296,7 +1296,7 @@
     name: ansible-collections-security-splunk-es
     check:
       jobs: &ansible-collections-security-splunk-es-jobs
-        - build-ansible-collection2
+        - build-ansible-collection
         - ansible-changelog-fragment
         - ansible-security-integration-splunk-es-python36
         - ansible-security-integration-splunk-es-python37
@@ -1318,7 +1318,7 @@
     name: ansible-collections-security-trendmicro-deepsec-units
     check:
       jobs: &ansible-collections-security-trendmicro-deepsec-jobs
-        - build-ansible-collection2
+        - build-ansible-collection
         - ansible-changelog-fragment
         - ansible-security-integration-trendmicro-deepsec-python36
         - ansible-security-integration-trendmicro-deepsec-python37
@@ -1334,7 +1334,7 @@
         - ansible-test-sanity-docker-stable-2.10
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
@@ -1350,13 +1350,13 @@
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
         - ansible-security-integration-trendmicro-deepsec-python38
-        - build-ansible-collection2
+        - build-ansible-collection
 
 - project-template:
     name: ansible-collections-servicenow-itsm-units
     check:
       jobs: &ansible-collections-servicenow-itsm-units-jobs
-        - build-ansible-collection2
+        - build-ansible-collection
         - ansible-test-sanity-docker-devel
         - ansible-test-sanity-docker-milestone
         - ansible-test-sanity-docker-stable-2.9
@@ -1437,7 +1437,7 @@
         - ansible-test-sanity-docker-stable-2.10
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
-        - build-ansible-collection2
+        - build-ansible-collection
 
 - project-template:
     name: noop-jobs
@@ -1461,11 +1461,11 @@
     check:
       jobs:
         - ansible-galaxy-importer
-        - build-ansible-collection2
+        - build-ansible-collection
     gate:
       jobs:
         - ansible-galaxy-importer
-        - build-ansible-collection2
+        - build-ansible-collection
     pre-release:
       jobs:
         - release-ansible-collection-galaxy
@@ -1479,10 +1479,10 @@
       Publish an Ansible collection to Ansible Automation Hub
     check:
       jobs:
-        - build-ansible-collection2
+        - build-ansible-collection
     gate:
       jobs:
-        - build-ansible-collection2
+        - build-ansible-collection
     pre-release:
       jobs:
         - release-ansible-collection-automation-hub
@@ -1501,7 +1501,7 @@
       Publish an Ansible collection to Ansible Automation Hub
     third-party-check:
       jobs:
-        - build-ansible-collection2
+        - build-ansible-collection
     pre-release:
       jobs:
         - release-ansible-collection-automation-hub
@@ -1521,11 +1521,11 @@
     check:
       jobs:
         - ansible-galaxy-importer
-        - build-ansible-collection2
+        - build-ansible-collection
     gate:
       jobs:
         - ansible-galaxy-importer
-        - build-ansible-collection2
+        - build-ansible-collection
     pre-release:
       jobs:
         - release-ansible-collection-galaxy
@@ -1540,7 +1540,7 @@
     third-party-check:
       jobs:
         - ansible-galaxy-importer
-        - build-ansible-collection2
+        - build-ansible-collection
     pre-release:
       jobs:
         - release-ansible-collection-galaxy
@@ -1555,11 +1555,11 @@
     check:
       jobs:
         - ansible-galaxy-importer
-        - build-ansible-collection2
+        - build-ansible-collection
     gate:
       jobs:
         - ansible-galaxy-importer
-        - build-ansible-collection2
+        - build-ansible-collection
     post-release:
       jobs:
         - release-ansible-collection-galaxy-dev
@@ -1621,7 +1621,7 @@
     name: network-ee-container-image-jobs
     check:
       jobs: &id001
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/amazon.aws
               - name: github.com/ansible-collections/ansible.netcommon
@@ -1647,7 +1647,7 @@
               - name: github.com/ansible-collections/vyos.vyos
         - ansible-buildset-registry:
             dependencies:
-              - build-ansible-collection2
+              - build-ansible-collection
         - network-ee-build-container-image
         - network-ee-build-container-image-stable-2.9
         - network-ee-build-container-image-stable-2.10
@@ -1703,7 +1703,7 @@
         - ansible-ee-integration-ovs-stable2.11
         - ansible-ee-integration-ovs-stable2.10
         - ansible-ee-integration-ovs-stable2.9
-        - build-ansible-collection2:
+        - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/ansible.utils
@@ -1719,4 +1719,4 @@
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
         - ansible-test-units-openvswitch-python38
-        - build-ansible-collection2
+        - build-ansible-collection


### PR DESCRIPTION
Rename build-ansible-collection2 back to build-ansible-collection. The
transition is done.

See: 2cfb52977c9da96ffe77b3a225b3a99847d123e5
