### PR TITLE
community.vmware: add ansible-test-sanity-docker-stable-2.15

### DIFF
--- a/zuul.d/ansible-test-jobs.yaml
+++ b/zuul.d/ansible-test-jobs.yaml
@@ -98,3 +98,13 @@
         override-checkout: stable-2.14
     vars:
       ansible_test_python: '3.11'
+
+- job:
+    name: ansible-test-sanity-docker-stable-2.15
+    parent: ansible-test-sanity-docker
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.15
+    voting: false
+    vars:
+      ansible_test_python: '3.11'

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -526,6 +526,7 @@
             voting: false
         - ansible-test-sanity-docker-stable-2.13
         - ansible-test-sanity-docker-stable-2.14
+        - ansible-test-sanity-docker-stable-2.15
         - ansible-test-units-community-vmware-python38
         - ansible-test-cloud-integration-vcenter7_only-stable214
         - ansible-test-cloud-integration-vcenter7_2esxi-stable214
@@ -537,6 +538,7 @@
         - build-ansible-collection
         - ansible-test-sanity-docker-stable-2.13
         - ansible-test-sanity-docker-stable-2.14
+        - ansible-test-sanity-docker-stable-2.15
         - ansible-test-units-community-vmware-python38
 
 - project-template:


### PR DESCRIPTION
Since ansible-core 2.15 will be released soon, I'd like to add a job running sanity tests against this version for community.vmware.