### PR TITLE
Make ansible-test-sanity-docker-stable-2.14 voting again

### DIFF
--- a/zuul.d/ansible-test-jobs.yaml
+++ b/zuul.d/ansible-test-jobs.yaml
@@ -88,4 +88,3 @@
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.14
-    voting: false


### PR DESCRIPTION
Undoing #1644 because it looks like ansible/ansible#79201 fixed ansible/ansible#78882.

See [here](https://github.com/ansible-collections/community.vmware/pull/1512#issuecomment-1290358645) for an example where the CI job succeeded.