### PR TITLE
community.vmware: Enable fail-fast

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -556,6 +556,7 @@
 - project-template:
     name: ansible-collections-community-vmware
     check:
+      fail-fast: true
       jobs:
         - ansible-tox-linters
         - build-ansible-collection:


### PR DESCRIPTION
The integration tests for community.vmware sometimes fail for no obvious reason. That is, not because there's something wrong with the code but because of a network issue or something. But even if one of the jobs fails, the others still keep running.

This means that even if a voting test job fails, another one might run for hours because of retries. But the CI still fails as a whole.

I think the CI pipeline should fail immediately in this case. This would both give us a quicker response and save resources.