### PR TITLE
vmware-ci-set-passwords: Blacklist ` and $

### DIFF
--- a/roles/vmware-ci-set-passwords/files/vcenter_set_password
+++ b/roles/vmware-ci-set-passwords/files/vcenter_set_password
@@ -18,7 +18,7 @@ import subprocess
 
 import time
 
-CHARACTER_BLACKLIST = ["\\", "'", '"', '%', '{', '}', ' ']
+CHARACTER_BLACKLIST = ["\\", "'", '"', '%', '{', '}', ' ', '`', '$']
 
 
 def set_new_pw():


### PR DESCRIPTION
Fixes #1761

A `` ` `` results in:

```
2023-11-16 09:31:18.175917 | TASK [Debug]
2023-11-16 09:31:18.214685 | aP6eFT17BAlFDby`vy@p
2023-11-16 09:31:18.221655 | 
2023-11-16 09:31:18.221772 | TASK [Prepare the wait for vcenter script]
2023-11-16 09:31:19.031070 | controller | changed
2023-11-16 09:31:19.041035 | 
2023-11-16 09:31:19.041108 | TASK [Run wait_for_vcenter]
2023-11-16 09:31:19.481599 | controller | + server=https://vcenter.test
2023-11-16 09:31:19.481627 | controller | /tmp/wait_for_vcenter: line 4: unexpected EOF while looking for matching ``'
```

And a `$` can lead to:

```
2023-11-16 09:36:41.456987 | TASK [Debug]
2023-11-16 09:36:41.491004 | V|jqP$8?$MFqM;A*6yPA
2023-11-16 09:36:41.498488 | 
2023-11-16 09:36:41.498580 | TASK [Prepare the wait for vcenter script]
2023-11-16 09:36:42.370479 | controller | changed
2023-11-16 09:36:42.377360 | 
2023-11-16 09:36:42.377425 | TASK [Run wait_for_vcenter]
2023-11-16 09:36:42.766118 | controller | + server=https://vcenter.test
2023-11-16 09:36:42.766142 | controller | /tmp/wait_for_vcenter: line 4: $8: unbound variable
```

#1836
ansible-collections/community.vmware#1929