### PR TITLE
Fix ansible-test-location issue

### DIFF
--- a/playbooks/ansible-test-base/run.yaml
+++ b/playbooks/ansible-test-base/run.yaml
@@ -1,5 +1,7 @@
 ---
 - hosts: controller
+  vars:
+    ansible_test_location: "~/{{ zuul.projects[ansible_collections_repo].src_dir }}"
   tasks:
     - name: Copy the galaxy.yml on the controller
       fetch:
@@ -25,6 +27,5 @@
         name: ansible-test
       vars:
         ansible_test_test_command: "{{ ansible_test_command }}"
-        ansible_test_location: "~/{{ zuul.projects[ansible_collections_repo].src_dir }}"
         ansible_test_git_branch: "{{ zuul.projects['github.com/ansible/ansible'].checkout }}"
         ansible_test_ansible_path: "~/{{ zuul.projects['github.com/ansible/ansible'].src_dir }}"

--- a/roles/ansible-test/defaults/main.yaml
+++ b/roles/ansible-test/defaults/main.yaml
@@ -4,7 +4,7 @@ ansible_test_test_command: 'integration'
 ansible_test_continue_on_error: true
 ansible_test_retry_on_error: false
 ansible_test_skip_tags: false
-ansible_test_location: "{{ ~/ansible-test | expanduser }}"
+ansible_test_location: "{{ '~/ansible-test' | expanduser }}"
 ansible_test_docker: false
 # Default ansible-test options
 ansible_test_git_branch: 'devel'


### PR DESCRIPTION
This aims to fix the following issue occuring when using the role `ansible-test`

```
2024-06-12 10:25:36.940239 | TASK [Copy the galaxy.yml on the controller]
2024-06-12 10:25:36.957876 | controller | ERROR
2024-06-12 10:25:36.958089 | controller | {
2024-06-12 10:25:36.958129 | controller |   "msg": "An unhandled exception occurred while templating '{{ ~/ansible-test | expanduser }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: template error while templating string: unexpected '~'. String: {{ ~/ansible-test | expanduser }}. unexpected '~'"
2024-06-12 10:25:36.958157 | controller | }
failure
```