### PR TITLE
c.vmware: test ansible 2.12, ignore py<3.8

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -14,7 +14,7 @@
         ansible_network_os: vmware_rest
       esxi1:
         ansible_network_os: vmware_rest
-    nodeset: vmware-vcsa-7.0.3-python36
+    nodeset: vmware-vcsa-7.0.3
 
 
 # master
@@ -44,30 +44,27 @@
 
 # vcenter 7.0.3
 - job:
-    name: ansible-test-cloud-integration-vcenter7_only-python36
+    name: ansible-test-cloud-integration-vcenter7_only
     parent: ansible-test-cloud-integration-vcenter
-    nodeset: vmware-vcsa-7.0.3-python36
+    nodeset: vmware-vcsa-7.0.3
     vars:
-      ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_only/
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-python36
+    name: ansible-test-cloud-integration-vcenter7_1esxi
     parent: ansible-test-cloud-integration-vcenter
-    nodeset: vmware-vcsa_1esxi-7.0.3-python36
+    nodeset: vmware-vcsa_1esxi-7.0.3
     vars:
-      ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_1esxi/
     # 5h
     timeout: 10800
 
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_2esxi-python36
+    name: ansible-test-cloud-integration-vcenter7_2esxi
     parent: ansible-test-cloud-integration-vcenter
-    nodeset: vmware-vcsa_2esxi-7.0.3-python36
+    nodeset: vmware-vcsa_2esxi-7.0.3
     vars:
-      ansible_test_python: 3.6
       ansible_test_integration_targets: zuul/vmware/vcenter_2esxi/
     # NOTE: we set ansible_network_os with some generic
     # value to pass the ansible-network playbooks
@@ -79,48 +76,47 @@
       esxi2:
         ansible_network_os: vmware_rest
 
-# stable211
 - job:
-    name: ansible-test-cloud-integration-vcenter7_only-python36-stable211
-    parent: ansible-test-cloud-integration-vcenter7_only-python36
+    name: ansible-test-cloud-integration-vcenter7_only-stable212
+    parent: ansible-test-cloud-integration-vcenter7_only
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.11
+        override-checkout: stable-2.12
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211
-    parent: ansible-test-cloud-integration-vcenter7_1esxi-python36
+    name: ansible-test-cloud-integration-vcenter7_1esxi-stable212
+    parent: ansible-test-cloud-integration-vcenter7_1esxi
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.11
+        override-checkout: stable-2.12
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_1_of_2
-    parent: ansible-test-cloud-integration-vcenter7_1esxi-python36
+    name: ansible-test-cloud-integration-vcenter7_1esxi-stable212_1_of_2
+    parent: ansible-test-cloud-integration-vcenter7_1esxi
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.11
+        override-checkout: stable-2.12
     vars:
       ansible_test_split_in: 2
       ansible_test_do_number: 1
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_2_of_2
-    parent: ansible-test-cloud-integration-vcenter7_1esxi-python36
+    name: ansible-test-cloud-integration-vcenter7_1esxi-stable212_2_of_2
+    parent: ansible-test-cloud-integration-vcenter7_1esxi
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.11
+        override-checkout: stable-2.12
     vars:
       ansible_test_split_in: 2
       ansible_test_do_number: 2
 
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_2esxi-python36-stable211
-    parent: ansible-test-cloud-integration-vcenter7_2esxi-python36
+    name: ansible-test-cloud-integration-vcenter7_2esxi-stable212
+    parent: ansible-test-cloud-integration-vcenter7_2esxi
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.11
+        override-checkout: stable-2.12
 
 
 ####################### vmware.vmware-rest #####################
@@ -141,7 +137,7 @@
         ansible_network_os: vmware_rest
       esxi1:
         ansible_network_os: vmware_rest
-    nodeset: vmware-vcsa_1esxi-7.0.3-python36
+    nodeset: vmware-vcsa_1esxi-7.0.3
 
 # NOTE(pabelanger): Due to low memory capacity in vexxhost, it is
 # possible to wedge the provider.  For now, only run 1 job at a time.

--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -256,7 +256,7 @@
 
 # vcenter 7.0.3
 - nodeset:
-    name: vmware-vcsa-7.0.3-python36
+    name: vmware-vcsa-7.0.3
     nodes:
       - name: controller
         label: ansible-fedora-35-1vcpu
@@ -268,7 +268,7 @@
           - vcenter
 
 - nodeset:
-    name: vmware-vcsa_1esxi-7.0.3-python36
+    name: vmware-vcsa_1esxi-7.0.3
     nodes:
       - name: controller
         label: ansible-fedora-35-1vcpu
@@ -288,7 +288,7 @@
           - esxi1
 
 - nodeset:
-    name: vmware-vcsa_2esxi-7.0.3-python36
+    name: vmware-vcsa_2esxi-7.0.3
     nodes:
       - name: controller
         label: ansible-fedora-35-1vcpu

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -558,16 +558,13 @@
               - name: github.com/ansible-collections/cloud.common
         - ansible-test-sanity-docker-devel
         - ansible-test-sanity-docker-milestone
-        - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
-        - ansible-test-units-community-vmware-python27
-        - ansible-test-units-community-vmware-python36
-        - ansible-test-units-community-vmware-python37
+        - ansible-test-sanity-docker-stable-2.13
         - ansible-test-units-community-vmware-python38
-        - ansible-test-cloud-integration-vcenter7_only-python36-stable211
-        - ansible-test-cloud-integration-vcenter7_2esxi-python36-stable211
-        - ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_1_of_2
-        - ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_2_of_2
+        - ansible-test-cloud-integration-vcenter7_only-stable212
+        - ansible-test-cloud-integration-vcenter7_2esxi-stable212
+        - ansible-test-cloud-integration-vcenter7_1esxi-stable212_1_of_2
+        - ansible-test-cloud-integration-vcenter7_1esxi-stable212_2_of_2
     gate:
       jobs:
         - ansible-tox-linters


### PR DESCRIPTION
- disable unit-tests for Python versions older than 3.8
- use the current Python version of the controller (3.10 on Fedora 36)
  for the integration tests
- remove the Python version from the job name, since we don't really
  care and the name is long enough.
