### PR TITLE
Bump sanity tests to Python 3.9 - devel branch has dropped support for Python 3.8

### DIFF
--- a/zuul.d/ansible-test-jobs.yaml
+++ b/zuul.d/ansible-test-jobs.yaml
@@ -2,12 +2,12 @@
 - job:
     name: ansible-test-sanity-docker
     parent: unittests
-    nodeset: controller-python38
+    nodeset: controller-python39
     dependencies:
       - name: build-ansible-collection
         soft: true
     pre-run:
-      - playbooks/ansible-cloud/py38/pre.yaml
+      - playbooks/ansible-cloud/py39/pre.yaml
       - playbooks/ansible-test-base/pre.yaml
     run: playbooks/ansible-test-base/run.yaml
     required-projects:
@@ -19,7 +19,7 @@
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
       ansible_test_command: sanity
       ansible_test_docker: true
-      ansible_test_python: 3.8
+      ansible_test_python: 3.9
       container_command: podman
 
 - job:

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -363,6 +363,12 @@
         label: ansible-fedora-36-1vcpu
 
 - nodeset:
+    name: controller-python39
+    nodes:
+      - name: controller
+        label: ansible-fedora-36-1vcpu
+
+- nodeset:
     name: controller-node
     nodes:
       - name: controller


### PR DESCRIPTION
Devel tests are currently failing because (as announced) Ansible core devel branch has now dropped support for Python 3.8.

For example: https://ansible.softwarefactory-project.io/zuul/build/cbdb49248070403589d008f339344c48