### PR TITLE
Drop new sanity tests against old stable-X AWS branches

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -362,6 +362,11 @@
       ansible_test_sanity_skiptests:
         - 'future-import-boilerplate'
         - 'metaclass-boilerplate'
+    branches:
+      - stable-3
+      - stable-4
+      - stable-5
+      - main
 
 - job:
     name: ansible-test-sanity-aws-ansible-2.13-python38
@@ -370,6 +375,10 @@
       ansible_test_sanity_skiptests:
         - 'future-import-boilerplate'
         - 'metaclass-boilerplate'
+    branches:
+      - stable-4
+      - stable-5
+      - main
 
 - job:
     name: ansible-test-sanity-aws-ansible-2.14
@@ -378,6 +387,9 @@
       ansible_test_sanity_skiptests:
         - 'future-import-boilerplate'
         - 'metaclass-boilerplate'
+    branches:
+      - stable-5
+      - main
 
 ### Cloud Common
 - job:


### PR DESCRIPTION
Drop the latest sanity tests running against older stable-X branches.  Sanity test fixes generally aren't fixing significant bugs/security issues.  By running the latest sanity tests against old branches we make it harder to backport the real bug/security fixes.  For example backporting https://github.com/ansible-collections/amazon.aws/pull/1210 for stable-3 is currently blocked by a pile of documentation linting issues.