### PR TITLE
Update community.okd sanity tests

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -134,6 +134,7 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/kubernetes.core
+                override-checkout: main
         - ansible-test-sanity-docker-devel
         - ansible-test-sanity-docker-milestone
         - ansible-test-sanity-docker-stable-2.15


### PR DESCRIPTION
`community.okd` on branch `stable-4` required `kubernetes.core>=5.0.0`, we cannot anymore build the collection using the same branch, therefore we need to have dependency with the main branch from kubernetes.core.