### PR TITLE
vmware_rest: Remove 2.13 / 2.14 sanity tests

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -453,7 +453,6 @@
             required-projects:
               - name: github.com/ansible-collections/cloud.common
               - name: github.com/ansible-collections/community.vmware
-        - ansible-tox-linters
         - ansible-test-sanity-docker-devel
         - ansible-test-sanity-docker-milestone
         - ansible-test-sanity-docker-stable-2.9

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -461,8 +461,6 @@
             voting: false
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
-        - ansible-test-sanity-docker-stable-2.13
-        - ansible-test-sanity-docker-stable-2.14
         - tox-cloud-refresh-examples-vmware
     gate:
       jobs: *ansible-collections-community-vmware-rest-jobs
@@ -474,8 +472,6 @@
         - ansible-test-sanity-docker-stable-2.10
         - ansible-test-sanity-docker-stable-2.11
         - ansible-test-sanity-docker-stable-2.12
-        - ansible-test-sanity-docker-stable-2.13
-        - ansible-test-sanity-docker-stable-2.14
         - build-ansible-collection
 
 - project-template:


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1830

Moving 2.13 / 2.14 sanity tests to GHA.

cc @alinabuzachis

_edit:_
Also remove linting: ansible-collections/vmware.vmware_rest#410