### PR TITLE
community.okd - update sanity tests: drop support for ansible-core<2.14

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -271,45 +271,18 @@
     voting: false
 
 - job:
-    name: ansible-test-sanity-okd-downstream-stable-2.9
+    name: ansible-test-sanity-okd-downstream-stable-2.15
     parent: ansible-test-sanity-okd-downstream
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.9
-    vars:
-      container_command: docker
+        override-checkout: stable-2.15
 
 - job:
-    name: ansible-test-sanity-okd-downstream-stable-2.10
+    name: ansible-test-sanity-okd-downstream-stable-2.16
     parent: ansible-test-sanity-okd-downstream
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.10
-    vars:
-      container_command: docker
-
-- job:
-    name: ansible-test-sanity-okd-downstream-stable-2.11
-    parent: ansible-test-sanity-okd-downstream
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.11
-    vars:
-      container_command: docker
-
-- job:
-    name: ansible-test-sanity-okd-downstream-stable-2.12
-    parent: ansible-test-sanity-okd-downstream
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.12
-
-- job:
-    name: ansible-test-sanity-okd-downstream-stable-2.13
-    parent: ansible-test-sanity-okd-downstream
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.13
+        override-checkout: stable-2.16
 
 - job:
     name: ansible-test-units-community-okd-python39

--- a/zuul.d/ansible-test-jobs.yaml
+++ b/zuul.d/ansible-test-jobs.yaml
@@ -98,3 +98,21 @@
         override-checkout: stable-2.14
     vars:
       ansible_test_python: '3.11'
+
+- job:
+    name: ansible-test-sanity-docker-stable-2.15
+    parent: ansible-test-sanity-docker
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.15
+    vars:
+      ansible_test_python: '3.11'
+
+- job:
+    name: ansible-test-sanity-docker-stable-2.16
+    parent: ansible-test-sanity-docker
+    required-projects:
+      - name: github.com/ansible/ansible
+        override-checkout: stable-2.16
+    vars:
+      ansible_test_python: '3.10'

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -134,22 +134,19 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/kubernetes.core
-                override-checkout: stable-2.4
+                override-checkout: stable-4
         - ansible-test-sanity-docker-devel
         - ansible-test-sanity-docker-milestone
-        - ansible-test-sanity-docker-stable-2.11
-        - ansible-test-sanity-docker-stable-2.12
-        - ansible-test-sanity-docker-stable-2.13
-        - ansible-test-sanity-docker-stable-2.14
+        - ansible-test-sanity-docker-stable-2.15
+        - ansible-test-sanity-docker-stable-2.16
         - ansible-galaxy-importer:
             voting: false
         - ansible-test-units-community-okd-python39
         - ansible-test-sanity-okd-downstream-devel
         - ansible-test-sanity-okd-downstream-milestone:
             voting: false
-        - ansible-test-sanity-okd-downstream-stable-2.11
-        - ansible-test-sanity-okd-downstream-stable-2.12
-        - ansible-test-sanity-okd-downstream-stable-2.13
+        - ansible-test-sanity-okd-downstream-stable-2.15
+        - ansible-test-sanity-okd-downstream-stable-2.16
 
 - project-template:
     name: ansible-collections-community-vmware


### PR DESCRIPTION
- Remove all sanity jobs running with `ansible-core<2.14`
- Increase dependency with `kubernetes.core` to `stable-4`