### PR TITLE
Run community.vmware integration tests with 2.17

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -78,46 +78,46 @@
         ansible_network_os: vmware_rest
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_only-stable216
+    name: ansible-test-cloud-integration-vcenter7_only-stable217
     parent: ansible-test-cloud-integration-vcenter7_only
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.16
+        override-checkout: stable-2.17
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-stable216
+    name: ansible-test-cloud-integration-vcenter7_1esxi-stable217
     parent: ansible-test-cloud-integration-vcenter7_1esxi
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.16
+        override-checkout: stable-2.17
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-stable216_1_of_2
+    name: ansible-test-cloud-integration-vcenter7_1esxi-stable217_1_of_2
     parent: ansible-test-cloud-integration-vcenter7_1esxi
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.16
+        override-checkout: stable-2.17
     vars:
       ansible_test_split_in: 2
       ansible_test_do_number: 1
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-stable216_2_of_2
+    name: ansible-test-cloud-integration-vcenter7_1esxi-stable217_2_of_2
     parent: ansible-test-cloud-integration-vcenter7_1esxi
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.16
+        override-checkout: stable-2.17
     vars:
       ansible_test_split_in: 2
       ansible_test_do_number: 2
 
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_2esxi-stable216
+    name: ansible-test-cloud-integration-vcenter7_2esxi-stable217
     parent: ansible-test-cloud-integration-vcenter7_2esxi
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.16
+        override-checkout: stable-2.17
 
 
 ####################### vmware.vmware-rest #####################

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -93,20 +93,14 @@
 
 - job:
     name: ansible-test-cloud-integration-vcenter7_1esxi-stable217_1_of_2
-    parent: ansible-test-cloud-integration-vcenter7_1esxi
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.17
+    parent: ansible-test-cloud-integration-vcenter7_1esxi-stable217
     vars:
       ansible_test_split_in: 2
       ansible_test_do_number: 1
 
 - job:
     name: ansible-test-cloud-integration-vcenter7_1esxi-stable217_2_of_2
-    parent: ansible-test-cloud-integration-vcenter7_1esxi
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.17
+    parent: ansible-test-cloud-integration-vcenter7_1esxi-stable217
     vars:
       ansible_test_split_in: 2
       ansible_test_do_number: 2

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -160,10 +160,10 @@
             required-projects:
               - name: github.com/ansible-collections/vmware.vmware_rest
               - name: github.com/ansible-collections/cloud.common
-        - ansible-test-cloud-integration-vcenter7_only-stable216
-        - ansible-test-cloud-integration-vcenter7_2esxi-stable216
-        - ansible-test-cloud-integration-vcenter7_1esxi-stable216_1_of_2
-        - ansible-test-cloud-integration-vcenter7_1esxi-stable216_2_of_2
+        - ansible-test-cloud-integration-vcenter7_only-stable217
+        - ansible-test-cloud-integration-vcenter7_2esxi-stable217
+        - ansible-test-cloud-integration-vcenter7_1esxi-stable217_1_of_2
+        - ansible-test-cloud-integration-vcenter7_1esxi-stable217_2_of_2
     gate:
       jobs:
         - ansible-tox-linters


### PR DESCRIPTION
Follow-up to #1835

Now that ansible-core 2.17 is out, `community.vmware` should be tested with this version.