### PR TITLE
Remove amazon.cloud job template

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -85,26 +85,6 @@
       jobs: *ansible-collections-community-aws-jobs
 
 - project-template:
-    name: ansible-collections-amazon-cloud
-    check:
-      jobs: &ansible-collections-amazon-cloud-jobs
-        - ansible-test-sanity-docker-devel
-        - ansible-test-sanity-docker-milestone
-        - ansible-test-sanity-docker-stable-2.11
-        - ansible-test-sanity-docker-stable-2.12
-        - ansible-test-sanity-docker-stable-2.13
-        - ansible-test-sanity-docker-stable-2.14
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/amazon.aws
-              - name: github.com/ansible-collections/community.aws
-              - name: github.com/ansible-collections/community.crypto
-    gate:
-      jobs: *ansible-collections-amazon-cloud-jobs
-    ondemand:
-      jobs: *ansible-collections-amazon-cloud-jobs
-
-- project-template:
     name: ansible-collections-amazon-cloud-code-generator
     check:
       jobs: &ansible-collections-amazon-cloud-generator-jobs


### PR DESCRIPTION
The testing for this collection is moved to GitHub Actions. Hence removing the template from zuul project-config.