### PR TITLE
Explicitly flag ansible-galaxy-importer as non-voting for AWS tests

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -58,6 +58,10 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/amazon.aws
+        - ansible-galaxy-importer:
+            voting: false
+    third-party-check:
+      jobs: *ansible-collections-community-aws-jobs
     gate:
       jobs: *ansible-collections-community-aws-jobs
 


### PR DESCRIPTION
It's being pulled into the community.aws buildsets by multiple templates, explicitly flag it as non-voting to work around this.