### PR TITLE
Make gouttelette cloud-tox-mypy job non voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1556,7 +1556,9 @@
     check:
       jobs: &ansible-collections-cloud-gouttelette-units-jobs
         - cloud-tox-py3
-        - cloud-tox-mypy
+        - cloud-tox-mypy:
+            # Nonvoting until the type hinting errors on the migrated code are fixed
+            voting: false
         - ansible-test-changelog
         - tox-cloud-generate-vmware
         - tox-cloud-generate-amazon


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

Making gouttelette cloud-tox-mypy job as non voting, until the typehint errors on the migrated code are fixed.