### PR TITLE
Remove required-projects for amazon.aws integration jobs

### DIFF
--- a/zuul.d/aws-integration-worker-jobs.yaml
+++ b/zuul.d/aws-integration-worker-jobs.yaml
@@ -1572,6 +1572,7 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/amazon.aws
+              - name: github.com/ansible-collections/community.aws
             timeout: 3600
             host-vars: {}
             vars: {}


### PR DESCRIPTION
This PR removes the dependencies from required-projects. These will be added to the collection's galaxy.yml.