### PR TITLE
Remove integration tests jobs for ansible.mcp

### DIFF
--- a/zuul.d/ansible-cloud-jobs.yaml
+++ b/zuul.d/ansible-cloud-jobs.yaml
@@ -382,29 +382,3 @@
         override-checkout: stable-2.14
     vars:
       ansible_collections_repo: github.com/ansible-collections/pravic
-
-### ansible.mcp
-- job:
-    name: integration-ansible-mcp
-    parent: ansible-mcp-integration-base
-    nodeset: cloud-fedora-42
-    dependencies:
-      - name: build-ansible-collection
-    pre-run:
-      - playbooks/ansible-test-base/pre.yaml
-      - playbooks/ansible-cloud/aws/pre.yaml
-    run: playbooks/ansible-test-base/run.yaml
-    files:
-      - ^plugins/.*$
-      - ^tests/integration/.*$
-    required-projects:
-      - name: github.com/ansible/ansible
-        override-checkout: milestone
-    timeout: 3600
-    vars:
-      ansible_test_command: integration
-      ansible_test_python: 3.12
-      ansible_test_retry_on_error: true
-      ansible_test_requirement_files:
-        - test-requirements.txt
-      ansible_collections_repo: github.com/ansible-collections/ansible.mcp

--- a/zuul.d/project-templates.yaml
+++ b/zuul.d/project-templates.yaml
@@ -496,20 +496,3 @@
         - ansible-test-changelog
     gate:
       jobs: *ansible-collections-cloud-gouttelette-units-jobs
-
-- project-template:
-    name: ansible-collections-ansible-mcp-integration
-    check:
-      jobs:
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/ansible.mcp
-            timeout: 3600
-        - integration-ansible-mcp
-    gate:
-      jobs:
-        - build-ansible-collection:
-            required-projects:
-              - name: github.com/ansible-collections/ansible.mcp
-            timeout: 3600
-        - integration-ansible-mcp


### PR DESCRIPTION
This PR aims to remove the the integration test configuration for the `ansible.mcp` collection.
The following PR needs to be merged first https://github.com/ansible/zuul-config/pull/638