### PR TITLE
Drop ncclient from test requirents

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
 alembic<1.5.0
 jxmlease
-ncclient


### PR DESCRIPTION
I think that most collections don't need `ncclient`. So it's special and shouldn't be a general requirement.

see also #1894