### PR TITLE
Remove amazon.cloud's gouttelette related jobs

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -690,19 +690,6 @@
       zuul_work_dir: "~/{{ zuul.projects['github.com/ansible-collections/vmware.vmware_rest'].src_dir }}"
 
 - job:
-    name: tox-cloud-refresh-examples-amazon
-    parent: tox
-    description: |
-      Refresh the example using gouttelette.
-    required-projects:
-      - name: github.com/ansible-collections/amazon.cloud
-      - name: github.com/ansible-collections/gouttelette
-    nodeset: container-ansible
-    vars:
-      tox_package_name: amazon_cloud
-      zuul_work_dir: "~/{{ zuul.projects['github.com/ansible-collections/amazon.cloud'].src_dir }}"
-
-- job:
     name: tox-cloud-refresh-modules-vmware
     parent: tox
     description: |
@@ -715,17 +702,3 @@
       tox_envlist: refresh_modules
       tox_package_name: vmware_rest
       zuul_work_dir: "~/{{ zuul.projects['github.com/ansible-collections/vmware.vmware_rest'].src_dir }}"
-
-- job:
-    name: tox-cloud-refresh-modules-amazon
-    parent: tox
-    description: |
-      Refresh the example using gouttelette.
-    required-projects:
-      - name: github.com/ansible-collections/amazon.cloud
-      - name: github.com/ansible-collections/gouttelette
-    nodeset: container-ansible
-    vars:
-      tox_envlist: refresh_modules
-      tox_package_name: amazon_cloud
-      zuul_work_dir: "~/{{ zuul.projects['github.com/ansible-collections/amazon.cloud'].src_dir }}"

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -699,7 +699,6 @@
       - name: github.com/ansible-collections/gouttelette
     nodeset: container-ansible
     vars:
-      tox_envlist: refresh-examples
       tox_package_name: amazon_cloud
       zuul_work_dir: "~/{{ zuul.projects['github.com/ansible-collections/amazon.cloud'].src_dir }}"
 

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1590,12 +1590,8 @@
             voting: false
         - ansible-test-changelog
         - tox-cloud-refresh-modules-vmware
-        - tox-cloud-refresh-modules-amazon
         - tox-cloud-refresh-examples-vmware
-        - tox-cloud-refresh-examples-amazon
         - tox-cloud-generate-vmware:
-            voting: false
-        - tox-cloud-generate-amazon:
             voting: false
     gate:
       jobs: *ansible-collections-cloud-gouttelette-units-jobs

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -520,13 +520,6 @@
             required-projects:
               - name: github.com/ansible-collections/vmware.vmware_rest
               - name: github.com/ansible-collections/cloud.common
-        - ansible-test-sanity-docker-devel:
-            voting: false
-        - ansible-test-sanity-docker-milestone:
-            voting: false
-        - ansible-test-sanity-docker-stable-2.13
-        - ansible-test-sanity-docker-stable-2.14
-        - ansible-test-units-community-vmware-python38
         - ansible-test-cloud-integration-vcenter7_only-stable214
         - ansible-test-cloud-integration-vcenter7_2esxi-stable214
         - ansible-test-cloud-integration-vcenter7_1esxi-stable214_1_of_2
@@ -535,9 +528,6 @@
       jobs:
         - ansible-tox-linters
         - build-ansible-collection
-        - ansible-test-sanity-docker-stable-2.13
-        - ansible-test-sanity-docker-stable-2.14
-        - ansible-test-units-community-vmware-python38
 
 - project-template:
     name: ansible-collections-community-vmware-rest

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -520,6 +520,13 @@
             required-projects:
               - name: github.com/ansible-collections/vmware.vmware_rest
               - name: github.com/ansible-collections/cloud.common
+        - ansible-test-sanity-docker-devel:
+            voting: false
+        - ansible-test-sanity-docker-milestone:
+            voting: false
+        - ansible-test-sanity-docker-stable-2.13
+        - ansible-test-sanity-docker-stable-2.14
+        - ansible-test-units-community-vmware-python38
         - ansible-test-cloud-integration-vcenter7_only-stable214
         - ansible-test-cloud-integration-vcenter7_2esxi-stable214
         - ansible-test-cloud-integration-vcenter7_1esxi-stable214_1_of_2
@@ -528,6 +535,9 @@
       jobs:
         - ansible-tox-linters
         - build-ansible-collection
+        - ansible-test-sanity-docker-stable-2.13
+        - ansible-test-sanity-docker-stable-2.14
+        - ansible-test-units-community-vmware-python38
 
 - project-template:
     name: ansible-collections-community-vmware-rest


### PR DESCRIPTION
gouttelette repository is archived. These jobs are no more needed for testing amazon.cloud.