### PR TITLE
aws: fix the relationship with the ansible-test-splitter job

### DIFF
--- a/tools/zuul-ansible-manager.py
+++ b/tools/zuul-ansible-manager.py
@@ -319,7 +319,6 @@ class AWSWorkerJob(Job):
     nodeset = NodesetName(__root__="fedora-36-1vcpu")
     dependencies: list[JobDependency] = [
         JobDependency(name="build-ansible-collection"),
-        JobDependency(name="ansible-test-splitter", soft=True),
     ]
     pre_run: ZuulMaybeList = Field(
         [
@@ -377,6 +376,7 @@ def build_aws_worker(collection: str, idx: int) -> Job:
         collection=collection,
         target="{{ child.targets_to_test[zuul.job] }}",
     )
+    new.dependencies.append(JobDependency(name="ansible-test-splitter"))
     return new
 
 

--- a/zuul.d/amazon-aws-periodical-jobs.yaml
+++ b/zuul.d/amazon-aws-periodical-jobs.yaml
@@ -6,8 +6,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -41,8 +39,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -76,8 +72,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -111,8 +105,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -146,8 +138,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -181,8 +171,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -216,8 +204,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -251,8 +237,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -286,8 +270,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -321,8 +303,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -356,8 +336,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -391,8 +369,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -426,8 +402,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -461,8 +435,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -496,8 +468,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -531,8 +501,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -566,8 +534,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -601,8 +567,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -636,8 +600,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -671,8 +633,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -706,8 +666,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -741,8 +699,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -776,8 +732,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -811,8 +765,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -846,8 +798,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -881,8 +831,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -916,8 +864,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -951,8 +897,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -986,8 +930,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1021,8 +963,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1056,8 +996,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1091,8 +1029,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1126,8 +1062,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1161,8 +1095,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1196,8 +1128,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1231,8 +1161,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1266,8 +1194,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1301,8 +1227,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1336,8 +1260,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1371,8 +1293,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1406,8 +1326,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1441,8 +1359,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1476,8 +1392,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1511,8 +1425,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1546,8 +1458,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1581,8 +1491,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1616,8 +1524,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1651,8 +1557,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1686,8 +1590,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1721,8 +1623,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1756,8 +1656,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1791,8 +1689,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1826,8 +1722,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1861,8 +1755,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1896,8 +1788,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1931,8 +1821,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1966,8 +1854,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2001,8 +1887,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2036,8 +1920,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2071,8 +1953,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2106,8 +1986,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2141,8 +2019,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2176,8 +2052,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2211,8 +2085,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2246,8 +2118,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2281,8 +2151,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2316,8 +2184,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2351,8 +2217,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2386,8 +2250,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2421,8 +2283,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2456,8 +2316,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2491,8 +2349,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2526,8 +2382,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2561,8 +2415,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2596,8 +2448,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2631,8 +2481,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2666,8 +2514,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2701,8 +2547,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2736,8 +2580,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2771,8 +2613,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2806,8 +2646,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2841,8 +2679,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2876,8 +2712,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2911,8 +2745,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -2946,8 +2778,6 @@
     nodeset: container-ansible
     dependencies:
       - name: build-ansible-collection
-      - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml

--- a/zuul.d/aws-integration-worker-jobs.yaml
+++ b/zuul.d/aws-integration-worker-jobs.yaml
@@ -7,7 +7,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -42,7 +41,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -77,7 +75,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -112,7 +109,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -147,7 +143,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -182,7 +177,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -217,7 +211,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -252,7 +245,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -287,7 +279,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -322,7 +313,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -357,7 +347,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -392,7 +381,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -427,7 +415,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -462,7 +449,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -497,7 +483,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -532,7 +517,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -567,7 +551,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -602,7 +585,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -637,7 +619,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -672,7 +653,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -707,7 +687,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -742,7 +721,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -777,7 +755,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -812,7 +789,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -847,7 +823,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -882,7 +857,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -917,7 +891,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -952,7 +925,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -987,7 +959,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1022,7 +993,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1057,7 +1027,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1092,7 +1061,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1127,7 +1095,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1162,7 +1129,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1197,7 +1163,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1232,7 +1197,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1267,7 +1231,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1302,7 +1265,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1337,7 +1299,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1372,7 +1333,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1407,7 +1367,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1442,7 +1401,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1477,7 +1435,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml
@@ -1512,7 +1469,6 @@
     dependencies:
       - name: build-ansible-collection
       - name: ansible-test-splitter
-        soft: true
     pre-run:
       - playbooks/ansible-test-base/pre.yaml
       - playbooks/ansible-cloud/aws/pre.yaml


### PR DESCRIPTION
- regular jobs need the ansible-test-splitter and not with just `soft=True`
  or the jobs start to early.
- perdiodical jobs don't need ansible-test-splitter
