### PR TITLE
use amazon.aws unit test as the template for community.aws unit tests instead of community.vmware

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -203,9 +203,9 @@
         - ansible-test-sanity-docker-stable-2.12
         - ansible-test-sanity-docker-stable-2.13
         - ansible-test-sanity-docker-stable-2.14
-        - ansible-test-units-community-vmware-python36
-        - ansible-test-units-community-aws-python38
-        - ansible-test-units-community-aws-python39
+        - ansible-test-units-amazon-aws-python36
+        - ansible-test-units-amazon-aws-python38
+        - ansible-test-units-amazon-aws-python39
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/amazon.aws


### PR DESCRIPTION
community.vmware is hard coded to look for community.vmware.  This broke community.aws CI