### PR TITLE
Remove ansible-collections-kubernetes-core-units

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -889,21 +889,6 @@
       jobs: *ansible-collections-juniper-junos-netconf-jobs
 
 - project-template:
-    name: ansible-collections-kubernetes-core-units
-    check:
-      jobs: &ansible-collections-kubernetes-core-units-jobs
-        - build-ansible-collection
-        - ansible-test-sanity-docker-devel
-        - ansible-test-sanity-docker-milestone:
-            voting: false
-        - ansible-test-sanity-docker-stable-2.9
-        - ansible-test-sanity-docker-stable-2.11
-        - ansible-test-sanity-docker-stable-2.12
-        - ansible-test-units-kubernetes-core-python38
-    gate:
-      jobs: *ansible-collections-kubernetes-core-units-jobs
-
-- project-template:
     name: ansible-collections-vyos-vyos
     check:
       jobs: &ansible-collections-vyos-vyos-jobs


### PR DESCRIPTION
Moved ansible-collections/kubernetes.core unit test to GHA. So removing the corresponding template from project-template.