### PR TITLE
Revert "add the possibility to define extra tests for ansible-test-splitter (#1662)"

### DIFF
--- a/roles/ansible-test-splitter/tasks/main.yaml
+++ b/roles/ansible-test-splitter/tasks/main.yaml
@@ -12,8 +12,6 @@
       {% if ansible_test_splitter__total_job is defined %}--total-job {{ ansible_test_splitter__total_job }}{% endif %}
       {% if ansible_test_splitter__test_changed|bool %}--test-changed{% else %}--test-all-the-targets{% endif %}
       {{ ansible_test_splitter__check_for_changes_in | join(' ') }}
-      --project-name {{ ansible_test_splitter__project_name }}
-      --pull-request {{ ansible_test_splitter__pull_request }}
 
 - name: Will split up the jobs with the following command
   debug:

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,6 @@ deps =
   pytest
   testtools
   pyyaml
-  requests
 commands = pytest {posargs}
 
 [testenv:black]

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -215,8 +215,6 @@
     timeout: 1000
     vars:
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
-      ansible_test_splitter__project_name: "{{ zuul.project.name }}"
-      ansible_test_splitter__pull_request: "{{ zuul.change | int }}"
 
 - semaphore:
     name: ansible-test-cloud-integration-aws


### PR DESCRIPTION
There is actually a problem with https://github.com/ansible/ansible-zuul-jobs/pull/1662. Thanks Mark Chappell.

```
2022-11-03 14:51:05.154291 | TASK [ansible-test-splitter : Split up the workload]
2022-11-03 14:51:08.745115 | controller | Traceback (most recent call last):
2022-11-03 14:51:08.745463 | controller |   File "/tmp/list_changed_targets.py", line 470, in <module>
2022-11-03 14:51:08.745498 | controller |     pr_request = read_pullrequest_zuul_override(
2022-11-03 14:51:08.745510 | controller |   File "/tmp/list_changed_targets.py", line 445, in read_pullrequest_zuul_override
2022-11-03 14:51:08.745523 | controller |     desc = read_pullrequest_body(project_name, pull_request)
2022-11-03 14:51:08.745534 | controller |   File "/tmp/list_changed_targets.py", line 435, in read_pullrequest_body
2022-11-03 14:51:08.745663 | controller |     return [x for x in requests.get(change_url).json().get("body").split("\n") if x]
2022-11-03 14:51:08.745682 | controller | AttributeError: 'NoneType' object has no attribute 'split'
2022-11-03 14:51:09.036429 | controller | ERROR
2022-11-03 14:51:09.036580 | controller | {
2022-11-03 14:51:09.036615 | controller |   "delta": "0:00:01.521214",
2022-11-03 14:51:09.036642 | controller |   "end": "2022-11-03 14:51:08.764549",
2022-11-03 14:51:09.036666 | controller |   "msg": "non-zero return code",
2022-11-03 14:51:09.036690 | controller |   "rc": 1,
2022-11-03 14:51:09.036713 | controller |   "start": "2022-11-03 14:51:07.243335"
2022-11-03 14:51:09.036736 | controller | }
2022-11-03 14:51:09.047045 |
```

This reverts commit 45caf41b291f54fa8c76b5d489e163f7850ad1b6.
