### PR TITLE
vcenter: we don't actually need to stop vsphere-ui

### DIFF
--- a/roles/vmware-ci-memory-configuration/tasks/main.yaml
+++ b/roles/vmware-ci-memory-configuration/tasks/main.yaml
@@ -9,10 +9,4 @@
     analytics
     cloudvm-ram-size -C 1 vsphere-ui
     systemctl disable vsphere-ui
-    service-control --stop vsphere-ui
-    service-control --restart vmware-sps
-    service-control --restart vmware-vpxd
-    service-control --restart vmware-stsd
-    service-control --restart observability
-    service-control --restart observability-vapi
   become: true


### PR DESCRIPTION
The stop/restart of all the processes take minutes and we reboot
the instance a couple of steps after anyway. Let's just skip that.
