### PR TITLE
Feature/remove unused vmware rest doc job

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -16,7 +16,6 @@
         ansible_network_os: vmware_rest
     nodeset: vmware-vcsa-7.0.3
 
-
 # master
 
 - job:
@@ -59,7 +58,6 @@
       ansible_test_integration_targets: zuul/vmware/vcenter_1esxi/
     # 5h
     timeout: 10800
-
 
 - job:
     name: ansible-test-cloud-integration-vcenter7_2esxi
@@ -105,14 +103,12 @@
       ansible_test_split_in: 2
       ansible_test_do_number: 2
 
-
 - job:
     name: ansible-test-cloud-integration-vcenter7_2esxi-stable217
     parent: ansible-test-cloud-integration-vcenter7_2esxi
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.17
-
 
 ####################### vmware.vmware-rest #####################
 - job:
@@ -196,7 +192,6 @@
       - name: github.com/ansible-collections/community.vmware
     vars:
       ansible_collections_repo: github.com/ansible-collections/community.vmware
-
 
 ### AWS
 - job:
@@ -454,7 +449,6 @@
         - name: container
           label: zuul-worker-f37
 
-
 ### Gouttelette
 - job:
     name: ansible-test-units-gouttelette-python39
@@ -512,20 +506,6 @@
         override-checkout: stable-2.14
     vars:
       ansible_collections_repo: github.com/ansible-collections/pravic
-
-- job:
-    name: tox-cloud-refresh-examples-vmware
-    parent: tox
-    description: |
-      Refresh the example using gouttelette.
-    required-projects:
-      - name: github.com/ansible-collections/vmware.vmware_rest
-      - name: github.com/ansible-collections/gouttelette
-    nodeset: container-ansible
-    vars:
-      tox_envlist: refresh-examples
-      tox_package_name: vmware_rest
-      zuul_work_dir: "~/{{ zuul.projects['github.com/ansible-collections/vmware.vmware_rest'].src_dir }}"
 
 - job:
     name: tox-cloud-refresh-modules-vmware

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -16,6 +16,7 @@
         ansible_network_os: vmware_rest
     nodeset: vmware-vcsa-7.0.3
 
+
 # master
 
 - job:
@@ -58,6 +59,7 @@
       ansible_test_integration_targets: zuul/vmware/vcenter_1esxi/
     # 5h
     timeout: 10800
+
 
 - job:
     name: ansible-test-cloud-integration-vcenter7_2esxi
@@ -103,12 +105,14 @@
       ansible_test_split_in: 2
       ansible_test_do_number: 2
 
+
 - job:
     name: ansible-test-cloud-integration-vcenter7_2esxi-stable217
     parent: ansible-test-cloud-integration-vcenter7_2esxi
     required-projects:
       - name: github.com/ansible/ansible
         override-checkout: stable-2.17
+
 
 ####################### vmware.vmware-rest #####################
 - job:
@@ -192,6 +196,7 @@
       - name: github.com/ansible-collections/community.vmware
     vars:
       ansible_collections_repo: github.com/ansible-collections/community.vmware
+
 
 ### AWS
 - job:
@@ -449,6 +454,7 @@
         - name: container
           label: zuul-worker-f37
 
+
 ### Gouttelette
 - job:
     name: ansible-test-units-gouttelette-python39
@@ -506,6 +512,7 @@
         override-checkout: stable-2.14
     vars:
       ansible_collections_repo: github.com/ansible-collections/pravic
+
 
 - job:
     name: tox-cloud-refresh-modules-vmware

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -178,7 +178,6 @@
             required-projects:
               - name: github.com/ansible-collections/cloud.common
               - name: github.com/ansible-collections/community.vmware
-        - tox-cloud-refresh-examples-vmware
     gate:
       jobs: *ansible-collections-community-vmware-rest-jobs
     periodic:
@@ -614,7 +613,6 @@
             voting: false
         - ansible-test-changelog
         - tox-cloud-refresh-modules-vmware
-        - tox-cloud-refresh-examples-vmware
         - tox-cloud-generate-vmware:
             voting: false
     gate:


### PR DESCRIPTION
This job no longer applies to the vmware_rest collection. The tox config was removed awhile ago, so new PRs have been failing since this job cannot run