### PR TITLE
add empty ansible-collections-{amazon,community}-aws-integration templates

### DIFF
--- a/zuul.d/aws-integration-worker-jobs.yaml
+++ b/zuul.d/aws-integration-worker-jobs.yaml
@@ -1,0 +1,17 @@
+---
+- project-template:
+    name: ansible-collections-amazon-aws-integration
+    check:
+      jobs:
+        - noop
+    gate:
+      jobs:
+        - noop
+- project-template:
+    name: ansible-collections-community-aws-integration
+    check:
+      jobs:
+        - noop
+    gate:
+      jobs:
+        - noop


### PR DESCRIPTION
This to be able to enable them in the zuul-config.
