### PR TITLE
vmware_rest_code_gen: only test with py39+

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -502,7 +502,6 @@
               - name: github.com/ansible-collections/cloud.common
               - name: github.com/ansible-collections/community.vmware
         - tox-cloud-generate-vmware
-        - ansible-tox-py38
         - ansible-tox-py39
     gate:
       jobs:
@@ -513,7 +512,6 @@
               - name: github.com/ansible-collections/cloud.common
               - name: github.com/ansible-collections/community.vmware
         - tox-cloud-generate-vmware
-        - ansible-tox-py38
         - ansible-tox-py39
 
 - project-template:


### PR DESCRIPTION
gouttelette doesn't support py38.
