### PR TITLE
aws: allow up to 8 jobs in parallel

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -218,7 +218,7 @@
 
 - semaphore:
     name: ansible-test-cloud-integration-aws
-    max: 6
+    max: 8
 
 - job:
     name: ansible-test-cloud-integration-aws


### PR DESCRIPTION
The limit at 6 was rather conservative and we've yet to hit a rate
limit. Trying 8 jobs in parallel now.
