### PR TITLE
Make ansible-test-units-amazon-aws-python310 as non-voting

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -271,6 +271,7 @@
 - job:
     name: ansible-test-units-amazon-aws-python310
     parent: ansible-test-units-base-python310
+    voting: false
     vars:
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
       ansible_test_requirement_files:

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -271,6 +271,9 @@
 - job:
     name: ansible-test-units-amazon-aws-python310
     parent: ansible-test-units-base-python310
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: devel
     vars:
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
       ansible_test_requirement_files:

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -271,9 +271,6 @@
 - job:
     name: ansible-test-units-amazon-aws-python310
     parent: ansible-test-units-base-python310
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: devel
     vars:
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
       ansible_test_requirement_files:

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -269,6 +269,7 @@
     abstract: true
     required-projects:
       - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
     vars:
       ansible_test_python: "3.10"
 

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -269,7 +269,6 @@
     abstract: true
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.12
     vars:
       ansible_test_python: "3.10"
 

--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -269,7 +269,7 @@
     abstract: true
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.11
+        override-checkout: stable-2.12
     vars:
       ansible_test_python: "3.10"
 


### PR DESCRIPTION
This job will be removed after GHA migration. This job may be failing because of pytest-ansible . Hence making it non-voting.