### PR TITLE
refresh the amazon.aws configuration

### DIFF
--- a/tools/zuul-ansible-manager.py
+++ b/tools/zuul-ansible-manager.py
@@ -291,6 +291,7 @@ def aws_periodical_jobs(amazon_aws_repo_dir: Path) -> None:
                     name="github.com/ansible-collections/community.general"
                 ),
                 RequiredProject(name="github.com/ansible-collections/community.crypto"),
+                RequiredProject(name="github.com/ansible-collections/ansible.windows"),
             ]
         }
     }
@@ -302,7 +303,6 @@ def aws_periodical_jobs(amazon_aws_repo_dir: Path) -> None:
         #  dependency list
         periodic=Queue(
             jobs=[build_ansible_collection] + [job.job.name for job in jobs],
-            queue="integrated-aws",
         ),
     )
 
@@ -401,6 +401,7 @@ def aws_integration_jobs(number_of_workers: int):
                     name="github.com/ansible-collections/community.general"
                 ),
                 RequiredProject(name="github.com/ansible-collections/community.crypto"),
+                RequiredProject(name="github.com/ansible-collections/ansible.windows"),
             ]
         }
     }
@@ -438,7 +439,6 @@ def aws_integration_jobs(number_of_workers: int):
                 ansible_test_splitter(collections=["community.aws", "amazon.aws"]),
             ]
             + [job.name for job in worker_jobs],
-            queue="integrated-aws",
         ),
         gate=Queue(
             jobs=[
@@ -446,7 +446,6 @@ def aws_integration_jobs(number_of_workers: int):
                 ansible_test_splitter(collections=["community.aws", "amazon.aws"]),
             ]
             + [job.name for job in worker_jobs],
-            queue="integrated-aws",
         ),
         ondemand=Queue(
             jobs=[
@@ -456,7 +455,6 @@ def aws_integration_jobs(number_of_workers: int):
                 ),
             ]
             + [job.name for job in worker_jobs],
-            queue="integrated-aws",
         ),
     )
 
@@ -471,7 +469,6 @@ def aws_integration_jobs(number_of_workers: int):
                 ansible_test_splitter(collections=["community.aws", "amazon.aws"]),
             ]
             + [job.name for job in community_aws_workder_jobs],
-            queue="integrated-aws",
         ),
         gate=Queue(
             jobs=[
@@ -479,7 +476,6 @@ def aws_integration_jobs(number_of_workers: int):
                 ansible_test_splitter(collections=["community.aws", "amazon.aws"]),
             ]
             + [job.name for job in community_aws_workder_jobs],
-            queue="integrated-aws",
         ),
         ondemand=Queue(
             jobs=[
@@ -489,7 +485,6 @@ def aws_integration_jobs(number_of_workers: int):
                 ),
             ]
             + [job.name for job in community_aws_workder_jobs],
