### PR TITLE
Revert "Remove community.okd unit and sanity tests"

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -237,6 +237,88 @@
     vars:
       ansible_collections_repo: "{{ zuul.project.canonical_name }}"
 
+### Community OKD
+
+- job:
+    name: ansible-test-sanity-okd-downstream
+    parent: ansible-test-sanity-docker
+    required-projects:
+      - name: github.com/openshift/community.okd
+    run: playbooks/ansible-cloud/okd/sanity.yaml
+
+- job:
+    name: ansible-test-sanity-okd-downstream-devel
+    parent: ansible-test-sanity-okd-downstream
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: devel
+    voting: false
+
+- job:
+    name: ansible-test-sanity-okd-downstream-milestone
+    parent: ansible-test-sanity-okd-downstream
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: milestone
+
+- job:
+    name: ansible-test-sanity-okd-downstream-milestone
+    parent: ansible-test-sanity-okd-downstream
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: milestone
+    branches: stable-2.\d+
+    voting: false
+
+- job:
+    name: ansible-test-sanity-okd-downstream-stable-2.9
+    parent: ansible-test-sanity-okd-downstream
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.9
+    vars:
+      container_command: docker
+
+- job:
+    name: ansible-test-sanity-okd-downstream-stable-2.10
+    parent: ansible-test-sanity-okd-downstream
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.10
+    vars:
+      container_command: docker
+
+- job:
+    name: ansible-test-sanity-okd-downstream-stable-2.11
+    parent: ansible-test-sanity-okd-downstream
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.11
+    vars:
+      container_command: docker
+
+- job:
+    name: ansible-test-sanity-okd-downstream-stable-2.12
+    parent: ansible-test-sanity-okd-downstream
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.12
+
+- job:
+    name: ansible-test-sanity-okd-downstream-stable-2.13
+    parent: ansible-test-sanity-okd-downstream
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.13
+
+- job:
+    name: ansible-test-units-community-okd-python39
+    parent: ansible-test-units-base-python39
+    required-projects:
+      - name: github.com/openshift/community.okd
+    vars:
+      ansible_collections_repo: github.com/openshift/community.okd
+
 ### Kubernetes Core
 - job:
     name: ansible-test-units-kubernetes-core-python38

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -364,8 +364,21 @@
             required-projects:
               - name: github.com/ansible-collections/kubernetes.core
                 override-checkout: stable-2.4
+        - ansible-test-sanity-docker-devel
+        - ansible-test-sanity-docker-milestone
+        - ansible-test-sanity-docker-stable-2.11
+        - ansible-test-sanity-docker-stable-2.12
+        - ansible-test-sanity-docker-stable-2.13
+        - ansible-test-sanity-docker-stable-2.14
         - ansible-galaxy-importer:
             voting: false
+        - ansible-test-units-community-okd-python39
+        - ansible-test-sanity-okd-downstream-devel
+        - ansible-test-sanity-okd-downstream-milestone:
+            voting: false
+        - ansible-test-sanity-okd-downstream-stable-2.11
+        - ansible-test-sanity-okd-downstream-stable-2.12
+        - ansible-test-sanity-okd-downstream-stable-2.13
 
 - project-template:
     name: ansible-collections-community-vmware


### PR DESCRIPTION
Reverts ansible/ansible-zuul-jobs#1829

community.okd's GHA workflows donot run. So reverting to zuul.