### PR TITLE
add job to run tox linters for aws-ci-admin

### DIFF
--- a/playbooks/ansible-aws-ci-admin/tox/pre.yaml
+++ b/playbooks/ansible-aws-ci-admin/tox/pre.yaml
@@ -1,0 +1,8 @@
+---
+- hosts: all
+  tasks:
+    - name: Ensure make
+      become: true
+      package:
+        name: make
+        state: present

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -527,3 +527,12 @@
       tox_envlist: refresh_modules
       tox_package_name: vmware_rest
       zuul_work_dir: "~/{{ zuul.projects['github.com/ansible-collections/vmware.vmware_rest'].src_dir }}"
+
+### aws-ci-admin
+- job:
+    name: ansible-tox-aws-ci-admin-py37
+    parent: ansible-tox-py37
+    pre-run:
+      - playbooks/ansible-aws-ci-admin/tox/pre.yaml
+    required-projects:
+      - name: github.com/ansible/aws-ci-admin

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -617,3 +617,16 @@
             voting: false
     gate:
       jobs: *ansible-collections-cloud-gouttelette-units-jobs
+
+- project-template:
+    name: ansible-aws-ci-admin
+    check:
+      jobs:
+        - ansible-tox-aws-ci-admin-py37:
+            vars:
+              tox_envlist: linters
+    gate:
+      jobs:
+        - ansible-tox-aws-ci-admin-py37:
+            vars:
+              tox_envlist: linters


### PR DESCRIPTION
The lint validation has been performed with tox running in a python 3.7 environment. 
We cannot use the job as it is since we need `make` to run the check, this is why we have a pre-run to install it.