### PR TITLE
Move junos devel tests to python 3.9

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -141,8 +141,8 @@
       ansible_test_integration_targets: "netconf_.*"
 
 - job:
-    name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python38
-    parent: ansible-test-network-integration-junos-vsrx-python38
+    name: ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python39
+    parent: ansible-test-network-integration-junos-vsrx-python39
     vars:
       ansible_collections_repo: github.com/ansible-collections/ansible.netcommon
       ansible_test_integration_targets: "netconf_.*"

--- a/zuul.d/junipernetworks-junos-jobs.yaml
+++ b/zuul.d/junipernetworks-junos-jobs.yaml
@@ -114,8 +114,8 @@
       ansible_test_python: 3.9
 
 - job:
-    name: ansible-test-network-integration-junos-vsrx-network_cli-libssh-python38
-    parent: ansible-test-network-integration-junos-vsrx-network_cli-python38
+    name: ansible-test-network-integration-junos-vsrx-network_cli-libssh-python39
+    parent: ansible-test-network-integration-junos-vsrx-network_cli-python39
     vars:
       ansible_test_network_cli_ssh_type: libssh
 

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -668,10 +668,9 @@
         - ansible-test-network-integration-junos-vsrx-netconf-python38-stable212:
             vars:
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-netconf-python38:
+        - ansible-test-network-integration-junos-vsrx-netconf-python39:
             vars:
               ansible_test_integration_targets: "junos_.*"
-            voting: false
         - ansible-test-network-integration-junos-vsrx-network_cli-python36-stable29:
             vars:
               ansible_test_integration_targets: "junos_.*"
@@ -683,10 +682,9 @@
         - ansible-test-network-integration-junos-vsrx-network_cli-python38-stable212:
             vars:
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-network_cli-python38:
+        - ansible-test-network-integration-junos-vsrx-network_cli-python39:
             vars:
               ansible_test_integration_targets: "junos_.*"
-            voting: false
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python36-stable29:
             vars:
               ansible_test_integration_targets: "junos_.*"
@@ -701,6 +699,7 @@
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python38:
             vars:
               ansible_test_integration_targets: "junos_.*"
+            voting: false
         - ansible-ee-integration-cisco-nxos-cli-python39-latest:
             voting: false
         - ansible-ee-integration-arista-eos-latest
@@ -744,18 +743,16 @@
             vars:
               ansible_test_integration_targets: "junos_.*"
             voting: false
-        - ansible-test-network-integration-junos-vsrx-netconf-python38:
+        - ansible-test-network-integration-junos-vsrx-netconf-python39:
             vars:
               ansible_test_integration_targets: "junos_.*"
-            voting: false
         - ansible-test-network-integration-junos-vsrx-network_cli-python36-stable29:
             vars:
               ansible_test_integration_targets: "junos_.*"
             voting: false
-        - ansible-test-network-integration-junos-vsrx-network_cli-python38:
+        - ansible-test-network-integration-junos-vsrx-network_cli-python39:
             vars:
               ansible_test_integration_targets: "junos_.*"
-            voting: false
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python36-stable29:
             vars:
               ansible_test_integration_targets: "junos_.*"
@@ -763,6 +760,7 @@
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python38:
             vars:
               ansible_test_integration_targets: "junos_.*"
+            voting: false
         - ansible-ee-integration-cisco-nxos-cli-python39-latest:
             voting: false
         - ansible-ee-integration-arista-eos-latest
@@ -791,9 +789,6 @@
     name: ansible-collections-juniper-junos
     check:
       jobs: &ansible-collections-juniper-junos-jobs
-        - ansible-test-network-integration-junos-vsrx-netconf-python38:
-            vars:
-              ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-netconf-python39:
             vars:
               ansible_test_integration_targets: "junos_.*"
