### PR TITLE
vmware_rest: Remove sanity tests

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -455,11 +455,6 @@
               - name: github.com/ansible-collections/community.vmware
         - ansible-test-sanity-docker-devel
         - ansible-test-sanity-docker-milestone
-        - ansible-test-sanity-docker-stable-2.9
-        - ansible-test-sanity-docker-stable-2.10:
-            voting: false
-        - ansible-test-sanity-docker-stable-2.11
-        - ansible-test-sanity-docker-stable-2.12
         - tox-cloud-refresh-examples-vmware
     gate:
       jobs: *ansible-collections-community-vmware-rest-jobs
@@ -467,10 +462,6 @@
       jobs:
         - ansible-test-sanity-docker-devel
         - ansible-test-sanity-docker-milestone
-        - ansible-test-sanity-docker-stable-2.9
-        - ansible-test-sanity-docker-stable-2.10
-        - ansible-test-sanity-docker-stable-2.11
-        - ansible-test-sanity-docker-stable-2.12
         - build-ansible-collection
 
 - project-template:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -453,13 +453,11 @@
             required-projects:
               - name: github.com/ansible-collections/cloud.common
               - name: github.com/ansible-collections/community.vmware
-        - ansible-test-sanity-docker-milestone
         - tox-cloud-refresh-examples-vmware
     gate:
       jobs: *ansible-collections-community-vmware-rest-jobs
     periodic:
       jobs:
-        - ansible-test-sanity-docker-milestone
         - build-ansible-collection
 
 - project-template:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -453,14 +453,12 @@
             required-projects:
               - name: github.com/ansible-collections/cloud.common
               - name: github.com/ansible-collections/community.vmware
-        - ansible-test-sanity-docker-devel
         - ansible-test-sanity-docker-milestone
         - tox-cloud-refresh-examples-vmware
     gate:
       jobs: *ansible-collections-community-vmware-rest-jobs
     periodic:
       jobs:
-        - ansible-test-sanity-docker-devel
         - ansible-test-sanity-docker-milestone
         - build-ansible-collection
 


### PR DESCRIPTION
Drop outdated ansible (core) versions. Also milestone and devel sanity tests.