### PR TITLE
Skip all 'indirect' targets if they're in an ignored category

### DIFF
--- a/roles/ansible-test-splitter/files/list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/list_changed_targets.py
@@ -295,10 +295,13 @@ class Collection:
                 return True
         return False
 
-    def add_target_to_plan(self, target_name):
+    def add_target_to_plan(self, target_name, is_direct=True):
         if not self._is_target_already_added(target_name):
             for t in self._targets():
                 if t.is_disabled():
+                    continue
+                # For indirect targets we want to skip "ignored" tests
+                if not is_direct and t.is_ignored():
                     continue
                 if t.is_alias_of(target_name):
                     self._my_test_plan.append(t)
@@ -306,9 +309,7 @@ class Collection:
     def cover_all(self):
         """Cover all the targets available."""
         for t in self._targets():
-            if t.is_ignored():
-                continue
-            self.add_target_to_plan(t.name)
+            self.add_target_to_plan(t.name, is_direct=False)
 
     def cover_module_utils(self, pymod, collections_names):
         """Track the targets to run follow up to a module_utils changed."""
@@ -326,7 +327,7 @@ class Collection:
         for mod in self.modules_import:
             intersect = [x for x in u_candidates if x in self.modules_import.get(mod)]
             if intersect:
-                self.add_target_to_plan(mod)
+                self.add_target_to_plan(mod, is_direct=False)
 
     def slow_targets_to_test(self):
         return sorted(list(set([t.name for t in self._my_test_plan if t.is_slow()])))

--- a/roles/ansible-test-splitter/files/test_list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/test_list_changed_targets.py
@@ -151,7 +151,10 @@ def test_c_disabled_unstable():
     # if the module is targets, we continue to ignore the disabled
     c.add_target_to_plan("a")
     assert len(c.regular_targets_to_test()) == 0
-    # but the unstable is ok
+    # unstable targets should not be triggered if they were pulled in as a dependency
+    c.add_target_to_plan("b", is_direct=False)
+    assert len(c.regular_targets_to_test()) == 0
+    # but the unstable is ok when directly triggered
     c.add_target_to_plan("b")
     assert len(c.regular_targets_to_test()) == 1
 


### PR DESCRIPTION
When making changes to module_utils we can trigger large numbers of integration tests.

If we wouldn't run the tests during a "test all" scenario we shouldn't trigger the tests just because they depend on something in module_utils