### PR TITLE
amazon.cloud: turn ansible-test-sanity-docker-stable-2.11 non-voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -121,7 +121,8 @@
       jobs: &ansible-collections-amazon-cloud-jobs
         - ansible-test-sanity-docker-devel
         - ansible-test-sanity-docker-milestone
-        - ansible-test-sanity-docker-stable-2.11
+        - ansible-test-sanity-docker-stable-2.11:
+            voting: false
         - ansible-test-sanity-docker-stable-2.12
         - ansible-test-integration-amazon-cloud
         - build-ansible-collection:


### PR DESCRIPTION
We've got several failing jobs at the same time. Let's turn this
one off for now to reduce the burden.
