### PR TITLE
Run community.vmware integration tests with 2.18

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -32,6 +32,7 @@
     post-run: playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
+        override-checkout: stable-2.18
       - name: github.com/ansible-collections/community.vmware
     timeout: 3600
     vars:
@@ -78,40 +79,30 @@
         ansible_network_os: vmware_rest
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_only-stable217
+    name: ansible-test-cloud-integration-vcenter7_only-stable218
     parent: ansible-test-cloud-integration-vcenter7_only
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.17
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-stable217
+    name: ansible-test-cloud-integration-vcenter7_1esxi-stable218
     parent: ansible-test-cloud-integration-vcenter7_1esxi
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.17
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-stable217_1_of_2
-    parent: ansible-test-cloud-integration-vcenter7_1esxi-stable217
+    name: ansible-test-cloud-integration-vcenter7_1esxi-stable218_1_of_2
+    parent: ansible-test-cloud-integration-vcenter7_1esxi-stable218
     vars:
       ansible_test_split_in: 2
       ansible_test_do_number: 1
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-stable217_2_of_2
-    parent: ansible-test-cloud-integration-vcenter7_1esxi-stable217
+    name: ansible-test-cloud-integration-vcenter7_1esxi-stable218_2_of_2
+    parent: ansible-test-cloud-integration-vcenter7_1esxi-stable218
     vars:
       ansible_test_split_in: 2
       ansible_test_do_number: 2
 
-
 - job:
-    name: ansible-test-cloud-integration-vcenter7_2esxi-stable217
+    name: ansible-test-cloud-integration-vcenter7_2esxi-stable218
     parent: ansible-test-cloud-integration-vcenter7_2esxi
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: stable-2.17
 
 
 ####################### vmware.vmware-rest #####################

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -160,10 +160,10 @@
             required-projects:
               - name: github.com/ansible-collections/vmware.vmware_rest
               - name: github.com/ansible-collections/cloud.common
-        - ansible-test-cloud-integration-vcenter7_only-stable217
-        - ansible-test-cloud-integration-vcenter7_2esxi-stable217
-        - ansible-test-cloud-integration-vcenter7_1esxi-stable217_1_of_2
-        - ansible-test-cloud-integration-vcenter7_1esxi-stable217_2_of_2
+        - ansible-test-cloud-integration-vcenter7_only-stable218
+        - ansible-test-cloud-integration-vcenter7_2esxi-stable218
+        - ansible-test-cloud-integration-vcenter7_1esxi-stable218_1_of_2
+        - ansible-test-cloud-integration-vcenter7_1esxi-stable218_2_of_2
     gate:
       jobs:
         - ansible-tox-linters


### PR DESCRIPTION
Follow-up to #1875

Now that ansible-core 2.18 is out, `community.vmware` should be tested with this version.

_edit:_
Tested in ansible-collections/community.vmware#2250 and ansible-collections/community.vmware#2251