### PR TITLE
aws: reduce the amount of testing during the gating

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -127,7 +127,8 @@
         - ansible-test-changelog
     gate:
       queue: integrated-aws
-      jobs: *ansible-collections-amazon-aws-jobs
+      jobs:
+        - ansible-test-units-amazon-aws-python39
     ondemand:
       queue: integrated-aws
       jobs:


### PR DESCRIPTION
Temporarily reduce the amount of testing during the gating to
speed up the merging of a serie of module promotion.
