### PR TITLE
list_changed_targets - fix handling of modules under a sub-directory

### DIFF
--- a/roles/ansible-test-splitter/files/list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/list_changed_targets.py
@@ -4,7 +4,6 @@ import argparse
 import ast
 import json
 from pathlib import PosixPath
-import pprint
 import sys
 import subprocess
 import yaml

--- a/roles/ansible-test-splitter/files/list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/list_changed_targets.py
@@ -208,7 +208,7 @@ class WhatHaveChanged:
         for d in self.changed_files():
             if str(d).startswith("tests/integration/targets/"):
                 # These are a special case, we only care that 'something' changed in that test
-                yield str(d).replace("tests/integration/targets/", "").split("/")[0]
+                yield str(d).replace("tests/integration/targets/", "").split("/", maxsplit=1)[0]
 
     def _path_matches(self, base_path):
         # Simplest case, just a file name
@@ -235,12 +235,21 @@ class WhatHaveChanged:
     def _util_matches(self, base_path, import_path):
         # We care about the file, but we also need to find what potential side effects would be for
         # our change
+        base_path = PosixPath(base_path)
         for d in self.changed_files():
-            if str(d).startswith(base_path):
+            try:
+                relative_path = d.relative_to(base_path)
+                parts = [*relative_path.parts[:-1]]
+                if str(d.stem) != "__init__":
+                    parts.append(d.stem)
+                relative_module = ".".join(parts)
                 yield (
                     PosixPath(d),
-                    f"ansible_collections.{self.collection_name()}.plugins.{import_path}.{d.stem}",
+                    f"ansible_collections.{self.collection_name()}.plugins.{import_path}.{relative_module}",
+                    relative_module,
                 )
+            except ValueError:
+                pass
 
     def module_utils(self):
         """List the Python modules impacted by the change"""
@@ -495,15 +504,15 @@ if __name__ == "__main__":
                 changes[whc.collection_name()]["connection"].append(path.stem)
                 for c in collections:
                     c.add_target_to_plan(f"connection_{path.stem}")
-            for path, pymod in whc.module_utils():
-                changes[whc.collection_name()]["module_utils"].append(path.stem)
+            for path, pymod, stem in whc.module_utils():
+                changes[whc.collection_name()]["module_utils"].append(stem)
                 for c in collections:
-                    c.add_target_to_plan(f"module_utils_{path.stem}")
+                    c.add_target_to_plan(f"module_utils_{stem.replace('.', '_')}")
                     c.cover_module_utils(pymod, collections_names)
-            for path, pymod in whc.plugin_utils():
-                changes[whc.collection_name()]["plugin_utils"].append(path.stem)
+            for path, pymodi, stem in whc.plugin_utils():
+                changes[whc.collection_name()]["plugin_utils"].append(stem)
                 for c in collections:
-                    c.add_target_to_plan(f"plugin_utils_{path.stem}")
+                    c.add_target_to_plan(f"plugin_utils_{stem.replace('.', '_')}")
                     c.cover_module_utils(pymod, collections_names)
             for path in whc.lookup():
                 changes[whc.collection_name()]["lookup"].append(path.stem)

--- a/roles/ansible-test-splitter/files/list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/list_changed_targets.py
@@ -80,7 +80,11 @@ def list_pyimport(prefix, subdir, module_content):
                 current_prefix = f"{prefix}"
             else:
                 current_prefix = ""
-            yield f"{current_prefix}{'.'.join(module)}"
+            full_path = f"{current_prefix}{'.'.join(module)}"
+            yield full_path
+            # ensure we also catch any modules being imported using "from x.y import z"
+            for name in node.names:
+                yield f"{full_path}.{name.name}"
 
 
 def build_import_tree(collection_path, collection_name, collections_names):

--- a/roles/ansible-test-splitter/files/list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/list_changed_targets.py
@@ -242,7 +242,7 @@ class WhatHaveChanged:
             try:
                 relative_path = d.relative_to(base_path)
                 parts = [*relative_path.parts[:-1]]
