### PR TITLE
tox-cloud-{generate,refresh-examples}-{amazon,vmware}: define tox_package_name

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -651,6 +651,7 @@
     nodeset: container-ansible
     vars:
       tox_envlist: generate
+      tox_package_name: amazon_cloud_code_generator
       zuul_work_dir: "~/{{ zuul.projects['github.com/ansible-collections/vmware_rest_code_generator'].src_dir }}"
 
 - job:
@@ -665,6 +666,7 @@
     nodeset: container-ansible
     vars:
       tox_envlist: generate
+      tox_package_name: amazon_cloud_code_generator
       zuul_work_dir: "~/{{ zuul.projects['github.com/ansible-collections/amazon_cloud_code_generator'].src_dir }}"
 
 ### Pravic
@@ -689,6 +691,7 @@
     nodeset: container-ansible
     vars:
       tox_envlist: refresh-examples
+      tox_package_name: vmware_rest
       zuul_work_dir: "~/{{ zuul.projects['github.com/ansible-collections/vmware.vmware_rest'].src_dir }}"
 
 - job:
@@ -702,4 +705,5 @@
     nodeset: container-ansible
     vars:
       tox_envlist: refresh-examples
+      tox_package_name: amazon_cloud
       zuul_work_dir: "~/{{ zuul.projects['github.com/ansible-collections/amazon.cloud'].src_dir }}"


### PR DESCRIPTION
Since these projects are not regular Python project (no setup.cfg),
we need to define their name through the `tox_package_name` parameter.

See: https://zuul-ci.org/docs/zuul-jobs/python-roles.html#rolevar-tox.tox_package_name
