### PR TITLE
set a default value to ensure_python__version

### DIFF
--- a/roles/ansible-test/tasks/init_test_options.yaml
+++ b/roles/ansible-test/tasks/init_test_options.yaml
@@ -51,6 +51,7 @@
   when:
     - ansible_test_python
     - not ansible_test_test_command == 'sanity'
+    - ansible_test_python|string != '3'
     - not ansible_test_docker
 
 - name: Setup --docker option

--- a/roles/our-ensure-python/defaults/main.yaml
+++ b/roles/our-ensure-python/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+ensure_python__version: 3

--- a/roles/our-ensure-python/tasks/main.yaml
+++ b/roles/our-ensure-python/tasks/main.yaml
@@ -7,7 +7,6 @@
     state: present
   when:
     - ansible_distribution == 'Fedora'
-    - ensure_python__version != "default"
 
 - name: Also install python3-devel
   become: true

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -35,6 +35,7 @@
       - name: github.com/ansible-collections/community.vmware
     timeout: 3600
     vars:
+      ansible_test_python: 3
       ansible_collections_repo: github.com/ansible-collections/community.vmware
       ansible_test_command: integration
       ansible_test_environment:
@@ -168,6 +169,7 @@
     vars:
       ansible_collections_repo: github.com/ansible-collections/vmware.vmware_rest
       ansible_test_command: network-integration
+      ansible_test_python: 3
       ansible_test_integration_targets: "zuul/"
     timeout: 3600
     semaphore: ansible-test-cloud-integration-vmware-rest


### PR DESCRIPTION
This to avoid errors like:

```
TASK [our-ensure-python : Install the right Python version (rpm)]
controller | ERROR
controller | {
controller |   "msg": "The conditional check 'ensure_python__version != \"default\"' failed. The error was: error while evaluating conditional (ensure_python__version != \"default\"): {{ ansible_test_python }}: 'ansible_test_python' is undefined\n\nThe error appears to be in '/var/lib/zuul/builds/2ca2c3be408940cf871b15451b5b8be5/untrusted/project_0/github.com/ansible/ansible-zuul-jobs/roles/our-ensure-python/tasks/main.yaml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Install the right Python version (rpm)\n  ^ here\n"
controller | }
```
