### PR TITLE
Fix unit test for community.okd using python 3.8

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -493,15 +493,6 @@
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
 
 ### Community OKD
-- job:
-    name: ansible-test-units-community-okd-python38
-    parent: ansible-test-units-base-python38
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: milestone
-      - name: github.com/openshift/community.okd
-    vars:
-      ansible_collections_repo: github.com/openshift/community.okd
 
 - job:
     name: ansible-test-sanity-okd-downstream

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -509,7 +509,6 @@
         - ansible-test-sanity-docker-stable-2.13
         - ansible-galaxy-importer:
             voting: false
-        - ansible-test-units-community-okd-python38
         - ansible-test-units-community-okd-python39
         - ansible-test-sanity-okd-downstream-devel
         - ansible-test-sanity-okd-downstream-milestone


### PR DESCRIPTION
Seems that ansible milestone branch requires Python >= 3.9