### PR TITLE
Remove cloud-aws_troubleshooting and cloud-aws_ops jobs

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1572,22 +1572,6 @@
         - build-ansible-collection
 
 - project-template:
-    name: ansible-collections-cloud-aws_troubleshooting
-    check:
-      jobs: &ansible-collections-cloud-aws_troubleshooting-jobs
-        - ansible-tox-linters
-    gate:
-      jobs: *ansible-collections-cloud-aws_troubleshooting-jobs
-
-- project-template:
-    name: ansible-collections-cloud-aws_ops
-    check:
-      jobs: &ansible-collections-cloud-aws_ops-jobs
-        - ansible-tox-linters
-    gate:
-      jobs: *ansible-collections-cloud-aws_ops-jobs
-
-- project-template:
     name: ansible-collections-cloud-terraform-units
     check:
       jobs: &ansible-collections-cloud-terraform-units-jobs


### PR DESCRIPTION
The jobs are migrated to Github actions from Zuul.