### PR TITLE
Fix reversal of dependency chain for module_utils

### DIFF
--- a/roles/ansible-test-splitter/files/list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/list_changed_targets.py
@@ -153,8 +153,8 @@ def build_import_tree(collection_path, collection_name, collections_names):
                 + ".py"
             )
             for i in list_pyimport(prefix, utils_path.read_text()):
-                if i.startswith(prefix) and utils not in utils_import[i]:
-                    utils_import[i].append(utils)
+                if i.startswith(prefix) and i not in utils_import[utils]:
+                    utils_import[utils].append(i)
                     if i not in visited:
                         utils_to_visit.append(i)
         except:


### PR DESCRIPTION
The module_utils dependency chain is currently being built backwards.

For example:
https://ansible.softwarefactory-project.io/zuul/build/f64d502af3f44ed98b90029c0f685263/logs

```
2023-01-02 21:30:11.948985 | controller |         "utils": {
2023-01-02 21:30:11.949037 | controller |           "ansible_collections.amazon.aws.plugins.module_utils.botocore": [
2023-01-02 21:30:11.949086 | controller |             "ansible_collections.amazon.aws.plugins.module_utils.s3"
2023-01-02 21:30:11.949133 | controller |           ],
2023-01-02 21:30:11.949180 | controller |           "ansible_collections.amazon.aws.plugins.module_utils.core": [
2023-01-02 21:30:11.949226 | controller |             "ansible_collections.amazon.aws.plugins.module_utils.route53"
2023-01-02 21:30:11.949273 | controller |           ],
2023-01-02 21:30:11.949321 | controller |           "ansible_collections.amazon.aws.plugins.module_utils.retries": [
2023-01-02 21:30:11.949367 | controller |             "ansible_collections.amazon.aws.plugins.module_utils.waiters"
2023-01-02 21:30:11.949414 | controller |           ],
2023-01-02 21:30:11.949460 | controller |           "ansible_collections.amazon.aws.plugins.module_utils.tagging": [
2023-01-02 21:30:11.949546 | controller |             "ansible_collections.amazon.aws.plugins.module_utils.route53"
2023-01-02 21:30:11.949603 | controller |           ]
2023-01-02 21:30:11.949657 | controller |         }
```

In reality `module_utils.s3` depends on `module_utils.botocore`.  However, this is being recorded as `module_utils.botocore` depending on `module_utils.s3`.  As a result, changes to `module_utils.s3` are triggering integration tests for everything that depends on `module_utils.botocore`(which are unnecessary), but changes to `module_utils.botocore` aren't triggering the tests for things which depend on `module_utils.s3` (when they should)

There's a separate bug which means that relative imports aren't being properly handled within module_utils.  I have a separate patch and I'll push a separate PR once this reversal is fixed.