### PR TITLE
ansible-test-sanity: use the current Python3 version

### DIFF
--- a/roles/our-ensure-python/tasks/main.yaml
+++ b/roles/our-ensure-python/tasks/main.yaml
@@ -2,6 +2,16 @@
 - name: Install the right Python version (rpm)
   become: true
   package:
-    name: "python{{ ensure_python__version }}"
+    name:
+      - "python{{ ensure_python__version }}"
     state: present
-  when: ansible_distribution == 'Fedora'
+  when:
+    - ansible_distribution == 'Fedora'
+    - ensure_python__version != "default"
+
+- name: Also install python3-devel
+  become: true
+  package:
+    name:
+      - python3-devel
+      - gcc

--- a/zuul.d/ansible-test-jobs.yaml
+++ b/zuul.d/ansible-test-jobs.yaml
@@ -2,12 +2,14 @@
 - job:
     name: ansible-test-sanity-docker
     parent: unittests
-    nodeset: controller-python38
+    nodeset:
+      nodes:
+        - name: controller
+          label: ansible-fedora-36-1vcpu
     dependencies:
       - name: build-ansible-collection
         soft: true
     pre-run:
-      - playbooks/ansible-cloud/py38/pre.yaml
       - playbooks/ansible-test-base/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
     required-projects:
@@ -19,7 +21,7 @@
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
       ansible_test_command: sanity
       ansible_test_docker: true
-      ansible_test_python: 3.8
+      ansible_test_python: 3
       container_command: podman
 
 - job:
@@ -28,6 +30,8 @@
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: devel
+    vars:
+      ansible_test_python: 3
     voting: false
 
 - job:

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -331,32 +331,32 @@
         nodes:
           - esxi1
 
-- nodeset:
+- nodeset:  # Deprecated
     name: controller-python27
     nodes:
       - name: controller
         label: ansible-fedora-35-1vcpu
 
-- nodeset:
+- nodeset:  # Deprecated
     name: controller-python35
     nodes:
       - name: controller
         # note: there is no py35 on f35
         label: ansible-fedora-35-1vcpu
 
-- nodeset:
+- nodeset:  # Deprecated
     name: controller-python36
     nodes:
       - name: controller
         label: ansible-fedora-35-1vcpu
 
-- nodeset:
+- nodeset:  # Deprecated
     name: controller-python37
     nodes:
       - name: controller
         label: ansible-fedora-35-1vcpu
 
-- nodeset:
+- nodeset:  # Deprecated
     name: controller-python38
     nodes:
       - name: controller


### PR DESCRIPTION
Do not pin on a specific Python version since we use a container anyway
at the end to run the tests.
