### PR TITLE
community.aws: unit-tests with py36

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -203,6 +203,7 @@
         - ansible-test-sanity-docker-stable-2.12
         - ansible-test-sanity-docker-stable-2.13
         - ansible-test-sanity-docker-stable-2.14
+        - ansible-test-units-community-vmware-python36
         - ansible-test-units-community-aws-python38
         - ansible-test-units-community-aws-python39
         - build-ansible-collection:


### PR DESCRIPTION
Python 3.6 is still supported.
