### PR TITLE
aws: run test in VM again

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -233,7 +233,7 @@
 - job:
     name: ansible-test-cloud-integration-aws
     parent: ansible-core-ci-aws-session
-    nodeset: container-ansible
+    nodeset: fedora-36-1vcpu
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter


### PR DESCRIPTION
Running the tests in a container create side effect that break the async
jobs.

```
ASYNC FAILED on testhost: jid=852540718378.2159
fatal: [testhost]: FAILED! => {
    "ansible_job_id": "852540718378.2159",
    "changed": false,
    "finished": 1,
    "invocation": {
        "module_args": {
            "_async_dir": "/root/.ansible_async",
            "jid": "852540718378.2159",
            "mode": "status"
        }
    },
    "msg": "could not find job",
    "results_file": "/root/.ansible_async/852540718378.2159",
    "started": 1,
    "stderr": "",
    "stderr_lines": [],
    "stdout": "",
    "stdout_lines": []
}
```
