### PR TITLE
Add custom template for community.docker

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1352,3 +1352,18 @@
             voting: false
     gate:
       jobs: *ansible-collections-cloud-gouttelette-units-jobs
+
+- project-template:
+    name: ansible-collections-community-docker
+    third-party-check:
+      jobs:
+        - build-ansible-collection:
+            required-projects:
+              - name: github.com/ansible-collections/community.library_inventory_filtering
+        - ansible-galaxy-importer
+    pre-release:
+      jobs:
+        - release-ansible-collection-galaxy
+    release:
+      jobs:
+        - release-ansible-collection-galaxy


### PR DESCRIPTION
Make sure community.library_inventory_filtering_v1 is installed for community.docker.