### PR TITLE
Sanity tests Community.okd

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -134,7 +134,6 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/kubernetes.core
-                override-checkout: stable-2.4
         - ansible-test-sanity-docker-devel
         - ansible-test-sanity-docker-milestone
         - ansible-test-sanity-docker-stable-2.11


### PR DESCRIPTION
Update `kubernetes.core` version when running job `build-ansible-collection`.
When running sanity tests on branch `X`, the `kubernetes.core` version will be checkout on version `X`
e.g: `community.okd:main` -> `kubernetes.core:main`, `community.okd:Stable-X` -> `kubernetes.core:Stable-X``
