### PR TITLE
community.vmware: Make ansible-galaxy-importer non-voting

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -137,10 +137,18 @@
         - ansible-test-cloud-integration-vcenter7_2esxi-stable218
         - ansible-test-cloud-integration-vcenter7_1esxi-stable218_1_of_2
         - ansible-test-cloud-integration-vcenter7_1esxi-stable218_2_of_2
+        - ansible-galaxy-importer:
+            voting: false
+    third-party-check:
+      jobs:
+        - ansible-galaxy-importer:
+            voting: false
     gate:
       jobs:
         - ansible-tox-linters
         - build-ansible-collection
+        - ansible-galaxy-importer:
+            voting: false
 
 - project-template:
     name: ansible-collections-kubernetes-core-units


### PR DESCRIPTION
It looks like `ansible-galaxy-importer` has problems with doc fragments from another collection. So I think we should make it non-voting and test this with a GHA.

At least until it's fixed or I find a way to make it work.

FYI I ran into this when trying to re-use doc fragments from `vmware.vmware` in `community.vmware`: ansible-collections/community.vmware#2369