### PR TITLE
Update python version for aws tests

### DIFF
--- a/zuul.d/amazon-aws-periodical-jobs.yaml
+++ b/zuul.d/amazon-aws-periodical-jobs.yaml
@@ -21,7 +21,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -54,7 +54,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -87,7 +87,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -120,7 +120,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -153,7 +153,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -186,7 +186,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -219,7 +219,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -252,7 +252,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -285,7 +285,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -318,7 +318,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -351,7 +351,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -384,7 +384,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -417,7 +417,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -450,7 +450,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -483,7 +483,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -516,7 +516,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -549,7 +549,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -582,7 +582,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -615,7 +615,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -648,7 +648,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -681,7 +681,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -714,7 +714,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -747,7 +747,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -780,7 +780,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -813,7 +813,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -846,7 +846,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -879,7 +879,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -912,7 +912,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -945,7 +945,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -978,7 +978,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1011,7 +1011,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1044,7 +1044,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1077,7 +1077,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1110,7 +1110,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1143,7 +1143,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1176,7 +1176,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1209,7 +1209,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1242,7 +1242,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1275,7 +1275,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1308,7 +1308,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1341,7 +1341,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1374,7 +1374,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1407,7 +1407,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1440,7 +1440,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1473,7 +1473,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1506,7 +1506,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1539,7 +1539,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1572,7 +1572,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1605,7 +1605,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1638,7 +1638,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1671,7 +1671,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1704,7 +1704,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1737,7 +1737,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1770,7 +1770,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1803,7 +1803,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1836,7 +1836,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1869,7 +1869,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1902,7 +1902,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1935,7 +1935,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1968,7 +1968,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2001,7 +2001,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2034,7 +2034,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2067,7 +2067,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2100,7 +2100,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2133,7 +2133,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2166,7 +2166,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2199,7 +2199,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2232,7 +2232,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2265,7 +2265,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2298,7 +2298,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2331,7 +2331,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2364,7 +2364,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2397,7 +2397,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2430,7 +2430,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2463,7 +2463,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2496,7 +2496,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2529,7 +2529,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2562,7 +2562,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2595,7 +2595,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2628,7 +2628,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2661,7 +2661,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2694,7 +2694,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2727,7 +2727,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2760,7 +2760,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2793,7 +2793,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2826,7 +2826,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2859,7 +2859,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2892,7 +2892,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2925,7 +2925,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt

--- a/zuul.d/amazon-aws-periodical-jobs.yaml
+++ b/zuul.d/amazon-aws-periodical-jobs.yaml
@@ -21,7 +21,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -54,7 +54,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -87,7 +87,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -120,7 +120,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -153,7 +153,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -186,7 +186,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -219,7 +219,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -252,7 +252,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -285,7 +285,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -318,7 +318,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -351,7 +351,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -384,7 +384,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -417,7 +417,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -450,7 +450,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -483,7 +483,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -516,7 +516,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -549,7 +549,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -582,7 +582,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -615,7 +615,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -648,7 +648,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -681,7 +681,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -714,7 +714,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -747,7 +747,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -780,7 +780,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -813,7 +813,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -846,7 +846,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -879,7 +879,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -912,7 +912,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -945,7 +945,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -978,7 +978,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1011,7 +1011,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1044,7 +1044,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1077,7 +1077,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1110,7 +1110,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1143,7 +1143,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1176,7 +1176,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1209,7 +1209,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1242,7 +1242,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1275,7 +1275,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1308,7 +1308,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1341,7 +1341,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1374,7 +1374,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1407,7 +1407,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1440,7 +1440,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1473,7 +1473,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1506,7 +1506,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1539,7 +1539,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1572,7 +1572,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1605,7 +1605,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1638,7 +1638,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1671,7 +1671,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1704,7 +1704,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1737,7 +1737,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1770,7 +1770,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1803,7 +1803,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1836,7 +1836,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1869,7 +1869,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1902,7 +1902,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1935,7 +1935,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1968,7 +1968,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2001,7 +2001,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2034,7 +2034,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2067,7 +2067,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2100,7 +2100,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2133,7 +2133,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2166,7 +2166,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2199,7 +2199,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2232,7 +2232,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2265,7 +2265,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2298,7 +2298,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2331,7 +2331,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2364,7 +2364,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2397,7 +2397,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2430,7 +2430,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2463,7 +2463,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2496,7 +2496,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2529,7 +2529,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2562,7 +2562,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2595,7 +2595,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2628,7 +2628,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2661,7 +2661,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2694,7 +2694,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2727,7 +2727,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2760,7 +2760,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2793,7 +2793,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2826,7 +2826,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2859,7 +2859,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2892,7 +2892,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2925,7 +2925,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt

