### PR TITLE
run sanity jobs on Fedora 36

### DIFF
--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -360,7 +360,7 @@
     name: controller-python38
     nodes:
       - name: controller
-        label: ansible-fedora-35-1vcpu
+        label: ansible-fedora-36-1vcpu
 
 - nodeset:
     name: controller-node


### PR DESCRIPTION
This has a workaround for the following error:

    /usr/bin/crun: symbol lookup error: /usr/bin/crun: undefined symbol: criu_join_ns_add

See: https://97fbf7205105f5758a8a-59414ed58c5bf6a18467cad021fce0d7.ssl.cf5.rackcdn.com/1392/7a66591e65a0efef41f2019e287c7afc1a33a114/check/ansible-test-sanity-docker-devel/62e0c29/job-output.txt
