### PR TITLE
Add ansible-lint to okd tests

### DIFF
--- a/playbooks/ansible-cloud/okd/pre.yaml
+++ b/playbooks/ansible-cloud/okd/pre.yaml
@@ -1,0 +1,10 @@
+---
+- hosts: controller
+  tasks:
+    - name: Build downstream collection
+      shell: "source ~/venv/bin/activate; make downstream-build"
+      args:
+        chdir: "{{ zuul.projects['github.com/openshift/community.okd'].src_dir }}"
+      environment:
+        DOWNSTREAM_BUILD_PYTHON: "python"
+        INSTALL_DOWNSTREAM_COLLECTION_PATH: "{{ downstream_collections_path }}"

--- a/playbooks/ansible-cloud/okd/sanity.yaml
+++ b/playbooks/ansible-cloud/okd/sanity.yaml
@@ -1,18 +1,10 @@
 ---
 - hosts: controller
   tasks:
-    - name: Build downstream collection
-      shell: "source ~/venv/bin/activate; make downstream-build"
-      args:
-        chdir: "{{ zuul.projects['github.com/openshift/community.okd'].src_dir }}"
-      environment:
-        DOWNSTREAM_BUILD_PYTHON: "python"
-        INSTALL_DOWNSTREAM_COLLECTION_PATH: "~/.ansible/collections/ansible_collections"
-
     - name: Run ansible-test
       import_role:
         name: ansible-test
       vars:
         ansible_test_test_command: "{{ ansible_test_command }}"
         ansible_test_venv_path: "~/venv"
-        ansible_test_location: "~/.ansible/collections/ansible_collections/redhat/openshift"
+        ansible_test_location: "{{ downstream_collections_path }}/redhat/openshift"

--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -175,7 +175,10 @@
     parent: ansible-test-sanity-docker
     required-projects:
       - name: github.com/openshift/community.okd
+    pre-run: playbooks/ansible-cloud/okd/pre.yaml
     run: playbooks/ansible-cloud/okd/sanity.yaml
+    vars:
+      downstream_collections_path: "~/.ansible/collections/ansible_collections"
 
 - job:
     name: ansible-test-sanity-okd-downstream-devel
@@ -245,6 +248,18 @@
       - name: github.com/openshift/community.okd
     vars:
       ansible_collections_repo: github.com/openshift/community.okd
+
+- job:
+    name: ansible-tox-linters-okd-downstream
+    parent: tox
+    required-projects:
+      - name: github.com/openshift/community.okd
+    tox_envlist: ansible-lint
+    tox_extra_args:
+      root: "~/.ansible/collections/ansible_collections/redhat/openshift"
+    pre-run: playbooks/ansible-cloud/okd/pre.yaml
+    vars:
+      downstream_collections_path: "~/.ansible/collections/ansible_collections"
 
 ### Kubernetes Core
 - job:

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -110,6 +110,7 @@
         - ansible-test-sanity-docker-stable-2.16
         - ansible-test-sanity-docker-stable-2.17
         - ansible-test-sanity-docker-stable-2.18
+        - ansible-tox-linters
         - ansible-galaxy-importer:
             voting: false
         - ansible-test-units-community-okd-python39
@@ -119,6 +120,7 @@
         - ansible-test-sanity-okd-downstream-stable-2.16
         - ansible-test-sanity-okd-downstream-stable-2.17
         - ansible-test-sanity-okd-downstream-stable-2.18
+        - ansible-tox-linters-okd-downstream
 
 - project-template:
     name: ansible-collections-community-vmware


### PR DESCRIPTION
The okd collection doesn't currently have any job running ansible-lint. We can't do this in a GHA because they are not available in the openshift org. One job is added to run the full set of linters using tox on the upstream collection. One job is added to run ansible-lint on the downstream collection. The downstream build process makes changes that would cause black to fail, so only ansible-lint is run on the downstream collection. This should be fine as the code formatting of the built downstream distribution doesn't really matter.