### PR TITLE
Revert #1843 and #1846

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -986,18 +986,3 @@
             voting: false
     gate:
       jobs: *ansible-collections-cloud-gouttelette-units-jobs
-
-- project-template:
-    name: ansible-collections-community-docker
-    third-party-check:
-      jobs:
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/community.library_inventory_filtering
-        - ansible-galaxy-importer
-    pre-release:
-      jobs:
-        - release-ansible-collection-galaxy
-    release:
-      jobs:
-        - release-ansible-collection-galaxy

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -807,10 +807,6 @@
     name: publish-to-galaxy-plain
     description: |
       Publish an Ansible collection to Ansible Galaxy
-    # This is needed to override the default config from publish-to-galaxy-3pci
-    third-party-check:
-      jobs:
-        - noop
     pre-release:
       jobs:
         - release-ansible-collection-galaxy


### PR DESCRIPTION
Revert #1843 and #1846. These didn't work:
- #1846 only adds a new `noop` tasks, but doesn't override the existing ones.
- #1843 won't help due to galaxy-importer not caring about dependencies (https://forum.ansible.com/t/galaxy-importer-collection-dependency-handling/3496/2).

This can only be merged once ansible-zuul-config has been modified to no longer use the `ansible-collections-community-docker` template.