### PR TITLE
Remove ansible-collections-cloud-common

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -385,21 +385,6 @@
             voting: false
 
 - project-template:
-    name: ansible-collections-cloud-common
-    check:
-      jobs: &ansible-collections-cloud-common-jobs
-        - ansible-test-cloud-integration-vmware-rest:
-            required-projects:
-              - name: github.com/ansible-collections/vmware.vmware_rest
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/community.vmware
-              - name: github.com/ansible-collections/vmware.vmware_rest
-              - name: github.com/ansible-collections/kubernetes.core
-    gate:
-      jobs: *ansible-collections-cloud-common-jobs
-
-- project-template:
     name: ansible-collections-community-vmware
     check:
       fail-fast: true


### PR DESCRIPTION
Removing ansible-collections-cloud-common , as the tests have moved to GHA