### PR TITLE
Turn devel and milestone sanity tests non-voting for c.v.

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -622,8 +622,10 @@
             required-projects:
               - name: github.com/ansible-collections/vmware.vmware_rest
               - name: github.com/ansible-collections/cloud.common
-        - ansible-test-sanity-docker-devel
-        - ansible-test-sanity-docker-milestone
+        - ansible-test-sanity-docker-devel:
+            voting: false
+        - ansible-test-sanity-docker-milestone:
+            voting: false
         - ansible-test-sanity-docker-stable-2.13
         - ansible-test-sanity-docker-stable-2.14
         - ansible-test-units-community-vmware-python38


### PR DESCRIPTION
I'd like to turn the sanity tests in community.vmware for both the devel and milestone branch to non-voting. This way, we see (potential) future problems but they don't stop us from merging PRs.

ansible/ansible#78882
ansible/ansible#79329