@@ -804,9 +799,6 @@
             vars:
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-netconf-python36-stable29:
-            vars:
-              ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-network_cli-python38:
             vars:
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-network_cli-python39:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -696,10 +696,9 @@
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python38-stable212:
             vars:
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python38:
+        - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python39:
             vars:
               ansible_test_integration_targets: "junos_.*"
-            voting: false
         - ansible-ee-integration-cisco-nxos-cli-python39-latest:
             voting: false
         - ansible-ee-integration-arista-eos-latest
@@ -757,10 +756,9 @@
             vars:
               ansible_test_integration_targets: "junos_.*"
             voting: false
-        - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python38:
+        - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python39:
             vars:
               ansible_test_integration_targets: "junos_.*"
-            voting: false
         - ansible-ee-integration-cisco-nxos-cli-python39-latest:
             voting: false
         - ansible-ee-integration-arista-eos-latest
@@ -813,7 +811,7 @@
         - ansible-test-network-integration-junos-vsrx-network_cli-python36-stable29:
             vars:
               ansible_test_integration_targets: "junos_.*"
-        - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python38:
+        - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python39:
             vars:
               ansible_test_integration_targets: "junos_.*"
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python38-stable212:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -671,6 +671,7 @@
         - ansible-test-network-integration-junos-vsrx-netconf-python38:
             vars:
               ansible_test_integration_targets: "junos_.*"
+            voting: false
         - ansible-test-network-integration-junos-vsrx-network_cli-python36-stable29:
             vars:
               ansible_test_integration_targets: "junos_.*"
@@ -685,6 +686,7 @@
         - ansible-test-network-integration-junos-vsrx-network_cli-python38:
             vars:
               ansible_test_integration_targets: "junos_.*"
+            voting: false
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python36-stable29:
             vars:
               ansible_test_integration_targets: "junos_.*"
@@ -745,6 +747,7 @@
         - ansible-test-network-integration-junos-vsrx-netconf-python38:
             vars:
               ansible_test_integration_targets: "junos_.*"
+            voting: false
         - ansible-test-network-integration-junos-vsrx-network_cli-python36-stable29:
             vars:
               ansible_test_integration_targets: "junos_.*"
@@ -752,6 +755,7 @@
         - ansible-test-network-integration-junos-vsrx-network_cli-python38:
             vars:
               ansible_test_integration_targets: "junos_.*"
+            voting: false
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python36-stable29:
             vars:
               ansible_test_integration_targets: "junos_.*"

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -836,7 +836,7 @@
     name: ansible-collections-juniper-junos-netconf
     check:
       jobs: &ansible-collections-juniper-junos-netconf-jobs
-        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python38
+        - ansible-test-network-integration-ansible-netcommon-junos-vsrx-netconf-python39
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.netcommon

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -664,7 +664,6 @@
         - ansible-test-network-integration-junos-vsrx-netconf-python36-stable211:
             vars:
               ansible_test_integration_targets: "junos_.*"
-            voting: false
         - ansible-test-network-integration-junos-vsrx-netconf-python38-stable212:
             vars:
               ansible_test_integration_targets: "junos_.*"
@@ -678,7 +677,6 @@
         - ansible-test-network-integration-junos-vsrx-network_cli-python36-stable211:
             vars:
               ansible_test_integration_targets: "junos_.*"
-            voting: false
         - ansible-test-network-integration-junos-vsrx-network_cli-python38-stable212:
             vars:
               ansible_test_integration_targets: "junos_.*"
@@ -692,7 +690,6 @@
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python36-stable211:
             vars:
               ansible_test_integration_targets: "junos_.*"
-            voting: false
         - ansible-test-network-integration-junos-vsrx-network_cli-libssh-python38-stable212:
             vars:
               ansible_test_integration_targets: "junos_.*"


### PR DESCRIPTION
~~ansible-test-network-integration-junos-vsrx-network_cli-libssh-python38 doesn't seem to have a python39 variant yet~~
All devel junos tests _should_ be using python 3.9 now?