### PR TITLE
Restrict ncclient version in test-requirements.txt

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 alembic<1.5.0
 jxmlease
-ncclient
+ncclient<0.6.18


### PR DESCRIPTION
The last ncclient release [0.6.18](https://pypi.org/project/ncclient/0.6.18/) seems to break the Zuul jobs. ansible-collections/community.vmware#2337 fails with:

```
2025-03-02 12:33:59.304660 | controller | Collecting ncclient
2025-03-02 12:33:59.304669 | controller |   Downloading ncclient-0.6.18.tar.gz (112 kB)
2025-03-02 12:33:59.304678 | controller |      â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â”â” 112.4/112.4 kB 33.3 MB/s eta 0:00:00
2025-03-02 12:33:59.304687 | controller |   Preparing metadata (setup.py): started
2025-03-02 12:33:59.304696 | controller |   Preparing metadata (setup.py): finished with status 'error'
2025-03-02 12:33:59.304705 | controller |   error: subprocess-exited-with-error
2025-03-02 12:33:59.304714 | controller |
2025-03-02 12:33:59.304726 | controller |   Ã— python setup.py egg_info did not run successfully.
2025-03-02 12:33:59.304735 | controller |   â”‚ exit code: 1
2025-03-02 12:33:59.304744 | controller |   â•°â”€> [7 lines of output]
2025-03-02 12:33:59.304753 | controller |       Traceback (most recent call last):
2025-03-02 12:33:59.304762 | controller |         File "<string>", line 2, in <module>
2025-03-02 12:33:59.304772 | controller |         File "<pip-setuptools-caller>", line 34, in <module>
2025-03-02 12:33:59.304783 | controller |         File "/tmp/pip-install-gc5p4tso/ncclient_037de0269b5b456b80b8306a391519e6/setup.py", line 36, in <module>
2025-03-02 12:33:59.304793 | controller |           test_req_lines = [line.strip() for line in open("requirements-test.txt").readlines()]
2025-03-02 12:33:59.304807 | controller |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-03-02 12:33:59.304817 | controller |       FileNotFoundError: [Errno 2] No such file or directory: 'requirements-test.txt'
2025-03-02 12:33:59.304826 | controller |       [end of output]
2025-03-02 12:33:59.304835 | controller |
2025-03-02 12:33:59.304844 | controller |   note: This error originates from a subprocess, and is likely not a problem with pip.
2025-03-02 12:33:59.304853 | controller | error: metadata-generation-failed
2025-03-02 12:33:59.304862 | controller |
2025-03-02 12:33:59.304969 | controller | Ã— Encountered error while generating package metadata.
2025-03-02 12:33:59.304985 | controller | â•°â”€> See above for output.
2025-03-02 12:33:59.304995 | controller |
2025-03-02 12:33:59.305004 | controller | note: This is an issue with the package mentioned above, not pip.
2025-03-02 12:33:59.305013 | controller | hint: See above for details.
```

[log](https://fca309234bdf28871a18-b0621ccb626ddbb2b40142c2655f4105.ssl.cf1.rackcdn.com/2337/c365462fb28d44c045aaca15e3c7265e113beb4d/check/ansible-test-cloud-integration-vcenter7_1esxi-stable218_1_of_2/9e79c48/job-output.txt)

I'm not sure if ncclient is really needed, so I'll start with restricting it for now.