### PR TITLE
add the possibility to define extra tests for ansible-test-splitter

### DIFF
--- a/roles/ansible-test-splitter/files/list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/list_changed_targets.py
@@ -52,7 +52,6 @@ parser.add_argument(
 parser.add_argument(
     "--pull-request",
     dest="pull_request",
-    required=True,
     type=int,
     help="GitHub Pull request number. e.g: 51",
 )
@@ -60,7 +59,6 @@ parser.add_argument(
 parser.add_argument(
     "--project-name",
     dest="project_name",
-    required=True,
     type=str,
     help="GitHub project name. e.g: ansible-collections/kubernetes.core",
 )
@@ -467,7 +465,11 @@ if __name__ == "__main__":
 
     ansible_releases = args.ansible_releases
     zuul_targets, zuul_extra_targets = [], []
-    pr_request = read_pullrequest_zuul_override(args.project_name, args.pull_request)
+    pr_request = None
+    if args.project_name is not None and args.pull_request is not None:
+        pr_request = read_pullrequest_zuul_override(
+            args.project_name, args.pull_request
+        )
 
     if pr_request:
         release_to_test = pr_request.get(ZUUL_RELEASES)

--- a/roles/ansible-test-splitter/files/list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/list_changed_targets.py
@@ -59,11 +59,19 @@ parser.add_argument(
 )
 
 parser.add_argument(
-    "--change-url",
-    dest="change_url",
+    "--pull-request",
+    dest="pull_request",
+    required=True,
+    type=int,
+    help="GitHub Pull request number. e.g: 51",
+)
+
+parser.add_argument(
+    "--project-name",
+    dest="project_name",
     required=True,
     type=str,
-    help="GitHub Pull request URL. e.g: https://api.github.com/repos/ansible-collections/kubernetes.core/pulls/51",
+    help="GitHub project name. e.g: ansible-collections/kubernetes.core",
 )
 
 parser.add_argument(
@@ -430,15 +438,19 @@ class ElGrandeSeparator:
         return result
 
 
-def read_pullrequest_body(change_url):
+def read_pullrequest_body(project_name, pull_request):
     if REQUESTS_MODULE_IMPORT_ERROR:
         raise REQUESTS_MODULE_IMPORT_ERROR
+    change_url = "https://api.github.com/repos/%s/pulls/%d" % (
+        project_name,
+        pull_request,
+    )
     return [x for x in requests.get(change_url).json().get("body").split("\n") if x]
 
 
-def read_user_extra_requests(change_url):
+def read_user_extra_requests(project_name, pull_request):
 
-    desc = read_pullrequest_body(change_url)
+    desc = read_pullrequest_body(project_name, pull_request)
     extra_requests_patterns = (
         "Zuul-Test-Include-Extra-Targets",
         "Zuul-Test-with-Targets",
@@ -469,7 +481,7 @@ if __name__ == "__main__":
 
     ansible_releases = args.ansible_releases
     zuul_targets, zuul_extra_targets = [], []
-    pr_request = read_user_extra_requests(args.change_url)
+    pr_request = read_user_extra_requests(args.project_name, args.pull_request)
 
     if pr_request:
         release_to_test = pr_request.get("Zuul-Test-with-Releases")

--- a/roles/ansible-test-splitter/files/list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/list_changed_targets.py
@@ -9,16 +9,7 @@ import subprocess
 import yaml
 import re
 from collections import defaultdict
-
-try:
-
-    import requests
-
-    REQUESTS_MODULE_IMPORT_ERROR = None
-
-except ImportError as e:
-
-    REQUESTS_MODULE_IMPORT_ERROR = e
+import requests
 
 
 parser = argparse.ArgumentParser(
@@ -439,8 +430,6 @@ class ElGrandeSeparator:
 
 
 def read_pullrequest_body(project_name, pull_request):
-    if REQUESTS_MODULE_IMPORT_ERROR:
-        raise REQUESTS_MODULE_IMPORT_ERROR
     change_url = "https://api.github.com/repos/%s/pulls/%d" % (
         project_name,
         pull_request,

--- a/roles/ansible-test-splitter/files/list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/list_changed_targets.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 
 try:
     from github import Github
+
     HAS_GITHUB_MODULE = True
 
 except ImportError:
@@ -450,7 +451,11 @@ def read_pullrequest_body(project_name, pr_number):
 def read_user_extra_requests(project_name, pr_number):
 
     desc = read_pullrequest_body(project_name, pr_number)
-    ansible_test_regex = ("Zuul-Test-Include-Extra-Targets", "Zuul-Test-with-Targets", "Zuul-Test-with-Releases")
+    ansible_test_regex = (
+        "Zuul-Test-Include-Extra-Targets",
+        "Zuul-Test-with-Targets",
+        "Zuul-Test-with-Releases",
+    )
 
     def _extract_data(line):
         data = (":".join(line.split(":")[1:])).replace(",", " ")
@@ -464,7 +469,7 @@ def read_user_extra_requests(project_name, pr_number):
                     result[key] = _extract_data(line)
         except:
             pass
-    
+
     return result
 
 
@@ -476,7 +481,9 @@ if __name__ == "__main__":
 
     ansible_releases = args.ansible_releases
     zuul_targets, zuul_extra_targets = [], []
-    pr_request = read_user_extra_requests(args.github_project_name, args.github_pull_request_number)
+    pr_request = read_user_extra_requests(
+        args.github_project_name, args.github_pull_request_number
+    )
     if pr_request:
         release_to_test = pr_request.get("Zuul-Test-with-Releases")
         if release_to_test:

--- a/roles/ansible-test-splitter/files/list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/list_changed_targets.py
@@ -433,7 +433,7 @@ class ElGrandeSeparator:
 def read_pullrequest_body(change_url):
     if REQUESTS_MODULE_IMPORT_ERROR:
         raise REQUESTS_MODULE_IMPORT_ERROR
-    return requests.get(change_url).json().get("body")
+    return [x for x in requests.get(change_url).json().get("body").split("\n") if x]
 
 
 def read_user_extra_requests(change_url):

--- a/roles/ansible-test-splitter/files/test_list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/test_list_changed_targets.py
@@ -209,18 +209,21 @@ def test_argparse_with_missing_arguments():
 
 
 def test_argparse_with_valid_arguments():
-    change_url = "".join(
+    project_name = "".join(
         [random.choice(string.ascii_letters + string.digits) for _ in range(50)]
     )
+    pull_request = random.randint(1, 1000)
     command_line = (
-        "--test-changed somewhere somewhere-else --change-url %s" % change_url
+        "--test-changed somewhere somewhere-else --project-name %s --pull-request %s"
+        % (project_name, pull_request)
     )
     args = parse_args(command_line.split(" "))
     assert args.collection_to_tests == [
         PosixPath("somewhere"),
         PosixPath("somewhere-else"),
     ]
-    assert args.change_url == change_url
+    assert args.project_name == project_name
+    assert args.pull_request == pull_request
 
 
 def test_splitter_with_slow():
@@ -333,10 +336,11 @@ def test_read_user_extra_requests(m_read_pullrequest_body, body, expected):
 
     m_read_pullrequest_body.return_value = body
 
-    change_url = "".join(
+    project_name = "".join(
         [random.choice(string.ascii_letters + string.digits) for _ in range(50)]
     )
+    pull_request = random.randint(1, 1000)
 
-    result = read_user_extra_requests(change_url)
+    result = read_user_extra_requests(project_name, pull_request)
     assert result == expected
-    m_read_pullrequest_body.assert_called_with(change_url)
+    m_read_pullrequest_body.assert_called_with(project_name, pull_request)

--- a/roles/ansible-test-splitter/files/test_list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/test_list_changed_targets.py
@@ -212,7 +212,9 @@ def test_argparse_with_missing_arguments():
 
 def test_argparse_with_valid_arguments():
     command_line = "--test-changed somewhere somewhere-else "
-    project_name = "".join([random.choice(string.ascii_letters + string.digits) for _ in range(50)])
+    project_name = "".join(
+        [random.choice(string.ascii_letters + string.digits) for _ in range(50)]
+    )
     pr_number = random.randint(1, 1000)
     command_line += "--github_project_name %s " % project_name
     command_line += "--github_pull_request_number %d" % pr_number
@@ -292,60 +294,52 @@ def test_what_changed_git_call(m_check_output):
     [
         ([], {}),
         (
-            [
-                "Zuul-Test-Include-Extra-Targets: target1, target2"
-            ],
-            {
-                "Zuul-Test-Include-Extra-Targets" : ["target1", "target2"]
-            }
+            ["Zuul-Test-Include-Extra-Targets: target1, target2"],
+            {"Zuul-Test-Include-Extra-Targets": ["target1", "target2"]},
         ),
         (
-            [
-                "Zuul-Test-Include-Extra-Targets: target1 target2"
-            ],
-            {
-                "Zuul-Test-Include-Extra-Targets" : ["target1", "target2"]
-            }
+            ["Zuul-Test-Include-Extra-Targets: target1 target2"],
+            {"Zuul-Test-Include-Extra-Targets": ["target1", "target2"]},
         ),
         (
             [
                 "Zuul-Test-Include-Extra-Targets: target1 target2",
-                "Zuul-Test-with-Releases release1 release2"
+                "Zuul-Test-with-Releases release1 release2",
             ],
-            {
-                "Zuul-Test-Include-Extra-Targets" : ["target1", "target2"]
-            }
-        ),
-        (
-            [
-                "Zuul-Test-Include-Extra-Targets: target1 target2",
-                "Zuul-Test-with-Releases:release1 release2"
-            ],
-            {
-                "Zuul-Test-Include-Extra-Targets" : ["target1", "target2"],
-                "Zuul-Test-with-Releases" : ["release1", "release2"]
-            }
+            {"Zuul-Test-Include-Extra-Targets": ["target1", "target2"]},
         ),
         (
             [
                 "Zuul-Test-Include-Extra-Targets: target1 target2",
                 "Zuul-Test-with-Releases:release1 release2",
-                "Zuul-Test-with-Targets: target1  "
             ],
             {
-                "Zuul-Test-Include-Extra-Targets" : ["target1", "target2"],
-                "Zuul-Test-with-Releases" : ["release1", "release2"],
-                "Zuul-Test-with-Targets" : ["target1"]
-            }
-        )
-    ]
+                "Zuul-Test-Include-Extra-Targets": ["target1", "target2"],
+                "Zuul-Test-with-Releases": ["release1", "release2"],
+            },
+        ),
+        (
+            [
+                "Zuul-Test-Include-Extra-Targets: target1 target2",
+                "Zuul-Test-with-Releases:release1 release2",
+                "Zuul-Test-with-Targets: target1  ",
+            ],
+            {
+                "Zuul-Test-Include-Extra-Targets": ["target1", "target2"],
+                "Zuul-Test-with-Releases": ["release1", "release2"],
+                "Zuul-Test-with-Targets": ["target1"],
+            },
+        ),
+    ],
 )
 @patch("list_changed_targets.read_pullrequest_body")
 def test_read_user_extra_requests(m_read_pullrequest_body, body, expected):
 
     m_read_pullrequest_body.return_value = body
 
-    project_name = "".join([random.choice(string.ascii_letters + string.digits) for _ in range(50)])
+    project_name = "".join(
+        [random.choice(string.ascii_letters + string.digits) for _ in range(50)]
+    )
     pr_number = random.randint(1, 1000)
 
     result = read_user_extra_requests(project_name, pr_number)

--- a/roles/ansible-test-splitter/files/test_list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/test_list_changed_targets.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from difflib import restore
 import pytest
 import io
 from pathlib import PosixPath
@@ -16,7 +15,6 @@ from list_changed_targets import (
     parse_args,
     read_collection_name,
     read_user_extra_requests,
-    read_pullrequest_body,
 )
 
 my_module = """
@@ -211,20 +209,18 @@ def test_argparse_with_missing_arguments():
 
 
 def test_argparse_with_valid_arguments():
-    command_line = "--test-changed somewhere somewhere-else "
-    project_name = "".join(
+    change_url = "".join(
         [random.choice(string.ascii_letters + string.digits) for _ in range(50)]
     )
-    pr_number = random.randint(1, 1000)
-    command_line += "--github_project_name %s " % project_name
-    command_line += "--github_pull_request_number %d" % pr_number
+    command_line = (
+        "--test-changed somewhere somewhere-else --change-url %s" % change_url
+    )
     args = parse_args(command_line.split(" "))
     assert args.collection_to_tests == [
         PosixPath("somewhere"),
         PosixPath("somewhere-else"),
     ]
-    assert args.github_project_name == project_name
-    assert args.github_pull_request_number == pr_number
+    assert args.change_url == change_url
 
 
 def test_splitter_with_slow():
@@ -337,11 +333,10 @@ def test_read_user_extra_requests(m_read_pullrequest_body, body, expected):
 
     m_read_pullrequest_body.return_value = body
 
-    project_name = "".join(
+    change_url = "".join(
         [random.choice(string.ascii_letters + string.digits) for _ in range(50)]
     )
-    pr_number = random.randint(1, 1000)
 
-    result = read_user_extra_requests(project_name, pr_number)
+    result = read_user_extra_requests(change_url)
     assert result == expected
-    m_read_pullrequest_body.assert_called_with(project_name, pr_number)
+    m_read_pullrequest_body.assert_called_with(change_url)

--- a/roles/ansible-test-splitter/files/test_list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/test_list_changed_targets.py
@@ -207,26 +207,7 @@ def test_c_with_cover():
 
 
 def test_argparse_with_missing_arguments():
-    with pytest.raises(SystemExit):
-        parse_args("--test-changed somewhere somewhere-else".split(" "))
-
-
-def test_argparse_with_valid_arguments():
-    project_name = "".join(
-        [random.choice(string.ascii_letters + string.digits) for _ in range(50)]
-    )
-    pull_request = random.randint(1, 1000)
-    command_line = (
-        "--test-changed somewhere somewhere-else --project-name %s --pull-request %s"
-        % (project_name, pull_request)
-    )
-    args = parse_args(command_line.split(" "))
-    assert args.collection_to_tests == [
-        PosixPath("somewhere"),
-        PosixPath("somewhere-else"),
-    ]
-    assert args.project_name == project_name
-    assert args.pull_request == pull_request
+    parse_args("--test-changed somewhere somewhere-else".split(" "))
 
 
 def test_splitter_with_slow():

--- a/roles/ansible-test-splitter/tasks/main.yaml
+++ b/roles/ansible-test-splitter/tasks/main.yaml
@@ -1,60 +1,32 @@
 ---
-- block:
-    - name: Create temporary directory for tests
-      tempfile:
-        state: directory
-        suffix: .splitter
-      register: _result
+- copy:
+    src: list_changed_targets.py
+    dest: /tmp/list_changed_targets.py
+    mode: '0700'
 
-    - set_fact:
-        venv_path: "{{ _result.path }}/env"
-        executable_path: "{{ _result.path }}/list_changed_targets.py"
+- set_fact:
+    splitter_cmd: >
+      python3 /tmp/list_changed_targets.py
+      --branch {{ zuul.branch }}
+      {% if ansible_test_splitter__releases_to_test is defined %}--ansible-releases {{ ansible_test_splitter__releases_to_test | join(' ') }}{% endif %}
+      {% if ansible_test_splitter__total_job is defined %}--total-job {{ ansible_test_splitter__total_job }}{% endif %}
+      {% if ansible_test_splitter__test_changed|bool %}--test-changed{% else %}--test-all-the-targets{% endif %}
+      {{ ansible_test_splitter__check_for_changes_in | join(' ') }}
+      --change-url {{ ansible_test_splitter__change_url }}
 
-    - name: Create virtual env with required libraries
-      pip:
-        name:
-          - PyGithub
-          - PyYAML
-        virtualenv: "{{ venv_path }}"
-        virtualenv_command: "virtualenv --python python3"
-        virtualenv_site_packages: true
+- name: Will split up the jobs with the following command
+  debug:
+    msg: "{{ splitter_cmd }}"
 
-    - copy:
-        src: list_changed_targets.py
-        dest: "{{ executable_path }}"
-        mode: '0700'
+- name: Split up the workload
+  command: "{{ splitter_cmd }}"
+  register: _result
 
-    - set_fact:
-        splitter_cmd: >
-          {{ venv_path }}/bin/python {{ executable_path }}
-          --branch {{ zuul.branch }}
-          {% if ansible_test_splitter__releases_to_test is defined %}--ansible-releases {{ ansible_test_splitter__releases_to_test | join(' ') }}{% endif %}
-          {% if ansible_test_splitter__total_job is defined %}--total-job {{ ansible_test_splitter__total_job }}{% endif %}
-          {% if ansible_test_splitter__test_changed|bool %}--test-changed{% else %}--test-all-the-targets{% endif %}
-          {{ ansible_test_splitter__check_for_changes_in | join(' ') }}
-          --github_project_name {{ ansible_test_splitter__project_name }}
-          --github_pull_request_number {{ ansible_test_splitter__pull_request }}
+- set_fact:
+    for_zuul_return: '{{ _result.stdout | from_json }}'
 
-    - name: Will split up the jobs with the following command
-      debug:
-        msg: "{{ splitter_cmd }}"
+- debug: var=for_zuul_return
 
-    - name: Split up the workload
-      command: "{{ splitter_cmd }}"
-      register: _result
-
-    - set_fact:
-        for_zuul_return: '{{ _result.stdout | from_json }}'
-
-    - debug: var=for_zuul_return
-
-    - name: Return the result to Zuul
-      zuul_return:
-        data: "{{ for_zuul_return.data }}"
-
-  always:
-    - name: Delete temporary file
-      file:
-        state: absent
-        path: "{{ _result.path }}"
-      ignore_errors: true
+- name: Return the result to Zuul
+  zuul_return:
+    data: "{{ for_zuul_return.data }}"

--- a/roles/ansible-test-splitter/tasks/main.yaml
+++ b/roles/ansible-test-splitter/tasks/main.yaml
@@ -1,31 +1,58 @@
 ---
-- copy:
-    src: list_changed_targets.py
-    dest: /tmp/list_changed_targets.py
-    mode: '0700'
+- block:
+    - name: Create temporary directory for tests
+      tempfile:
+        state: directory
+        suffix: .splitter
+      register: _result
 
-- set_fact:
-    splitter_cmd: >
-      python3 /tmp/list_changed_targets.py
-      --branch {{ zuul.branch }}
-      {% if ansible_test_splitter__releases_to_test is defined %}--ansible-releases {{ ansible_test_splitter__releases_to_test | join(' ') }}{% endif %}
-      {% if ansible_test_splitter__total_job is defined %}--total-job {{ ansible_test_splitter__total_job }}{% endif %}
-      {% if ansible_test_splitter__test_changed|bool %}--test-changed{% else %}--test-all-the-targets{% endif %}
-      {{ ansible_test_splitter__check_for_changes_in | join(' ') }}
+    - set_fact:
+        venv_path: "{{ _result.path }}/env"
+        executable_path: "{{ _result.path }}/list_changed_targets.py"
 
-- name: Will split up the jobs with the following command
-  debug:
-    msg: "{{ splitter_cmd }}"
+    - name: Create virtual env with required libraries
+      pip:
+        name:
+          - PyGithub
+        virtualenv: "{{ venv_path }}"
+        virtualenv_command: "virtualenv --python python3"
 
-- name: Split up the workload
-  command: "{{ splitter_cmd }}"
-  register: _result
+    - copy:
+        src: list_changed_targets.py
+        dest: "{{ executable_path }}"
+        mode: '0700'
 
-- set_fact:
-    for_zuul_return: '{{ _result.stdout | from_json }}'
+    - set_fact:
+        splitter_cmd: >
+          {{ venv_path }}/bin/python {{ executable_path }}
+          --branch {{ zuul.branch }}
+          {% if ansible_test_splitter__releases_to_test is defined %}--ansible-releases {{ ansible_test_splitter__releases_to_test | join(' ') }}{% endif %}
+          {% if ansible_test_splitter__total_job is defined %}--total-job {{ ansible_test_splitter__total_job }}{% endif %}
+          {% if ansible_test_splitter__test_changed|bool %}--test-changed{% else %}--test-all-the-targets{% endif %}
+          {{ ansible_test_splitter__check_for_changes_in | join(' ') }}
+          --github_project_name {{ ansible_test_splitter__project_name }}
+          --github_pull_request_number {{ ansible_test_splitter__pull_request }}
 
-- debug: var=for_zuul_return
+    - name: Will split up the jobs with the following command
+      debug:
+        msg: "{{ splitter_cmd }}"
 
-- name: Return the result to Zuul
-  zuul_return:
-    data: "{{ for_zuul_return.data }}"
+    - name: Split up the workload
+      command: "{{ splitter_cmd }}"
+      register: _result
+
+    - set_fact:
+        for_zuul_return: '{{ _result.stdout | from_json }}'
+
+    - debug: var=for_zuul_return
+
+    - name: Return the result to Zuul
+      zuul_return:
+        data: "{{ for_zuul_return.data }}"
+
+  always:
+    - name: Delete temporary file
+      file:
+        state: absent
+        path: "{{ _result.path }}"
+      ignore_errors: true

--- a/roles/ansible-test-splitter/tasks/main.yaml
+++ b/roles/ansible-test-splitter/tasks/main.yaml
@@ -14,8 +14,11 @@
       pip:
         name:
           - PyGithub
+          - PyYAML
+          - AST
         virtualenv: "{{ venv_path }}"
         virtualenv_command: "virtualenv --python python3"
+        virtualenv_site_packages: true
 
     - copy:
         src: list_changed_targets.py

--- a/roles/ansible-test-splitter/tasks/main.yaml
+++ b/roles/ansible-test-splitter/tasks/main.yaml
@@ -12,7 +12,8 @@
       {% if ansible_test_splitter__total_job is defined %}--total-job {{ ansible_test_splitter__total_job }}{% endif %}
       {% if ansible_test_splitter__test_changed|bool %}--test-changed{% else %}--test-all-the-targets{% endif %}
       {{ ansible_test_splitter__check_for_changes_in | join(' ') }}
-      --change-url {{ ansible_test_splitter__change_url }}
+      --project-name {{ ansible_test_splitter__project_name }}
+      --pull-request {{ ansible_test_splitter__pull_request }}
 
 - name: Will split up the jobs with the following command
   debug:

--- a/roles/ansible-test-splitter/tasks/main.yaml
+++ b/roles/ansible-test-splitter/tasks/main.yaml
@@ -15,7 +15,6 @@
         name:
           - PyGithub
           - PyYAML
-          - AST
         virtualenv: "{{ venv_path }}"
         virtualenv_command: "virtualenv --python python3"
         virtualenv_site_packages: true

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 alembic<1.5.0
 jxmlease
 ncclient
+requests

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
 alembic<1.5.0
 jxmlease
 ncclient
-requests

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ deps =
   pytest
   testtools
   pyyaml
+  requests
 commands = pytest {posargs}
 
 [testenv:black]

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -215,7 +215,8 @@
     timeout: 1000
     vars:
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
-      ansible_test_splitter__change_url: "{{ zuul.change_url }}"
+      ansible_test_splitter__project_name: "{{ zuul.project.name }}"
+      ansible_test_splitter__pull_request: "{{ zuul.change | int }}"
 
 - semaphore:
     name: ansible-test-cloud-integration-aws

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -215,8 +215,7 @@
     timeout: 1000
     vars:
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
-      ansible_test_splitter__project_name: "{{ zuul.project.name }}"
-      ansible_test_splitter__pull_request: "{{ zuul.change | int }}"
+      ansible_test_splitter__change_url: "{{ zuul.change_url }}"
 
 - semaphore:
     name: ansible-test-cloud-integration-aws

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -215,6 +215,8 @@
     timeout: 1000
     vars:
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
+      ansible_test_splitter__project_name: "{{ zuul.project.name }}"
+      ansible_test_splitter__pull_request: "{{ zuul.change | int }}"
 
 - semaphore:
     name: ansible-test-cloud-integration-aws


### PR DESCRIPTION
For the collection using the `ansible-test-splitter` role, users can add the following line in the pull request description

#### Define list of ansible release to test
Zuul-Releases: 2.9 devel
#### Define list of extra targets to include to ansible-test
Zuul-Extra-Targets: target1 target2 target3
#### Define list of targets for ansible-test
Zuul-Targets: target1