### PR TITLE
Bump python version from 3.9 to 3.11 for aws integration tests

### DIFF
--- a/zuul.d/amazon-aws-periodical-jobs.yaml
+++ b/zuul.d/amazon-aws-periodical-jobs.yaml
@@ -21,7 +21,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -54,7 +54,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -87,7 +87,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -120,7 +120,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -153,7 +153,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -186,7 +186,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -219,7 +219,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -252,7 +252,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -285,7 +285,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -318,7 +318,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -351,7 +351,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -384,7 +384,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -417,7 +417,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -450,7 +450,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -483,7 +483,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -516,7 +516,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -549,7 +549,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -582,7 +582,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -615,7 +615,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -648,7 +648,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -681,7 +681,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -714,7 +714,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -747,7 +747,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -780,7 +780,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -813,7 +813,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -846,7 +846,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -879,7 +879,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -912,7 +912,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -945,7 +945,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -978,7 +978,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1011,7 +1011,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1044,7 +1044,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1077,7 +1077,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1110,7 +1110,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1143,7 +1143,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1176,7 +1176,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1209,7 +1209,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1242,7 +1242,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1275,7 +1275,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1308,7 +1308,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1341,7 +1341,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1374,7 +1374,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1407,7 +1407,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1440,7 +1440,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1473,7 +1473,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1506,7 +1506,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1539,7 +1539,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1572,7 +1572,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1605,7 +1605,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1638,7 +1638,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1671,7 +1671,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1704,7 +1704,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1737,7 +1737,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1770,7 +1770,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1803,7 +1803,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1836,7 +1836,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1869,7 +1869,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1902,7 +1902,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1935,7 +1935,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -1968,7 +1968,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2001,7 +2001,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2034,7 +2034,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2067,7 +2067,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2100,7 +2100,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2133,7 +2133,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2166,7 +2166,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2199,7 +2199,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2232,7 +2232,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2265,7 +2265,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2298,7 +2298,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2331,7 +2331,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2364,7 +2364,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2397,7 +2397,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2430,7 +2430,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2463,7 +2463,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2496,7 +2496,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2529,7 +2529,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2562,7 +2562,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2595,7 +2595,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2628,7 +2628,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2661,7 +2661,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2694,7 +2694,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2727,7 +2727,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2760,7 +2760,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2793,7 +2793,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2826,7 +2826,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2859,7 +2859,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2892,7 +2892,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt
@@ -2925,7 +2925,7 @@
     host-vars: {}
     vars:
       ansible_test_command: integration
-      ansible_test_python: 3.9
+      ansible_test_python: 3.11
       ansible_test_retry_on_error: true
       ansible_test_requirement_files:
         - requirements.txt


### PR DESCRIPTION
Bump python version from 3.9 to 3.11