### PR TITLE
update ibm.qradar jobs

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1005,37 +1005,10 @@
       jobs: &ansible-collections-security-ibm-qradar-jobs
         - build-ansible-collection
         - ansible-changelog-fragment
-        - ansible-test-security-integration-qradar-python36:
-            voting: false
-        - ansible-test-security-integration-qradar-python38:
-            voting: false
-        - ansible-test-security-integration-qradar-python39:
-            voting: false
-        - ansible-test-security-integration-qradar-python38-stable29:
-            voting: false
-        - ansible-test-security-integration-qradar-python39-stable212:
-            voting: false
-        - ansible-test-security-integration-qradar-python39-stable213:
-            voting: false
-        - ansible-test-security-integration-qradar-python39-stable214:
-            voting: false
-        - ansible-test-sanity-docker-devel
-        - ansible-test-sanity-docker-milestone
-        - ansible-test-sanity-docker-stable-2.9
-        - ansible-test-sanity-docker-stable-2.12
-        - ansible-test-sanity-docker-stable-2.13
-        - ansible-test-sanity-docker-stable-2.14
     gate:
       jobs: *ansible-collections-security-ibm-qradar-jobs
     periodic:
       jobs:
-        - ansible-test-sanity-docker-devel
-        - ansible-test-sanity-docker-milestone
-        - ansible-test-sanity-docker-stable-2.9
-        - ansible-test-sanity-docker-stable-2.12
-        - ansible-test-sanity-docker-stable-2.13
-        - ansible-test-sanity-docker-stable-2.14
-        - ansible-test-security-integration-qradar-python39
         - build-ansible-collection
 
 - project-template:


### PR DESCRIPTION
- Removing integration tests temporarily since the appliance doesn't work and these job unnecessarily hog CI resources.
- Sanity and units are being tested through GHA now.