### PR TITLE
Make ansible-test-sanity-docker-milestone non-voting

### DIFF
--- a/zuul.d/ansible-test-jobs.yaml
+++ b/zuul.d/ansible-test-jobs.yaml
@@ -40,6 +40,7 @@
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: milestone
+    voting: false
 
 - job:
     name: ansible-test-sanity-docker-stable-2.9


### PR DESCRIPTION
I see failures with the current milestone branch when running sanity tests. So I think we should make the CI job non-voting temporarily.

ansible/ansible#79329