### PR TITLE
community.vmware: Drop vmware.vmware_rest requirement

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -127,10 +127,6 @@
       fail-fast: true
       jobs:
         - ansible-tox-linters
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/vmware.vmware_rest
-              - name: github.com/ansible-collections/cloud.common
         - ansible-test-cloud-integration-vcenter7_only-stable218
         - ansible-test-cloud-integration-vcenter7_2esxi-stable218
         - ansible-test-cloud-integration-vcenter7_1esxi-stable218_1_of_2


### PR DESCRIPTION
The modules we use in `community.vmware` to prepare the integration tests are deprecated. So it's a good idea to get rid of them. And then we wouldn't require `vmware.vmware_rest` anymore.

This might also make it possible to undo ansible/zuul-config#587 / redo ansible/zuul-config#586.