### PR TITLE
amazon-aws-periodical-jobs: properly configure build-ansible-collection

### DIFF
--- a/zuul.d/amazon-aws-periodical-jobs.yaml
+++ b/zuul.d/amazon-aws-periodical-jobs.yaml
@@ -508,7 +508,13 @@
     name: ansible-collections-amazon-aws-each-target
     periodic:
       jobs:
-        - build-ansible-collection
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-collections/ansible.utils
+              - name: github.com/ansible-collections/ansible.netcommon
+              - name: github.com/ansible-collections/community.aws
+              - name: github.com/ansible-collections/community.general
+              - name: github.com/ansible-collections/community.crypto
         - integration-amazon.aws-target-aws_caller_info
         - integration-amazon.aws-target-cloudformation
         - integration-amazon.aws-target-ec2_ami


### PR DESCRIPTION
We need to list the `required-projects` when we include `build-ansible-collection`.
