### PR TITLE
Remove aws-ci-admin

### DIFF
--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -42,15 +42,6 @@
         - ansible-tox-py39
 
 - project-template:
-    name: ansible-aws-ci-admin
-    check:
-      jobs:
-        - ansible-tox-linters
-    gate:
-      jobs:
-        - ansible-tox-linters
-
-- project-template:
     name: ansible-collections-community-aws
     check:
       jobs: &ansible-collections-community-aws-jobs


### PR DESCRIPTION
This PR removes template for project `ansible/aws-ci-admin`
Depends-ON: https://github.com/ansible/zuul-config/pull/637