### PR TITLE
Update nodesets label

### DIFF
--- a/zuul.d/nodesets.yaml
+++ b/zuul.d/nodesets.yaml
@@ -3,7 +3,7 @@
     name: container-ansible
     nodes:
       - name: controller
-        label: zuul-worker-ansible-f37
+        label: zuul-worker-ansible
 
 # We don't have CentOS8 Stream yet
 - nodeset:
@@ -393,7 +393,7 @@
     name: ansible-tox-linters
     nodes:
       - name: controller
-        label: zuul-worker-ansible-f37
+        label: zuul-linter-fedora-stable
 
 - nodeset:
     name: ansible-galaxy-importer
@@ -405,20 +405,20 @@
     name: ansible-tox-py38
     nodes:
       - name: controller
-        label: zuul-worker-ansible-f37
+        label: zuul-worker-ansible
 
 - nodeset:
     name: ansible-tox-py39
     nodes:
       - name: controller
-        label: zuul-worker-ansible-f37
+        label: zuul-worker-ansible
 
 
 - nodeset:
     name: ansible-tox-py310
     nodes:
       - name: controller
-        label: zuul-worker-ansible-f37
+        label: zuul-worker-ansible
 
 - nodeset:
     name: rhel8


### PR DESCRIPTION
Previous label zuul-worker-ansible-f37 has been removed, due it was EOL for a while.
Also updated other job labels.