### PR TITLE
Remove IOSXR unit and sanity jobs

### DIFF
--- a/zuul.d/cisco-iosxr-jobs.yaml
+++ b/zuul.d/cisco-iosxr-jobs.yaml
@@ -36,42 +36,6 @@
       ansible_test_command: network-integration
       ansible_test_integration_targets: "iosxr_.* netconf_.*"
 
-- job:
-    name: ansible-test-units-iosxr-python36
-    parent: ansible-test-units-base-python36
-    required-projects:
-      - name: github.com/ansible-collections/cisco.iosxr
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/cisco.iosxr
-
-- job:
-    name: ansible-test-units-iosxr-python37
-    parent: ansible-test-units-base-python37
-    required-projects:
-      - name: github.com/ansible-collections/cisco.iosxr
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/cisco.iosxr
-
-- job:
-    name: ansible-test-units-iosxr-python38
-    parent: ansible-test-units-base-python38
-    required-projects:
-      - name: github.com/ansible-collections/cisco.iosxr
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/cisco.iosxr
-
-- job:
-    name: ansible-test-units-iosxr-python39
-    parent: ansible-test-units-base-python39
-    required-projects:
-      - name: github.com/ansible-collections/cisco.iosxr
-    vars:
-      ansible_collections_repo: github.com/ansible-collections/cisco.iosxr
-
 # As we are facing retry-limit issue(https://storyboard.openstack.org/#!/story/2009226) integration tests for iosxr are disable
 - job:
     name: ansible-test-network-integration-iosxr-netconf

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -435,26 +435,6 @@
         - build-ansible-collection
 
 - project-template:
-    name: ansible-collections-cisco-iosxr-units
-    check:
-      jobs: &ansible-collections-cisco-iosxr-units-jobs
-        - ansible-changelog-fragment
-        - ansible-test-sanity-docker-devel
-        - ansible-test-sanity-docker-milestone
-        - ansible-test-sanity-docker-stable-2.9
-        - ansible-test-sanity-docker-stable-2.10
-        - ansible-test-sanity-docker-stable-2.11
-        - ansible-test-sanity-docker-stable-2.12
-        - ansible-test-units-iosxr-python36
-        - ansible-test-units-iosxr-python37
-        - ansible-test-units-iosxr-python38
-        - ansible-test-units-iosxr-python39
-    gate:
-      queue: integrated
-      fail-fast: true
-      jobs: *ansible-collections-cisco-iosxr-units-jobs
-
-- project-template:
     name: ansible-collections-cisco-iosxr
     check:
       jobs:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -458,7 +458,6 @@
         - ansible-test-sanity-docker-stable-2.10
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
-        - ansible-test-units-iosxr-python38
         - build-ansible-collection
 
 - project-template:


### PR DESCRIPTION
Depends-On: https://github.com/ansible/zuul-config/pull/416

Remove IOSXR unit and sanity jobs as they are addressed in GHA