### PR TITLE
Run community.vmware integration tests with 2.15

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -78,46 +78,46 @@
         ansible_network_os: vmware_rest
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_only-stable214
+    name: ansible-test-cloud-integration-vcenter7_only-stable215
     parent: ansible-test-cloud-integration-vcenter7_only
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.14
+        override-checkout: stable-2.15
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-stable214
+    name: ansible-test-cloud-integration-vcenter7_1esxi-stable215
     parent: ansible-test-cloud-integration-vcenter7_1esxi
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.14
+        override-checkout: stable-2.15
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-stable214_1_of_2
+    name: ansible-test-cloud-integration-vcenter7_1esxi-stable215_1_of_2
     parent: ansible-test-cloud-integration-vcenter7_1esxi
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.14
+        override-checkout: stable-2.15
     vars:
       ansible_test_split_in: 2
       ansible_test_do_number: 1
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-stable214_2_of_2
+    name: ansible-test-cloud-integration-vcenter7_1esxi-stable215_2_of_2
     parent: ansible-test-cloud-integration-vcenter7_1esxi
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.14
+        override-checkout: stable-2.15
     vars:
       ansible_test_split_in: 2
       ansible_test_do_number: 2
 
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_2esxi-stable214
+    name: ansible-test-cloud-integration-vcenter7_2esxi-stable215
     parent: ansible-test-cloud-integration-vcenter7_2esxi
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.14
+        override-checkout: stable-2.15
 
 
 ####################### vmware.vmware-rest #####################

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -520,10 +520,10 @@
             required-projects:
               - name: github.com/ansible-collections/vmware.vmware_rest
               - name: github.com/ansible-collections/cloud.common
-        - ansible-test-cloud-integration-vcenter7_only-stable214
-        - ansible-test-cloud-integration-vcenter7_2esxi-stable214
-        - ansible-test-cloud-integration-vcenter7_1esxi-stable214_1_of_2
-        - ansible-test-cloud-integration-vcenter7_1esxi-stable214_2_of_2
+        - ansible-test-cloud-integration-vcenter7_only-stable215
+        - ansible-test-cloud-integration-vcenter7_2esxi-stable215
+        - ansible-test-cloud-integration-vcenter7_1esxi-stable215_1_of_2
+        - ansible-test-cloud-integration-vcenter7_1esxi-stable215_2_of_2
     gate:
       jobs:
         - ansible-tox-linters


### PR DESCRIPTION
Now that ansible-core 2.15 is out, `community.vmware` should be tested with this version.

I hope I've implemented this correctly, I'm not an expert on ansible-zuul-jobs.