### PR TITLE
Bump AWS Integration tests to later Python

### DIFF
--- a/tools/zuul-ansible-manager.py
+++ b/tools/zuul-ansible-manager.py
@@ -347,7 +347,7 @@ class AWSWorkerJob(Job):
 
     vars = {
         "ansible_test_command": "integration",
-        "ansible_test_python": 3.9,
+        "ansible_test_python": 3.11,
         "ansible_test_retry_on_error": True,
         "ansible_test_requirement_files": [
             "requirements.txt",

--- a/zuul.d/aws-integration-worker-jobs.yaml
+++ b/zuul.d/aws-integration-worker-jobs.yaml
@@ -22,7 +22,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -56,7 +56,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -90,7 +90,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -124,7 +124,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -158,7 +158,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -192,7 +192,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -226,7 +226,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -260,7 +260,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -294,7 +294,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -328,7 +328,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -362,7 +362,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -396,7 +396,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -430,7 +430,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -464,7 +464,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -498,7 +498,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -532,7 +532,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -566,7 +566,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -600,7 +600,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -634,7 +634,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -668,7 +668,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -702,7 +702,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -736,7 +736,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -770,7 +770,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -804,7 +804,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -838,7 +838,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -872,7 +872,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -906,7 +906,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -940,7 +940,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -974,7 +974,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1008,7 +1008,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1042,7 +1042,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1076,7 +1076,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1110,7 +1110,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1144,7 +1144,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1178,7 +1178,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1212,7 +1212,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1246,7 +1246,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1280,7 +1280,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1314,7 +1314,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1348,7 +1348,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1382,7 +1382,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1416,7 +1416,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1450,7 +1450,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1484,7 +1484,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt


### PR DESCRIPTION
The AWS Integration tests run against Ansible "milestone".  The milestone release has been updated and dropped support for Python 3.9 on controllers, and as such we need to bump the version we're running integration tests against.