### PR TITLE
Allow 'trivial' changelog fragments

### DIFF
--- a/playbooks/ansible-test-changelog/library/validate_changelog.py
+++ b/playbooks/ansible-test-changelog/library/validate_changelog.py
@@ -141,6 +141,7 @@ class ValidateChangeLog(AnsibleModule):
                 "deprecated_features",
                 "removed_features",
                 "security_fixes",
+                "trivial",
                 "bugfixes",
             )
             with open(path, "rb") as f:


### PR DESCRIPTION
There are times when there's no need for a 'public' changelog isn't necessary (eg test-only changes, or module-docs work)

Based on comments from @felixfontein the appropriate way to deal with this is to allow 'trivial' fragments:

`always remember the 'trivial:' category in changelog fragments, it's exactly for such cases where you don't want to clutter the changelog with such things, but have to write a fragment`