### PR TITLE
Remove 2.12 from community.vmware

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -593,7 +593,6 @@
               - name: github.com/ansible-collections/cloud.common
         - ansible-test-sanity-docker-devel
         - ansible-test-sanity-docker-milestone
-        - ansible-test-sanity-docker-stable-2.12
         - ansible-test-sanity-docker-stable-2.13
         - ansible-test-sanity-docker-stable-2.14
         - ansible-test-units-community-vmware-python38


### PR DESCRIPTION
I'm trying to release a new major version of community.vmware soon, in time for Ansible 7. I would like to drop support for ansible-core < 2.13, but this means I'm running into problems with the `ansible-test-sanity-docker-stable-2.12`.

Therefor, I would like to remove it from the tests.