### PR TITLE
Allow setuptools>=50.0.0

### DIFF
--- a/playbooks/ansible-test-base/pre.yaml
+++ b/playbooks/ansible-test-base/pre.yaml
@@ -64,7 +64,7 @@
         - ansible_test_python is version('3.11', '<=')
 
     - name: Install selinux into virtualenv
-      shell: '~/venv/bin/pip install {{ _selinux_package }} "setuptools<50.0.0"'
+      shell: '~/venv/bin/pip install {{ _selinux_package }} "setuptools"'
       when: ansible_os_family == "RedHat"
 
     - name: Install pytest-forked into virtualenv


### PR DESCRIPTION
It looks like the restriction `setuptools<50.0.0` is a problem when trying to run the integration tests for `community.vmware` with Python 3.12 and / or the current pyVmomi / vsphere-automation-sdk.

Removing this restriction seems to work, but I cannot say if this will break other integration tests or not.

See also:
ansible-collections/community.vmware#2108
#1880
vmware/vsphere-automation-sdk-python#407