### PR TITLE
turns tox-cloud-generate-amazon non-voting

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -663,6 +663,7 @@
       - name: github.com/ansible-collections/amazon_cloud_code_generator
       - name: github.com/ansible-collections/gouttelette
     nodeset: container-ansible
+    voting: false
     vars:
       tox_envlist: generate
       zuul_work_dir: "~/{{ zuul.projects['github.com/ansible-collections/amazon_cloud_code_generator'].src_dir }}"


### PR DESCRIPTION
This the time we merge the following PR:

- https://github.com/ansible-collections/amazon_cloud_code_generator/pull/54
- https://github.com/ansible-collections/amazon_cloud_code_generator/pull/55