--- a/zuul.d/amazon-aws-periodical-jobs.yaml
+++ b/zuul.d/amazon-aws-periodical-jobs.yaml
@@ -21,7 +21,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -54,7 +54,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -87,7 +87,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -120,7 +120,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -153,7 +153,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -186,7 +186,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -219,7 +219,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -252,7 +252,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -285,7 +285,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -318,7 +318,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -351,7 +351,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -384,7 +384,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -417,7 +417,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -450,7 +450,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -483,7 +483,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -516,7 +516,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -549,7 +549,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -582,7 +582,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -615,7 +615,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -648,7 +648,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -681,7 +681,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -714,7 +714,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -747,7 +747,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -780,7 +780,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -813,7 +813,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -846,7 +846,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -879,7 +879,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -912,7 +912,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -945,7 +945,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -978,7 +978,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1011,7 +1011,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1044,7 +1044,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1077,7 +1077,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1110,7 +1110,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1143,7 +1143,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1176,7 +1176,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1209,7 +1209,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1242,7 +1242,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1275,7 +1275,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1308,7 +1308,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1341,7 +1341,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1374,7 +1374,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1407,7 +1407,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1440,7 +1440,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1473,7 +1473,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1506,7 +1506,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1539,7 +1539,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1572,7 +1572,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1605,7 +1605,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1638,7 +1638,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1671,7 +1671,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1704,7 +1704,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1737,7 +1737,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1770,7 +1770,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1803,7 +1803,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1836,7 +1836,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1869,7 +1869,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1902,7 +1902,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1935,7 +1935,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1968,7 +1968,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2001,7 +2001,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2034,7 +2034,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2067,7 +2067,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2100,7 +2100,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2133,7 +2133,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2166,7 +2166,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2199,7 +2199,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2232,7 +2232,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2265,7 +2265,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2298,7 +2298,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2331,7 +2331,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2364,7 +2364,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2397,7 +2397,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2430,7 +2430,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2463,7 +2463,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2496,7 +2496,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2529,7 +2529,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2562,7 +2562,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2595,7 +2595,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2628,7 +2628,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2661,7 +2661,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2694,7 +2694,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2727,7 +2727,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2760,7 +2760,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2793,7 +2793,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2826,7 +2826,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2859,7 +2859,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2892,7 +2892,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2925,7 +2925,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt

--- a/zuul.d/aws-integration-worker-jobs.yaml
+++ b/zuul.d/aws-integration-worker-jobs.yaml
@@ -22,7 +22,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -56,7 +56,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -90,7 +90,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -124,7 +124,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -158,7 +158,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -192,7 +192,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -226,7 +226,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -260,7 +260,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -294,7 +294,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -328,7 +328,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -362,7 +362,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -396,7 +396,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -430,7 +430,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -464,7 +464,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -498,7 +498,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -532,7 +532,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -566,7 +566,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -600,7 +600,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -634,7 +634,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -668,7 +668,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -702,7 +702,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -736,7 +736,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -770,7 +770,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -804,7 +804,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -838,7 +838,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -872,7 +872,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -906,7 +906,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -940,7 +940,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -974,7 +974,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1008,7 +1008,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1042,7 +1042,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1076,7 +1076,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1110,7 +1110,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1144,7 +1144,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1178,7 +1178,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1212,7 +1212,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1246,7 +1246,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1280,7 +1280,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1314,7 +1314,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1348,7 +1348,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1382,7 +1382,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1416,7 +1416,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1450,7 +1450,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1484,7 +1484,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.11
+      ansible_test_python: 3.10
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt

--- a/zuul.d/aws-integration-worker-jobs.yaml
+++ b/zuul.d/aws-integration-worker-jobs.yaml
@@ -22,7 +22,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -56,7 +56,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -90,7 +90,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -124,7 +124,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -158,7 +158,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -192,7 +192,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -226,7 +226,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -260,7 +260,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -294,7 +294,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -328,7 +328,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -362,7 +362,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -396,7 +396,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -430,7 +430,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -464,7 +464,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -498,7 +498,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -532,7 +532,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -566,7 +566,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -600,7 +600,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -634,7 +634,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -668,7 +668,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -702,7 +702,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -736,7 +736,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -770,7 +770,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -804,7 +804,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -838,7 +838,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -872,7 +872,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -906,7 +906,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -940,7 +940,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -974,7 +974,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1008,7 +1008,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1042,7 +1042,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1076,7 +1076,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1110,7 +1110,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1144,7 +1144,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1178,7 +1178,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1212,7 +1212,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1246,7 +1246,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1280,7 +1280,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1314,7 +1314,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1348,7 +1348,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1382,7 +1382,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1416,7 +1416,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1450,7 +1450,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1484,7 +1484,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt

--- a/zuul.d/aws-integration-worker-jobs.yaml
+++ b/zuul.d/aws-integration-worker-jobs.yaml
@@ -22,7 +22,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -56,7 +56,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -90,7 +90,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -124,7 +124,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -158,7 +158,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -192,7 +192,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -226,7 +226,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -260,7 +260,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -294,7 +294,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -328,7 +328,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -362,7 +362,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -396,7 +396,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -430,7 +430,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -464,7 +464,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -498,7 +498,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -532,7 +532,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -566,7 +566,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -600,7 +600,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -634,7 +634,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -668,7 +668,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -702,7 +702,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -736,7 +736,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -770,7 +770,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -804,7 +804,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -838,7 +838,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -872,7 +872,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -906,7 +906,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -940,7 +940,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -974,7 +974,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1008,7 +1008,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1042,7 +1042,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1076,7 +1076,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1110,7 +1110,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1144,7 +1144,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1178,7 +1178,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1212,7 +1212,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1246,7 +1246,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1280,7 +1280,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1314,7 +1314,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1348,7 +1348,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1382,7 +1382,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1416,7 +1416,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1450,7 +1450,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1484,7 +1484,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.10
+      ansible_test_python: "3.10"
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt


### PR DESCRIPTION
The milestone branch no longer supports python 3.9