### PR TITLE
Restore voting rights to ansible-galaxy-importer on community.aws

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -197,12 +197,10 @@
         - integration-community.aws-11
         - integration-community.aws-12
         - integration-community.aws-13
-        - ansible-galaxy-importer:
-            voting: false
+        - ansible-galaxy-importer
     third-party-check:
       jobs:
-        - ansible-galaxy-importer:
-            voting: false
+        - ansible-galaxy-importer
     gate:
       queue: integrated-aws
       jobs: *ansible-collections-community-aws-jobs


### PR DESCRIPTION
The importer job originally broke because community.aws depends on the docs fragments from amazon.aws

The docs tests have been split off into GitHub actions (which cope with the cross-repo dependency), and the docs test disabled in ansible-galaxy-importer.  Since the test performs other checks, give it back the right to vote.