### PR TITLE
Make sure changelog test works properly on branches

### DIFF
--- a/playbooks/ansible-test-changelog/run.yaml
+++ b/playbooks/ansible-test-changelog/run.yaml
@@ -3,7 +3,12 @@
   gather_facts: false
 
   tasks:
+    - debug:
+        var: ansible_test_changelog__branch
+    - debug:
+        var: zuul.branch
+
     - name: Validate changelog fragments from Pull request
       validate_changelog:
         repository: "{{ ansible_test_changelog__repository | default(zuul.project.src_dir) }}"
-        branch: "{{ ansible_test_changelog__branch | default('main') }}"
+        branch: "{{ ansible_test_changelog__branch | default(zuul.branch) | default('main') }}"

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -239,6 +239,7 @@
         - integration-community.aws-17
         - integration-community.aws-18
 
+        - ansible-test-changelog
         - ansible-galaxy-importer
     third-party-check:
       jobs:


### PR DESCRIPTION
See for example https://c49a1c51c7d7c3035884-283c70707867ec61c5cb813877763122.ssl.cf2.rackcdn.com/1157/bffb9f8c60785ed9d84cae2e49e98ac5a6b3bd34/gate/ansible-test-changelog/aaeaa7e/job-output.txt

There **IS** a changelog fragment present, and it gated into main fine.  It's refusing to gate into stable-5