### PR TITLE
Run community.vmware integration tests with 2.14

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -78,46 +78,46 @@
         ansible_network_os: vmware_rest
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_only-stable212
+    name: ansible-test-cloud-integration-vcenter7_only-stable214
     parent: ansible-test-cloud-integration-vcenter7_only
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.12
+        override-checkout: stable-2.14
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-stable212
+    name: ansible-test-cloud-integration-vcenter7_1esxi-stable214
     parent: ansible-test-cloud-integration-vcenter7_1esxi
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.12
+        override-checkout: stable-2.14
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-stable212_1_of_2
+    name: ansible-test-cloud-integration-vcenter7_1esxi-stable214_1_of_2
     parent: ansible-test-cloud-integration-vcenter7_1esxi
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.12
+        override-checkout: stable-2.14
     vars:
       ansible_test_split_in: 2
       ansible_test_do_number: 1
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-stable212_2_of_2
+    name: ansible-test-cloud-integration-vcenter7_1esxi-stable214_2_of_2
     parent: ansible-test-cloud-integration-vcenter7_1esxi
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.12
+        override-checkout: stable-2.14
     vars:
       ansible_test_split_in: 2
       ansible_test_do_number: 2
 
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_2esxi-stable212
+    name: ansible-test-cloud-integration-vcenter7_2esxi-stable214
     parent: ansible-test-cloud-integration-vcenter7_2esxi
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.12
+        override-checkout: stable-2.14
 
 
 ####################### vmware.vmware-rest #####################

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -546,10 +546,10 @@
         - ansible-test-sanity-docker-stable-2.13
         - ansible-test-sanity-docker-stable-2.14
         - ansible-test-units-community-vmware-python38
-        - ansible-test-cloud-integration-vcenter7_only-stable212
-        - ansible-test-cloud-integration-vcenter7_2esxi-stable212
-        - ansible-test-cloud-integration-vcenter7_1esxi-stable212_1_of_2
-        - ansible-test-cloud-integration-vcenter7_1esxi-stable212_2_of_2
+        - ansible-test-cloud-integration-vcenter7_only-stable214
+        - ansible-test-cloud-integration-vcenter7_2esxi-stable214
+        - ansible-test-cloud-integration-vcenter7_1esxi-stable214_1_of_2
+        - ansible-test-cloud-integration-vcenter7_1esxi-stable214_2_of_2
     gate:
       jobs:
         - ansible-tox-linters


### PR DESCRIPTION
It looks like `community.vmware` integration tests are still run with ansible (core) 2.12. I think it's about time we change this to the current version 2.14.

I hope I've implemented this correctly, I'm not an expert on `ansible-zuul-jobs`.