-            queue="integrated-aws",
         ),
     )
     zuul_config = MappingList(

--- a/zuul.d/amazon-aws-periodical-jobs.yaml
+++ b/zuul.d/amazon-aws-periodical-jobs.yaml
@@ -265,7 +265,7 @@
     extra-vars: {}
     semaphore: ansible-test-cloud-integration-aws
 - job:
-    name: integration-amazon.aws-target-ec2_ami
+    name: integration-amazon.aws-target-ec2_ami_instance
     parent: ansible-core-ci-aws-session
     nodeset: container-ansible
     dependencies:
@@ -293,7 +293,73 @@
         - tests/integration/requirements.txt
       ansible_test_constraint_files:
         - tests/integration/constraints.txt
-      ansible_test_integration_targets: ec2_ami
+      ansible_test_integration_targets: ec2_ami_instance
+      ansible_collections_repo: github.com/ansible-collections/amazon.aws
+    extra-vars: {}
+    semaphore: ansible-test-cloud-integration-aws
+- job:
+    name: integration-amazon.aws-target-ec2_ami_snapshot
+    parent: ansible-core-ci-aws-session
+    nodeset: container-ansible
+    dependencies:
+      - name: build-ansible-collection
+    pre-run:
+      - playbooks/ansible-test-base/pre.yaml
+      - playbooks/ansible-cloud/aws/pre.yaml
+    run: playbooks/ansible-test-base/run.yaml
+    files:
+      - ^plugins/.*$
+      - ^tests/integration/.*$
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: milestone
+      - name: github.com/ansible-collections/community.aws
+    timeout: 3600
+    host-vars: {}
+    vars:
+      ansible_test_command: integration
+      ansible_test_python: 3.9
+      ansible_test_retry_on_error: true
+      ansible_test_requirement_files:
+        - requirements.txt
+        - test-requirements.txt
+        - tests/integration/requirements.txt
+      ansible_test_constraint_files:
+        - tests/integration/constraints.txt
+      ansible_test_integration_targets: ec2_ami_snapshot
+      ansible_collections_repo: github.com/ansible-collections/amazon.aws
+    extra-vars: {}
+    semaphore: ansible-test-cloud-integration-aws
+- job:
+    name: integration-amazon.aws-target-ec2_ami_tpm
+    parent: ansible-core-ci-aws-session
+    nodeset: container-ansible
+    dependencies:
+      - name: build-ansible-collection
+    pre-run:
+      - playbooks/ansible-test-base/pre.yaml
+      - playbooks/ansible-cloud/aws/pre.yaml
+    run: playbooks/ansible-test-base/run.yaml
+    files:
+      - ^plugins/.*$
+      - ^tests/integration/.*$
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: milestone
+      - name: github.com/ansible-collections/community.aws
+    timeout: 3600
+    host-vars: {}
+    vars:
+      ansible_test_command: integration
+      ansible_test_python: 3.9
+      ansible_test_retry_on_error: true
+      ansible_test_requirement_files:
+        - requirements.txt
+        - test-requirements.txt
+        - tests/integration/requirements.txt
+      ansible_test_constraint_files:
+        - tests/integration/constraints.txt
+      ansible_test_integration_targets: ec2_ami_tpm
       ansible_collections_repo: github.com/ansible-collections/amazon.aws
     extra-vars: {}
     semaphore: ansible-test-cloud-integration-aws
@@ -1651,6 +1717,39 @@
     extra-vars: {}
     semaphore: ansible-test-cloud-integration-aws
 - job:
+    name: integration-amazon.aws-target-lambda_event
+    parent: ansible-core-ci-aws-session
+    nodeset: container-ansible
+    dependencies:
+      - name: build-ansible-collection
+    pre-run:
+      - playbooks/ansible-test-base/pre.yaml
+      - playbooks/ansible-cloud/aws/pre.yaml
+    run: playbooks/ansible-test-base/run.yaml
+    files:
+      - ^plugins/.*$
+      - ^tests/integration/.*$
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: milestone
+      - name: github.com/ansible-collections/community.aws
+    timeout: 3600
+    host-vars: {}
+    vars:
+      ansible_test_command: integration
+      ansible_test_python: 3.9
+      ansible_test_retry_on_error: true
+      ansible_test_requirement_files:
+        - requirements.txt
+        - test-requirements.txt
+        - tests/integration/requirements.txt
+      ansible_test_constraint_files:
+        - tests/integration/constraints.txt
+      ansible_test_integration_targets: lambda_event
+      ansible_collections_repo: github.com/ansible-collections/amazon.aws
+    extra-vars: {}
+    semaphore: ansible-test-cloud-integration-aws
+- job:
     name: integration-amazon.aws-target-lambda_layer
     parent: ansible-core-ci-aws-session
     nodeset: container-ansible
@@ -1746,6 +1845,39 @@
       ansible_test_constraint_files:
         - tests/integration/constraints.txt
       ansible_test_integration_targets: lookup_aws_account_attribute
+      ansible_collections_repo: github.com/ansible-collections/amazon.aws
+    extra-vars: {}
+    semaphore: ansible-test-cloud-integration-aws
+- job:
+    name: integration-amazon.aws-target-lookup_aws_collection_constants
+    parent: ansible-core-ci-aws-session
+    nodeset: container-ansible
+    dependencies:
+      - name: build-ansible-collection
+    pre-run:
+      - playbooks/ansible-test-base/pre.yaml
+      - playbooks/ansible-cloud/aws/pre.yaml
+    run: playbooks/ansible-test-base/run.yaml
+    files:
+      - ^plugins/.*$
+      - ^tests/integration/.*$
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: milestone
+      - name: github.com/ansible-collections/community.aws
+    timeout: 3600
+    host-vars: {}
+    vars:
+      ansible_test_command: integration
+      ansible_test_python: 3.9
+      ansible_test_retry_on_error: true
+      ansible_test_requirement_files:
+        - requirements.txt
+        - test-requirements.txt
+        - tests/integration/requirements.txt
+      ansible_test_constraint_files:
+        - tests/integration/constraints.txt
+      ansible_test_integration_targets: lookup_aws_collection_constants
       ansible_collections_repo: github.com/ansible-collections/amazon.aws
     extra-vars: {}
     semaphore: ansible-test-cloud-integration-aws
@@ -2808,7 +2940,6 @@
 - project-template:
     name: ansible-collections-amazon-aws-each-target
     periodic:
-      queue: integrated-aws
       jobs:
         - build-ansible-collection:
             required-projects:
@@ -2818,6 +2949,7 @@
               - name: github.com/ansible-collections/community.aws
               - name: github.com/ansible-collections/community.general
               - name: github.com/ansible-collections/community.crypto
+              - name: github.com/ansible-collections/ansible.windows
             timeout: 3600
             host-vars: {}
             vars: {}
@@ -2830,7 +2962,9 @@
         - integration-amazon.aws-target-cloudwatch_metric_alarm
         - integration-amazon.aws-target-cloudwatchevent_rule
         - integration-amazon.aws-target-cloudwatchlogs
-        - integration-amazon.aws-target-ec2_ami
+        - integration-amazon.aws-target-ec2_ami_instance
+        - integration-amazon.aws-target-ec2_ami_snapshot
+        - integration-amazon.aws-target-ec2_ami_tpm
         - integration-amazon.aws-target-ec2_eip
         - integration-amazon.aws-target-ec2_eni
         - integration-amazon.aws-target-ec2_instance_block_devices
@@ -2872,9 +3006,11 @@
         - integration-amazon.aws-target-kms_key
         - integration-amazon.aws-target-lambda
         - integration-amazon.aws-target-lambda_alias
+        - integration-amazon.aws-target-lambda_event
         - integration-amazon.aws-target-lambda_layer
         - integration-amazon.aws-target-lambda_policy
         - integration-amazon.aws-target-lookup_aws_account_attribute
+        - integration-amazon.aws-target-lookup_aws_collection_constants
         - integration-amazon.aws-target-lookup_aws_service_ip_ranges
         - integration-amazon.aws-target-lookup_secretsmanager_secret
         - integration-amazon.aws-target-lookup_ssm_parameter

--- a/zuul.d/aws-integration-worker-jobs.yaml
+++ b/zuul.d/aws-integration-worker-jobs.yaml
@@ -1499,16 +1499,16 @@
 - project-template:
     name: ansible-collections-amazon-aws-integration
     check:
-      queue: integrated-aws
       jobs:
         - build-ansible-collection:
-            required-projects: &ansible-collections-amazon-aws-build-requirements
+            required-projects:
               - name: github.com/ansible-collections/ansible.utils
               - name: github.com/ansible-collections/amazon.aws
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/community.aws
               - name: github.com/ansible-collections/community.general
               - name: github.com/ansible-collections/community.crypto
+              - name: github.com/ansible-collections/ansible.windows
             timeout: 3600
             host-vars: {}
             vars: {}
@@ -1573,10 +1573,16 @@
         - integration-community.aws-21
         - integration-community.aws-22
     gate:
-      queue: integrated-aws
       jobs:
         - build-ansible-collection:
-            required-projects: *ansible-collections-amazon-aws-build-requirements
+            required-projects:
+              - name: github.com/ansible-collections/ansible.utils
+              - name: github.com/ansible-collections/amazon.aws
+              - name: github.com/ansible-collections/ansible.netcommon
+              - name: github.com/ansible-collections/community.aws
+              - name: github.com/ansible-collections/community.general
+              - name: github.com/ansible-collections/community.crypto
+              - name: github.com/ansible-collections/ansible.windows
             timeout: 3600
             host-vars: {}
             vars: {}
@@ -1641,10 +1647,16 @@
         - integration-community.aws-21
         - integration-community.aws-22
     ondemand:
-      queue: integrated-aws
       jobs:
         - build-ansible-collection:
-            required-projects: *ansible-collections-amazon-aws-build-requirements
+            required-projects:
+              - name: github.com/ansible-collections/ansible.utils
+              - name: github.com/ansible-collections/amazon.aws
+              - name: github.com/ansible-collections/ansible.netcommon
+              - name: github.com/ansible-collections/community.aws
+              - name: github.com/ansible-collections/community.general
+              - name: github.com/ansible-collections/community.crypto
+              - name: github.com/ansible-collections/ansible.windows
             timeout: 3600
             host-vars: {}
             vars: {}
@@ -1711,17 +1723,16 @@
 - project-template:
     name: ansible-collections-community-aws-integration
     check:
-      queue: integrated-aws
       jobs:
         - build-ansible-collection:
-            required-projects: &ansible-collections-community-aws-build-requirements
+            required-projects:
               - name: github.com/ansible-collections/ansible.utils
-              - name: github.com/ansible-collections/ansible.windows
               - name: github.com/ansible-collections/amazon.aws
               - name: github.com/ansible-collections/ansible.netcommon
               - name: github.com/ansible-collections/community.aws
               - name: github.com/ansible-collections/community.general
               - name: github.com/ansible-collections/community.crypto
+              - name: github.com/ansible-collections/ansible.windows
             timeout: 3600
             host-vars: {}
             vars: {}
@@ -1764,10 +1775,16 @@
         - integration-community.aws-21
         - integration-community.aws-22
     gate:
-      queue: integrated-aws
       jobs:
         - build-ansible-collection:
-            required-projects: *ansible-collections-community-aws-build-requirements
+            required-projects:
+              - name: github.com/ansible-collections/ansible.utils
+              - name: github.com/ansible-collections/amazon.aws
+              - name: github.com/ansible-collections/ansible.netcommon
+              - name: github.com/ansible-collections/community.aws
+              - name: github.com/ansible-collections/community.general
+              - name: github.com/ansible-collections/community.crypto
+              - name: github.com/ansible-collections/ansible.windows
             timeout: 3600
             host-vars: {}
             vars: {}
@@ -1810,10 +1827,16 @@
         - integration-community.aws-21
         - integration-community.aws-22
     ondemand:
-      queue: integrated-aws
       jobs:
         - build-ansible-collection:
-            required-projects: *ansible-collections-community-aws-build-requirements
+            required-projects:
+              - name: github.com/ansible-collections/ansible.utils
+              - name: github.com/ansible-collections/amazon.aws
+              - name: github.com/ansible-collections/ansible.netcommon
+              - name: github.com/ansible-collections/community.aws
+              - name: github.com/ansible-collections/community.general
+              - name: github.com/ansible-collections/community.crypto
+              - name: github.com/ansible-collections/ansible.windows
             timeout: 3600
             host-vars: {}
             vars: {}


### PR DESCRIPTION
Also: don't use the periodic-queue, it seems to be a source of problem
since the last SF upgrade:
    
```
Zuul encountered a syntax error while parsing its configuration in the
repo ansible/ansible-zuul-jobs on branch master. The error was:

extra keys not allowed @ data['periodic']['queue']

The error appears in the following project-template stanza:
```