### PR TITLE
Run community.vmware integration tests with 2.19

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -31,7 +31,7 @@
     post-run: playbooks/ansible-test-base/post.yaml
     required-projects:
       - name: github.com/ansible/ansible
-        override-checkout: stable-2.18
+        override-checkout: stable-2.19
       - name: github.com/ansible-collections/community.vmware
     timeout: 3600
     vars:
@@ -77,29 +77,29 @@
         ansible_network_os: vmware_rest
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_only-stable218
+    name: ansible-test-cloud-integration-vcenter7_only-stable219
     parent: ansible-test-cloud-integration-vcenter7_only
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-stable218
+    name: ansible-test-cloud-integration-vcenter7_1esxi-stable219
     parent: ansible-test-cloud-integration-vcenter7_1esxi
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-stable218_1_of_2
-    parent: ansible-test-cloud-integration-vcenter7_1esxi-stable218
+    name: ansible-test-cloud-integration-vcenter7_1esxi-stable219_1_of_2
+    parent: ansible-test-cloud-integration-vcenter7_1esxi-stable219
     vars:
       ansible_test_split_in: 2
       ansible_test_do_number: 1
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_1esxi-stable218_2_of_2
-    parent: ansible-test-cloud-integration-vcenter7_1esxi-stable218
+    name: ansible-test-cloud-integration-vcenter7_1esxi-stable219_2_of_2
+    parent: ansible-test-cloud-integration-vcenter7_1esxi-stable219
     vars:
       ansible_test_split_in: 2
       ansible_test_do_number: 2
 
 - job:
-    name: ansible-test-cloud-integration-vcenter7_2esxi-stable218
+    name: ansible-test-cloud-integration-vcenter7_2esxi-stable219
     parent: ansible-test-cloud-integration-vcenter7_2esxi
 
 ##### units

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -127,10 +127,10 @@
       fail-fast: true
       jobs:
         - ansible-tox-linters
-        - ansible-test-cloud-integration-vcenter7_only-stable218
-        - ansible-test-cloud-integration-vcenter7_2esxi-stable218
-        - ansible-test-cloud-integration-vcenter7_1esxi-stable218_1_of_2
-        - ansible-test-cloud-integration-vcenter7_1esxi-stable218_2_of_2
+        - ansible-test-cloud-integration-vcenter7_only-stable219
+        - ansible-test-cloud-integration-vcenter7_2esxi-stable219
+        - ansible-test-cloud-integration-vcenter7_1esxi-stable219_1_of_2
+        - ansible-test-cloud-integration-vcenter7_1esxi-stable219_2_of_2
         - ansible-galaxy-importer:
             voting: false
     third-party-check:


### PR DESCRIPTION
Follow-up to #1887

Now that ansible-core 2.19 is out, `community.vmware` should be tested with this version.