-                if str(d.stem) != "__init__":
+                if d.stem != "__init__":
                     parts.append(d.stem)
                 relative_module = ".".join(parts)
                 yield (

--- a/roles/ansible-test-splitter/files/list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/list_changed_targets.py
@@ -4,6 +4,7 @@ import argparse
 import ast
 import json
 from pathlib import PosixPath
+import pprint
 import sys
 import subprocess
 import yaml
@@ -208,7 +209,9 @@ class WhatHaveChanged:
         for d in self.changed_files():
             if str(d).startswith("tests/integration/targets/"):
                 # These are a special case, we only care that 'something' changed in that test
-                yield str(d).replace("tests/integration/targets/", "").split("/", maxsplit=1)[0]
+                yield str(d).replace("tests/integration/targets/", "").split(
+                    "/", maxsplit=1
+                )[0]
 
     def _path_matches(self, base_path):
         # Simplest case, just a file name

--- a/roles/ansible-test-splitter/files/test_list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/test_list_changed_targets.py
@@ -40,6 +40,7 @@ def main():
 
 my_module_3 = """
 from .modules import AnsibleAWSModule
+from ._autoscaling import common as _common
 from ipaddress import ipaddress
 import time
 import botocore.exceptions
@@ -55,34 +56,25 @@ def test_read_collection_name():
 
 
 def test_list_pyimport():
-    assert list(
-        list_pyimport("ansible_collections.amazon.aws.plugins.", "modules", my_module)
-    ) == [
+    assert set() == {
         "ansible_collections.amazon.aws.plugins.module_utils.core",
         "ipaddress",
         "time",
         "botocore.exceptions",
-    ]
+    } - set(list_pyimport("ansible_collections.amazon.aws.plugins.", "modules", my_module))
 
-    assert list(
-        list_pyimport(
-            "ansible_collections.kubernetes.core.plugins.", "modules", my_module_2
-        )
-    ) == [
+    assert set() == {
         "ansible_collections.kubernetes.core.plugins.module_utils.k8sdynamicclient",
         "ansible_collections.kubernetes.core.plugins.module_utils.common",
-    ]
+    } - set(list_pyimport("ansible_collections.kubernetes.core.plugins.", "modules", my_module_2))
 
-    assert list(
-        list_pyimport(
-            "ansible_collections.amazon.aws.plugins.", "module_utils", my_module_3
-        )
-    ) == [
+    assert set() == {
+        "ansible_collections.amazon.aws.plugins.module_utils._autoscaling.common",
         "ansible_collections.amazon.aws.plugins.module_utils.modules",
         "ipaddress",
         "time",
         "botocore.exceptions",
-    ]
+    } - set(list_pyimport("ansible_collections.amazon.aws.plugins.", "module_utils", my_module_3))
 
 
 def test_what_changed_files():
@@ -91,6 +83,8 @@ def test_what_changed_files():
     whc.changed_files = lambda: [
         PosixPath("tests/something"),
         PosixPath("plugins/module_utils/core.py"),
+        PosixPath("plugins/module_utils/_autoscaling/common.py"),
+        PosixPath("plugins/module_utils/_autoscaling/__init__.py"),
         PosixPath("plugins/plugin_utils/base.py"),
         PosixPath("plugins/connection/aws_ssm.py"),
         PosixPath("plugins/modules/ec2.py"),
@@ -104,13 +98,25 @@ def test_what_changed_files():
         (
             PosixPath("plugins/plugin_utils/base.py"),
             "ansible_collections.a.b.plugins.plugin_utils.base",
+            "base",
         )
     ]
     assert list(whc.module_utils()) == [
         (
             PosixPath("plugins/module_utils/core.py"),
             "ansible_collections.a.b.plugins.module_utils.core",
-        )
+            "core",
+        ),
+        (
+            PosixPath("plugins/module_utils/_autoscaling/common.py"),
+            "ansible_collections.a.b.plugins.module_utils._autoscaling.common",
+            "_autoscaling.common",
+        ),
+        (
+            PosixPath("plugins/module_utils/_autoscaling/__init__.py"),
+            "ansible_collections.a.b.plugins.module_utils._autoscaling",
+            "_autoscaling",
+        ),
     ]
     assert list(whc.lookup()) == [PosixPath("plugins/lookup/aws_test.py")]
     assert list(whc.targets()) == [

--- a/roles/ansible-test-splitter/files/test_list_changed_targets.py
+++ b/roles/ansible-test-splitter/files/test_list_changed_targets.py
@@ -61,12 +61,18 @@ def test_list_pyimport():
         "ipaddress",
         "time",
         "botocore.exceptions",
-    } - set(list_pyimport("ansible_collections.amazon.aws.plugins.", "modules", my_module))
+    } - set(
+        list_pyimport("ansible_collections.amazon.aws.plugins.", "modules", my_module)
+    )
 
     assert set() == {
         "ansible_collections.kubernetes.core.plugins.module_utils.k8sdynamicclient",
         "ansible_collections.kubernetes.core.plugins.module_utils.common",
-    } - set(list_pyimport("ansible_collections.kubernetes.core.plugins.", "modules", my_module_2))
+    } - set(
+        list_pyimport(
+            "ansible_collections.kubernetes.core.plugins.", "modules", my_module_2
+        )
+    )
 
     assert set() == {
         "ansible_collections.amazon.aws.plugins.module_utils._autoscaling.common",
@@ -74,7 +80,11 @@ def test_list_pyimport():
         "ipaddress",
         "time",
         "botocore.exceptions",
-    } - set(list_pyimport("ansible_collections.amazon.aws.plugins.", "module_utils", my_module_3))
+    } - set(
+        list_pyimport(
+            "ansible_collections.amazon.aws.plugins.", "module_utils", my_module_3
+        )
+    )
 
 
 def test_what_changed_files():


### PR DESCRIPTION
1. Ensures that utils imported using "from XXX import YYY" are identified as being imported
2. Ensures that utils in a subdirectory are correctly identified (eg `plugins/module_utils/_autoscaling/common.py` as `module_utils._autoscaling.common` instead of `module_utils.common`)
3. Handle the special case of `__init__.py`
