### PR TITLE
Add amazon.aws as a dependency of community.aws in third-party checks

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -210,6 +210,9 @@
     third-party-check:
       jobs:
         - ansible-galaxy-importer
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-collections/amazon.aws
     gate:
       queue: integrated-aws
       jobs: *ansible-collections-community-aws-jobs


### PR DESCRIPTION
Without building the dependency we can't properly set up the dependencies for the main branch which still contains unreleased code.