### PR TITLE
Update Sanity tests for amazon.aws and community.aws

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -455,6 +455,8 @@
 - job:
     name: ansible-test-sanity-aws-ansible-2.9-python38
     parent: ansible-test-sanity-docker-stable-2.9
+    branches:
+      - stable-1.5
     vars:
       ansible_test_sanity_skiptests:
         - 'future-import-boilerplate'
@@ -463,6 +465,25 @@
 - job:
     name: ansible-test-sanity-aws-ansible-2.11-python38
     parent: ansible-test-sanity-docker-stable-2.11
+    branches:
+      - stable-1.5
+      - stable-2
+    vars:
+      ansible_test_sanity_skiptests:
+        - 'future-import-boilerplate'
+        - 'metaclass-boilerplate'
+
+- job:
+    name: ansible-test-sanity-aws-ansible-2.12-python38
+    parent: ansible-test-sanity-docker-stable-2.12
+    vars:
+      ansible_test_sanity_skiptests:
+        - 'future-import-boilerplate'
+        - 'metaclass-boilerplate'
+
+- job:
+    name: ansible-test-sanity-aws-ansible-2.13-python38
+    parent: ansible-test-sanity-docker-stable-2.13
     vars:
       ansible_test_sanity_skiptests:
         - 'future-import-boilerplate'

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -59,6 +59,8 @@
         - ansible-test-sanity-aws-ansible-python38
         - ansible-test-sanity-aws-ansible-2.9-python38
         - ansible-test-sanity-aws-ansible-2.11-python38
+        - ansible-test-sanity-aws-ansible-2.12-python38
+        - ansible-test-sanity-aws-ansible-2.13-python38
         - ansible-test-units-amazon-aws-python38
         - ansible-test-units-amazon-aws-python39
         - build-ansible-collection:
@@ -157,9 +159,15 @@
       jobs: &ansible-collections-community-aws-jobs
         - ansible-test-sanity-docker-devel
         - ansible-test-sanity-docker-milestone
-        - ansible-test-sanity-docker-stable-2.9
-        - ansible-test-sanity-docker-stable-2.11
+        - ansible-test-sanity-docker-stable-2.9:
+            branches:
+              - stable-1.5
+        - ansible-test-sanity-docker-stable-2.11:
+            branches:
+              - stable-1.5
+              - stable-2
         - ansible-test-sanity-docker-stable-2.12
+        - ansible-test-sanity-docker-stable-2.13
         - ansible-test-units-community-aws-python38
         - ansible-test-units-community-aws-python39
         - build-ansible-collection:


### PR DESCRIPTION
At the last [Ansible AWS community meeting](https://meetbot-raw.fedoraproject.org/ansible-aws/2022-05-26/ansible_aws_community_meeting.2022-05-26-17.33.log.html) we discussed dropping the old sanity tests.

Drop the 2.9/2.11 sanity tests for newer branches and add the 2.13 sanity tests.