### PR TITLE
also disable ansible-test-units-gouttelette-python39

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1548,7 +1548,6 @@
     name: ansible-collections-cloud-gouttelette-units
     check:
       jobs: &ansible-collections-cloud-gouttelette-units-jobs
-        - ansible-test-units-gouttelette-python39
         - cloud-tox-py3
         - ansible-test-changelog
     gate:


### PR DESCRIPTION
It also depends on build-ansible-collection.
