### PR TITLE
Allow projects without third-party-check that publish to Galaxy

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -1174,6 +1174,17 @@
         - release-ansible-collection-galaxy
 
 - project-template:
+    name: publish-to-galaxy-plain
+    description: |
+      Publish an Ansible collection to Ansible Galaxy
+    pre-release:
+      jobs:
+        - release-ansible-collection-galaxy
+    release:
+      jobs:
+        - release-ansible-collection-galaxy
+
+- project-template:
     name: publish-to-galaxy-3pci
     description: |
       Publish an Ansible collection to Ansible Galaxy


### PR DESCRIPTION
Replaces #1843. The third-party-check is very slow and can be replaced with the shared GHA workflow from https://github.com/ansible-community/github-action-test-galaxy-import.

This allows collection to mark themselves as "we have a replacement for the third-party-check" in https://github.com/ansible/zuul-config/.
