### PR TITLE
cloud.common - Migrate Kubernetes integration tests to GHA

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -396,19 +396,6 @@
               - name: github.com/ansible-collections/community.vmware
               - name: github.com/ansible-collections/vmware.vmware_rest
               - name: github.com/ansible-collections/kubernetes.core
-        - ansible-test-splitter:
-            required-projects:
-              - name: github.com/ansible-collections/kubernetes.core
-            vars:
-              ansible_test_splitter__test_changed: false
-              ansible_test_splitter__total_job: 3
-              ansible_test_splitter__check_for_changes_in:
-                - "~/{{ zuul.projects['github.com/ansible-collections/kubernetes.core'].src_dir }}"
-              ansible_test_splitter__releases_to_test:
-                - "with-turbo"
-        - integration-kubernetes.core-with-turbo-1
-        - integration-kubernetes.core-with-turbo-2
-        - integration-kubernetes.core-with-turbo-3
     gate:
       jobs: *ansible-collections-cloud-common-jobs
 


### PR DESCRIPTION
We can safely migrate `kubernetes.core` integration tests to GHA when testing `cloud.common` pull requests.
We are keeping `vmware.vmware_rest` integration as these need special configuration for VMWARE cluster.