### PR TITLE
Use older python for older ansible-test (sanity tests)

### DIFF
--- a/zuul.d/ansible-test-jobs.yaml
+++ b/zuul.d/ansible-test-jobs.yaml
@@ -79,7 +79,7 @@
       - name: github.com/ansible/ansible
         override-checkout: stable-2.12
     vars:
-      ansible_test_python: 3.10
+      ansible_test_python: '3.10'
 
 - job:
     name: ansible-test-sanity-docker-stable-2.13
@@ -88,7 +88,7 @@
       - name: github.com/ansible/ansible
         override-checkout: stable-2.13
     vars:
-      ansible_test_python: 3.10
+      ansible_test_python: '3.10'
 
 - job:
     name: ansible-test-sanity-docker-stable-2.14
@@ -97,4 +97,4 @@
       - name: github.com/ansible/ansible
         override-checkout: stable-2.14
     vars:
-      ansible_test_python: 3.11
+      ansible_test_python: '3.11'

--- a/zuul.d/ansible-test-jobs.yaml
+++ b/zuul.d/ansible-test-jobs.yaml
@@ -50,6 +50,7 @@
         override-checkout: stable-2.9
     vars:
       container_command: docker
+      ansible_test_python: 3.8
 
 - job:
     name: ansible-test-sanity-docker-stable-2.10
@@ -59,6 +60,7 @@
         override-checkout: stable-2.10
     vars:
       container_command: docker
+      ansible_test_python: 3.8
 
 - job:
     name: ansible-test-sanity-docker-stable-2.11
@@ -68,6 +70,7 @@
         override-checkout: stable-2.11
     vars:
       container_command: docker
+      ansible_test_python: 3.9
 
 - job:
     name: ansible-test-sanity-docker-stable-2.12
@@ -75,6 +78,8 @@
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.12
+    vars:
+      ansible_test_python: 3.10
 
 - job:
     name: ansible-test-sanity-docker-stable-2.13
@@ -82,6 +87,8 @@
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.13
+    vars:
+      ansible_test_python: 3.10
 
 - job:
     name: ansible-test-sanity-docker-stable-2.14
@@ -89,3 +96,5 @@
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.14
+    vars:
+      ansible_test_python: 3.11


### PR DESCRIPTION
After bumping to f37 we're seeing Python errors in the tests for Ansible 2.12 / 2.13:

```
2023-02-20 18:54:33.856128 | 
2023-02-20 18:54:33.856264 | TASK [ansible-test : Run the test suite]
2023-02-20 18:54:34.530375 | controller | This version of ansible-test cannot be executed with Python version 3.11.0. Supported Python versions are: 3.8, 3.9, 3.10
2023-02-20 18:54:34.712579 | controller | ERROR
2023-02-20 18:54:34.712899 | controller | {
2023-02-20 18:54:34.712954 | controller |   "delta": "0:00:00.015958",
2023-02-20 18:54:34.712988 | controller |   "end": "2023-02-20 18:54:34.532547",
2023-02-20 18:54:34.713025 | controller |   "msg": "non-zero return code",
2023-02-20 18:54:34.713055 | controller |   "rc": 1,
2023-02-20 18:54:34.713092 | controller |   "start": "2023-02-20 18:54:34.516589"
2023-02-20 18:54:34.713130 | controller | }
```