### PR TITLE
Don't use main branch of k8s for okd sanity

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -107,7 +107,6 @@
         - build-ansible-collection:
             required-projects:
               - name: github.com/ansible-collections/kubernetes.core
-                override-checkout: main
         - ansible-test-sanity-docker-devel
         - ansible-test-sanity-docker-milestone
         - ansible-test-sanity-docker-stable-2.16

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -104,9 +104,7 @@
     name: ansible-collections-community-okd
     third-party-check:
       jobs:
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/kubernetes.core
+        - build-ansible-collection
         - ansible-test-sanity-docker-devel
         - ansible-test-sanity-docker-milestone
         - ansible-test-sanity-docker-stable-2.16


### PR DESCRIPTION
We can't run the sanity jobs against k8s main, because there may be breaking changes that older, but still supported, versions of okd can't address. This change should use a released k8s version that matches the range specified in galaxy.yml.