### PR TITLE
ansible-test/sanity/container: check all the Python versions

### DIFF
--- a/roles/ansible-test/tasks/init_test_options.yaml
+++ b/roles/ansible-test/tasks/init_test_options.yaml
@@ -50,6 +50,8 @@
     ansible_test_options: "{{ ansible_test_options }} --python {{ ansible_test_python }}"
   when:
     - ansible_test_python
+    - not ansible_test_test_command == 'sanity'
+    - not ansible_test_docker
 
 - name: Setup --docker option
   set_fact:


### PR DESCRIPTION
The PR remove the --python x.y flag when we run ansible-test sanity. This way we properly tests all the support version of Python. This change was requested by gundalow a while ago. This is likely to break stuff if you've got Python3 only code and you don't have the right lines in the ignores files.

Also, since Ansible 2.12, we can ignore a specific Python version.
See: https://github.com/ansible-collections/community.aws/blob/main/tests/config.yml