### PR TITLE
Add ansible.windows as a dependency for the community.aws tests

### DIFF
--- a/zuul.d/aws-integration-worker-jobs.yaml
+++ b/zuul.d/aws-integration-worker-jobs.yaml
@@ -1728,6 +1728,7 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/ansible.utils
+              - name: github.com/ansible-collections/ansible.windows
               - name: github.com/ansible-collections/amazon.aws
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/community.aws


### PR DESCRIPTION
The aws_ssm connection plugin depends on ansible.windows to test connections to Windows instances

https://github.com/ansible-collections/community.aws/pull/1670