### PR TITLE
amazon.aws: unit-test with py36

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -435,6 +435,20 @@
 #### units
 
 - job:
+    name: ansible-test-units-amazon-aws-python36
+    parent: ansible-test-units-base-python36
+    vars:
+      ansible_collections_repo: "{{ zuul.project.canonical_name }}"
+      ansible_test_requirement_files:
+        - requirements.txt
+        - test-requirements.txt
+        # Ansible-test picks up requirements and constraints from
+        # tests/unit when running in docker, mirror this
+        - tests/unit/requirements.txt
+      ansible_test_constraint_files:
+        - tests/unit/constraints.txt
+
+- job:
     name: ansible-test-units-amazon-aws-python38
     parent: ansible-test-units-base-python38
     vars:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -70,6 +70,7 @@
         - ansible-test-sanity-aws-ansible-2.11-python38
         - ansible-test-sanity-aws-ansible-2.12-python38
         - ansible-test-sanity-aws-ansible-2.13-python38
+        - ansible-test-units-amazon-aws-python36
         - ansible-test-units-amazon-aws-python38
         - ansible-test-units-amazon-aws-python39
         - cloud-tox-py3


### PR DESCRIPTION
py36 is the lowest version that we support and it's the most likely to
break, for instance when we introduce features that are only supported
with more modern versions.
